### PR TITLE
Configure GitHub Pages for stabileo.com

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -29,6 +29,18 @@ jobs:
           cache: npm
           cache-dependency-path: web/package-lock.json
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build WASM engine
+        run: wasm-pack build --target web --out-dir ../web/src/lib/wasm
+        working-directory: engine
+
       - name: Install dependencies
         working-directory: web
         run: npm ci

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -36,8 +36,6 @@ jobs:
       - name: Build
         working-directory: web
         run: npm run build
-        env:
-          BASE_PATH: /dedaliano
 
       - uses: actions/configure-pages@v5
 

--- a/web/public/CNAME
+++ b/web/public/CNAME
@@ -1,0 +1,1 @@
+stabileo.com


### PR DESCRIPTION
## Summary
- Add `CNAME` file in `web/public/` so Vite copies it to `dist/` on every build, preserving the custom domain across deploys
- Remove `BASE_PATH: /dedaliano` from the GH Pages workflow — not needed with a custom domain (site serves at `/`)

## Context
GitHub Pages shows `www.stabileo.com` as improperly configured (InvalidDNSError). The CNAME file ensures GitHub retains the custom domain setting after each deployment. DNS records in Cloudflare are already correct (A records for apex, CNAME `www` → `lambdaclass.github.io`).