### PR TITLE
feat: 3D engines, bugfixes, and lib improvements

### DIFF
--- a/web/src/lib/canvas/draw-diagrams.ts
+++ b/web/src/lib/canvas/draw-diagrams.ts
@@ -3,6 +3,7 @@
 import type { AnalysisResults, EnvelopeDiagramData } from '../engine/types';
 import {
   computeMomentDiagram, computeShearDiagram, computeAxialDiagram,
+  computeDiagramValueAt,
   type ElementDiagram,
 } from '../engine/diagrams';
 import { toDisplay, unitLabel, type UnitSystem } from '../utils/units';
@@ -28,32 +29,21 @@ const DIAGRAM_COLORS: Record<DiagramKind, { fill: string; stroke: string; text: 
  */
 export function computeDiagramGlobalMax(results: AnalysisResults, kind: DiagramKind): number {
   let globalMax = 0;
+  const N = 20;
   for (const ef of results.elementForces) {
-    if (kind === 'moment') {
-      globalMax = Math.max(globalMax, Math.abs(ef.mStart), Math.abs(ef.mEnd));
-      if (Math.abs(ef.qI) > 1e-10 || Math.abs(ef.qJ) > 1e-10) {
-        for (let i = 1; i < 10; i++) {
-          const xi = (i / 10) * ef.length;
-          const dq = ef.qJ - ef.qI;
-          const m = ef.mStart - ef.vStart * xi - ef.qI * xi * xi / 2 - dq * xi * xi * xi / (6 * ef.length);
-          globalMax = Math.max(globalMax, Math.abs(m));
-        }
-      }
-      for (const pl of ef.pointLoads ?? []) {
-        const dq = ef.qJ - ef.qI;
-        const mAtA = ef.mStart - ef.vStart * pl.a - ef.qI * pl.a * pl.a / 2 - dq * pl.a * pl.a * pl.a / (6 * ef.length);
-        globalMax = Math.max(globalMax, Math.abs(mAtA));
-      }
-    } else if (kind === 'shear') {
-      globalMax = Math.max(globalMax, Math.abs(ef.vStart), Math.abs(ef.vEnd));
-      for (let i = 1; i < 10; i++) {
-        const xi = (i / 10) * ef.length;
-        const dq = ef.qJ - ef.qI;
-        const v = ef.vStart + ef.qI * xi + dq * xi * xi / (2 * ef.length);
-        globalMax = Math.max(globalMax, Math.abs(v));
-      }
-    } else {
-      globalMax = Math.max(globalMax, Math.abs(ef.nStart), Math.abs(ef.nEnd));
+    // Sample the full diagram (including point load effects) at N+1 points,
+    // plus extra points around each point load to capture discontinuities.
+    const sampleTs: number[] = [];
+    for (let i = 0; i <= N; i++) sampleTs.push(i / N);
+    for (const pl of ef.pointLoads ?? []) {
+      const tPl = pl.a / ef.length;
+      if (tPl > 1e-6) sampleTs.push(tPl - 1e-6);
+      sampleTs.push(tPl);
+      if (tPl < 1 - 1e-6) sampleTs.push(tPl + 1e-6);
+    }
+    for (const t of sampleTs) {
+      const val = Math.abs(computeDiagramValueAt(kind, t, ef));
+      if (val > globalMax) globalMax = val;
     }
   }
   return globalMax;

--- a/web/src/lib/canvas/draw-influence.ts
+++ b/web/src/lib/canvas/draw-influence.ts
@@ -1,6 +1,7 @@
 // Draw influence line diagram on Canvas 2D
 
 import type { InfluenceLineResult } from '../store/model.svelte';
+import { t } from '../i18n';
 
 interface DrawContext {
   ctx: CanvasRenderingContext2D;
@@ -222,7 +223,7 @@ export function drawInfluenceLine(
           // Label
           ctx.font = 'bold 10px sans-serif';
           ctx.textAlign = 'center';
-          ctx.fillText('P=1', fromX + snx * 8, fromY + sny * 8);
+          ctx.fillText(t('influence.unitLoad'), fromX + snx * 8, fromY + sny * 8);
         }
       }
     }
@@ -276,8 +277,8 @@ export function drawInfluenceLine(
   ctx.fillStyle = '#ff6b6b';
   ctx.font = 'bold 12px sans-serif';
   ctx.textAlign = 'left';
-  const labelText = `LI: ${il.quantity}` +
-    (il.targetNodeId !== undefined ? ` (Nodo ${il.targetNodeId})` : '') +
-    (il.targetElementId !== undefined ? ` (Elem ${il.targetElementId}, t=${(il.targetPosition ?? 0.5).toFixed(1)})` : '');
+  const labelText = `${t('influence.label')}: ${il.quantity}` +
+    (il.targetNodeId !== undefined ? ` (${t('influence.node')} ${il.targetNodeId})` : '') +
+    (il.targetElementId !== undefined ? ` (${t('influence.elem')} ${il.targetElementId}, t=${(il.targetPosition ?? 0.5).toFixed(1)})` : '');
   ctx.fillText(labelText, 10, 20);
 }

--- a/web/src/lib/data/material-presets.ts
+++ b/web/src/lib/data/material-presets.ts
@@ -1,6 +1,8 @@
 // Preset materials for quick selection
 // Properties in SI units: E (MPa), ν, ρ (kN/m³), fy (MPa)
 
+import { t } from '../i18n';
+
 export interface MaterialPreset {
   name: string;
   category: 'acero' | 'hormigon' | 'madera' | 'aluminio';
@@ -10,16 +12,42 @@ export interface MaterialPreset {
   fy?: number;  // MPa
 }
 
+/** Returns material presets with translated names (call inside reactive context) */
+export function getMaterialPresets(): MaterialPreset[] {
+  return [
+    // ─── Aceros estructurales ───
+    { name: t('material.steelA36'),       category: 'acero', e: 200000, nu: 0.3, rho: 78.5, fy: 250 },
+    { name: t('material.steelA572Gr50'),  category: 'acero', e: 200000, nu: 0.3, rho: 78.5, fy: 345 },
+    { name: t('material.steelA992'),      category: 'acero', e: 200000, nu: 0.3, rho: 78.5, fy: 345 },
+    { name: t('material.steelA500GrC'),   category: 'acero', e: 200000, nu: 0.3, rho: 78.5, fy: 317 },
+    { name: t('material.steelADN420'),    category: 'acero', e: 200000, nu: 0.3, rho: 78.5, fy: 420 },
+
+    // ─── Hormigones argentinos (CIRSOC 201) ───
+    // E = 4700 √f'c (MPa), ν ≈ 0.2, ρ ≈ 24 kN/m³
+    { name: t('material.concreteH20'), category: 'hormigon', e: 21019, nu: 0.2, rho: 24.0, fy: 20 },
+    { name: t('material.concreteH25'), category: 'hormigon', e: 23500, nu: 0.2, rho: 24.0, fy: 25 },
+    { name: t('material.concreteH30'), category: 'hormigon', e: 25743, nu: 0.2, rho: 24.0, fy: 30 },
+    { name: t('material.concreteH35'), category: 'hormigon', e: 27806, nu: 0.2, rho: 24.0, fy: 35 },
+    { name: t('material.concreteH40'), category: 'hormigon', e: 29725, nu: 0.2, rho: 24.5, fy: 40 },
+    { name: t('material.concreteH45'), category: 'hormigon', e: 31529, nu: 0.2, rho: 24.5, fy: 45 },
+    { name: t('material.concreteH50'), category: 'hormigon', e: 33234, nu: 0.2, rho: 25.0, fy: 50 },
+
+    // ─── Maderas estructurales ───
+    { name: t('material.woodPine'),       category: 'madera', e: 10000, nu: 0.3, rho: 5.0 },
+    { name: t('material.woodEucalyptus'), category: 'madera', e: 15000, nu: 0.3, rho: 8.0 },
+
+    // ─── Aluminio ───
+    { name: t('material.aluminum6061T6'), category: 'aluminio', e: 69000, nu: 0.33, rho: 27.0, fy: 276 },
+  ];
+}
+
+/** @deprecated Use getMaterialPresets() instead */
 export const MATERIAL_PRESETS: MaterialPreset[] = [
-  // ─── Aceros estructurales ───
   { name: 'Acero A36',       category: 'acero', e: 200000, nu: 0.3, rho: 78.5, fy: 250 },
   { name: 'Acero A572 Gr50', category: 'acero', e: 200000, nu: 0.3, rho: 78.5, fy: 345 },
   { name: 'Acero A992',      category: 'acero', e: 200000, nu: 0.3, rho: 78.5, fy: 345 },
   { name: 'Acero A500 Gr C', category: 'acero', e: 200000, nu: 0.3, rho: 78.5, fy: 317 },
   { name: 'Acero ADN 420',   category: 'acero', e: 200000, nu: 0.3, rho: 78.5, fy: 420 },
-
-  // ─── Hormigones argentinos (CIRSOC 201) ───
-  // E = 4700 √f'c (MPa), ν ≈ 0.2, ρ ≈ 24 kN/m³
   { name: 'Hormigón H-20', category: 'hormigon', e: 21019, nu: 0.2, rho: 24.0, fy: 20 },
   { name: 'Hormigón H-25', category: 'hormigon', e: 23500, nu: 0.2, rho: 24.0, fy: 25 },
   { name: 'Hormigón H-30', category: 'hormigon', e: 25743, nu: 0.2, rho: 24.0, fy: 30 },
@@ -27,24 +55,20 @@ export const MATERIAL_PRESETS: MaterialPreset[] = [
   { name: 'Hormigón H-40', category: 'hormigon', e: 29725, nu: 0.2, rho: 24.5, fy: 40 },
   { name: 'Hormigón H-45', category: 'hormigon', e: 31529, nu: 0.2, rho: 24.5, fy: 45 },
   { name: 'Hormigón H-50', category: 'hormigon', e: 33234, nu: 0.2, rho: 25.0, fy: 50 },
-
-  // ─── Maderas estructurales ───
   { name: 'Madera (pino)',   category: 'madera', e: 10000, nu: 0.3, rho: 5.0 },
   { name: 'Madera (eucalipto)', category: 'madera', e: 15000, nu: 0.3, rho: 8.0 },
-
-  // ─── Aluminio ───
   { name: 'Aluminio 6061-T6', category: 'aluminio', e: 69000, nu: 0.33, rho: 27.0, fy: 276 },
 ];
 
 export const MATERIAL_CATEGORIES = [
-  { id: 'acero', label: 'Aceros' },
-  { id: 'hormigon', label: 'Hormigones' },
-  { id: 'madera', label: 'Maderas' },
-  { id: 'aluminio', label: 'Aluminio' },
+  { id: 'acero', label: 'matCat.steel' },
+  { id: 'hormigon', label: 'matCat.concrete' },
+  { id: 'madera', label: 'matCat.wood' },
+  { id: 'aluminio', label: 'matCat.aluminum' },
 ] as const;
 
 export function searchPresets(query: string, category?: string): MaterialPreset[] {
-  let source = MATERIAL_PRESETS;
+  let source = getMaterialPresets();
   if (category) source = source.filter(p => p.category === category);
   if (!query.trim()) return source;
   const q = query.trim().toLowerCase();

--- a/web/src/lib/data/section-shapes.ts
+++ b/web/src/lib/data/section-shapes.ts
@@ -2,6 +2,8 @@
 // All dimensions in meters, output A in m², Iy/Iz in m⁴
 // Convention: iy = about Y (horizontal axis), iz = about Z (vertical axis)
 
+import { t } from '../i18n';
+
 export type ShapeType =
   | 'rect' | 'circular' | 'hollow-rect' | 'hollow-circular' | 'I-custom'
   | 'T-custom' | 'U-custom' | 'C-custom'
@@ -29,126 +31,126 @@ export const SECTION_SHAPES: ShapeDefinition[] = [
   // ── Steel shapes ──
   {
     id: 'hollow-rect',
-    label: 'Cajón rectangular',
-    description: 'Sección rectangular hueca',
+    label: 'shape.hollowRect',
+    description: 'shape.hollowRect.desc',
     category: 'steel',
     params: [
-      { id: 'b', label: 'Ancho ext. (b)', unit: 'm', step: 0.01, defaultValue: 0.20 },
-      { id: 'h', label: 'Alto ext. (h)', unit: 'm', step: 0.01, defaultValue: 0.30 },
-      { id: 't', label: 'Espesor (t)', unit: 'm', step: 0.0001, defaultValue: 0.01 },
+      { id: 'b', label: 'shape.param.extWidth', unit: 'm', step: 0.01, defaultValue: 0.20 },
+      { id: 'h', label: 'shape.param.extHeight', unit: 'm', step: 0.01, defaultValue: 0.30 },
+      { id: 't', label: 'shape.param.thickness', unit: 'm', step: 0.0001, defaultValue: 0.01 },
     ],
   },
   {
     id: 'hollow-circular',
-    label: 'Tubo circular',
-    description: 'Sección circular hueca (CHS)',
+    label: 'shape.hollowCircular',
+    description: 'shape.hollowCircular.desc',
     category: 'steel',
     params: [
-      { id: 'd', label: 'Diámetro ext. (d)', unit: 'm', step: 0.01, defaultValue: 0.20 },
-      { id: 't', label: 'Espesor (t)', unit: 'm', step: 0.0001, defaultValue: 0.008 },
+      { id: 'd', label: 'shape.param.extDiam', unit: 'm', step: 0.01, defaultValue: 0.20 },
+      { id: 't', label: 'shape.param.thickness', unit: 'm', step: 0.0001, defaultValue: 0.008 },
     ],
   },
   {
     id: 'I-custom',
-    label: 'Doble T (I)',
-    description: 'Perfil I/H personalizado',
+    label: 'shape.iCustom',
+    description: 'shape.iCustom.desc',
     category: 'steel',
     params: [
-      { id: 'h', label: 'Altura total (h)', unit: 'm', step: 0.01, defaultValue: 0.30 },
-      { id: 'b', label: 'Ancho ala (b)', unit: 'm', step: 0.01, defaultValue: 0.15 },
-      { id: 'tw', label: 'Espesor alma (tw)', unit: 'm', step: 0.0001, defaultValue: 0.007 },
-      { id: 'tf', label: 'Espesor ala (tf)', unit: 'm', step: 0.0001, defaultValue: 0.011 },
+      { id: 'h', label: 'shape.param.totalHeight', unit: 'm', step: 0.01, defaultValue: 0.30 },
+      { id: 'b', label: 'shape.param.flangeWidth', unit: 'm', step: 0.01, defaultValue: 0.15 },
+      { id: 'tw', label: 'shape.param.webThickness', unit: 'm', step: 0.0001, defaultValue: 0.007 },
+      { id: 'tf', label: 'shape.param.flangeThickness', unit: 'm', step: 0.0001, defaultValue: 0.011 },
     ],
   },
   {
     id: 'T-custom',
-    label: 'T',
-    description: 'Perfil T de acero (ala + alma)',
+    label: 'shape.tCustom',
+    description: 'shape.tCustom.desc',
     category: 'steel',
     params: [
-      { id: 'h', label: 'Altura total (h)', unit: 'm', step: 0.001, defaultValue: 0.20 },
-      { id: 'bf', label: 'Ancho ala (bf)', unit: 'm', step: 0.001, defaultValue: 0.15 },
-      { id: 'tw', label: 'Espesor alma (tw)', unit: 'm', step: 0.0001, defaultValue: 0.007 },
-      { id: 'tf', label: 'Espesor ala (tf)', unit: 'm', step: 0.0001, defaultValue: 0.011 },
+      { id: 'h', label: 'shape.param.totalHeight', unit: 'm', step: 0.001, defaultValue: 0.20 },
+      { id: 'bf', label: 'shape.param.flangeWidthBf', unit: 'm', step: 0.001, defaultValue: 0.15 },
+      { id: 'tw', label: 'shape.param.webThickness', unit: 'm', step: 0.0001, defaultValue: 0.007 },
+      { id: 'tf', label: 'shape.param.flangeThickness', unit: 'm', step: 0.0001, defaultValue: 0.011 },
     ],
   },
   {
     id: 'U-custom',
-    label: 'U (canal)',
-    description: 'Perfil U/canal personalizado',
+    label: 'shape.uCustom',
+    description: 'shape.uCustom.desc',
     category: 'steel',
     params: [
-      { id: 'h', label: 'Altura total (h)', unit: 'm', step: 0.001, defaultValue: 0.20 },
-      { id: 'b', label: 'Ancho ala (b)', unit: 'm', step: 0.001, defaultValue: 0.075 },
-      { id: 'tw', label: 'Espesor alma (tw)', unit: 'm', step: 0.0001, defaultValue: 0.006 },
-      { id: 'tf', label: 'Espesor ala (tf)', unit: 'm', step: 0.0001, defaultValue: 0.009 },
+      { id: 'h', label: 'shape.param.totalHeight', unit: 'm', step: 0.001, defaultValue: 0.20 },
+      { id: 'b', label: 'shape.param.flangeWidth', unit: 'm', step: 0.001, defaultValue: 0.075 },
+      { id: 'tw', label: 'shape.param.webThickness', unit: 'm', step: 0.0001, defaultValue: 0.006 },
+      { id: 'tf', label: 'shape.param.flangeThickness', unit: 'm', step: 0.0001, defaultValue: 0.009 },
     ],
   },
   {
     id: 'C-custom',
-    label: 'C (con labios)',
-    description: 'Perfil C con aletitas/labios en los extremos de las alas',
+    label: 'shape.cCustom',
+    description: 'shape.cCustom.desc',
     category: 'steel',
     params: [
-      { id: 'h', label: 'Altura total (h)', unit: 'm', step: 0.001, defaultValue: 0.20 },
-      { id: 'b', label: 'Ancho ala (b)', unit: 'm', step: 0.001, defaultValue: 0.075 },
-      { id: 'tw', label: 'Espesor alma (tw)', unit: 'm', step: 0.0001, defaultValue: 0.006 },
-      { id: 'tf', label: 'Espesor ala (tf)', unit: 'm', step: 0.0001, defaultValue: 0.009 },
-      { id: 'c', label: 'Largo labio (c)', unit: 'm', step: 0.001, defaultValue: 0.02 },
-      { id: 'tl', label: 'Espesor labio (tl)', unit: 'm', step: 0.0001, defaultValue: 0.009 },
+      { id: 'h', label: 'shape.param.totalHeight', unit: 'm', step: 0.001, defaultValue: 0.20 },
+      { id: 'b', label: 'shape.param.flangeWidth', unit: 'm', step: 0.001, defaultValue: 0.075 },
+      { id: 'tw', label: 'shape.param.webThickness', unit: 'm', step: 0.0001, defaultValue: 0.006 },
+      { id: 'tf', label: 'shape.param.flangeThickness', unit: 'm', step: 0.0001, defaultValue: 0.009 },
+      { id: 'c', label: 'shape.param.lipLength', unit: 'm', step: 0.001, defaultValue: 0.02 },
+      { id: 'tl', label: 'shape.param.lipThickness', unit: 'm', step: 0.0001, defaultValue: 0.009 },
     ],
   },
   // ── Concrete shapes ──
   {
     id: 'concrete-square',
-    label: 'Cuadrada',
-    description: 'Sección cuadrada de hormigón',
+    label: 'shape.concSquare',
+    description: 'shape.concSquare.desc',
     category: 'concrete',
     params: [
-      { id: 'a', label: 'Lado (a)', unit: 'm', step: 0.01, defaultValue: 0.30 },
+      { id: 'a', label: 'shape.param.side', unit: 'm', step: 0.01, defaultValue: 0.30 },
     ],
   },
   {
     id: 'concrete-rect',
-    label: 'Rectangular',
-    description: 'Sección rectangular de hormigón',
+    label: 'shape.concRect',
+    description: 'shape.concRect.desc',
     category: 'concrete',
     params: [
-      { id: 'b', label: 'Ancho (b)', unit: 'm', step: 0.01, defaultValue: 0.20 },
-      { id: 'h', label: 'Alto (h)', unit: 'm', step: 0.01, defaultValue: 0.40 },
+      { id: 'b', label: 'shape.param.width', unit: 'm', step: 0.01, defaultValue: 0.20 },
+      { id: 'h', label: 'shape.param.height', unit: 'm', step: 0.01, defaultValue: 0.40 },
     ],
   },
   {
     id: 'concrete-circular',
-    label: 'Circular',
-    description: 'Sección circular maciza de hormigón',
+    label: 'shape.concCircular',
+    description: 'shape.concCircular.desc',
     category: 'concrete',
     params: [
-      { id: 'd', label: 'Diámetro (d)', unit: 'm', step: 0.01, defaultValue: 0.40 },
+      { id: 'd', label: 'shape.param.diameter', unit: 'm', step: 0.01, defaultValue: 0.40 },
     ],
   },
   {
     id: 'concrete-T',
-    label: 'T (viga con losa)',
-    description: 'Viga T de hormigón (ala = ancho de influencia de losa)',
+    label: 'shape.concT',
+    description: 'shape.concT.desc',
     category: 'concrete',
     params: [
-      { id: 'bw', label: 'Ancho alma (bw)', unit: 'm', step: 0.01, defaultValue: 0.25 },
-      { id: 'hw', label: 'Alto alma (hw)', unit: 'm', step: 0.01, defaultValue: 0.50 },
-      { id: 'bf', label: 'Ancho ala (bf)', unit: 'm', step: 0.01, defaultValue: 0.80 },
-      { id: 'hf', label: 'Espesor ala (hf)', unit: 'm', step: 0.01, defaultValue: 0.12 },
+      { id: 'bw', label: 'shape.param.webWidth', unit: 'm', step: 0.01, defaultValue: 0.25 },
+      { id: 'hw', label: 'shape.param.webHeight', unit: 'm', step: 0.01, defaultValue: 0.50 },
+      { id: 'bf', label: 'shape.param.flangeWidthBf', unit: 'm', step: 0.01, defaultValue: 0.80 },
+      { id: 'hf', label: 'shape.param.flangeDepth', unit: 'm', step: 0.01, defaultValue: 0.12 },
     ],
   },
   {
     id: 'concrete-invL',
-    label: 'L invertida',
-    description: 'Viga L invertida (losa a un solo lado)',
+    label: 'shape.concInvL',
+    description: 'shape.concInvL.desc',
     category: 'concrete',
     params: [
-      { id: 'bw', label: 'Ancho alma (bw)', unit: 'm', step: 0.01, defaultValue: 0.25 },
-      { id: 'hw', label: 'Alto alma (hw)', unit: 'm', step: 0.01, defaultValue: 0.50 },
-      { id: 'bf', label: 'Ancho ala (bf)', unit: 'm', step: 0.01, defaultValue: 0.50 },
-      { id: 'hf', label: 'Espesor ala (hf)', unit: 'm', step: 0.01, defaultValue: 0.12 },
+      { id: 'bw', label: 'shape.param.webWidth', unit: 'm', step: 0.01, defaultValue: 0.25 },
+      { id: 'hw', label: 'shape.param.webHeight', unit: 'm', step: 0.01, defaultValue: 0.50 },
+      { id: 'bf', label: 'shape.param.flangeWidthBf', unit: 'm', step: 0.01, defaultValue: 0.50 },
+      { id: 'hf', label: 'shape.param.flangeDepth', unit: 'm', step: 0.01, defaultValue: 0.12 },
     ],
   },
 ];
@@ -440,7 +442,7 @@ export function generateSectionName(shapeType: ShapeType, params: Record<string,
     case 'circular':
       return `Circ \u2300${(params.d * 100).toFixed(0)} cm`;
     case 'hollow-rect':
-      return `Cajón ${(params.b * 100).toFixed(0)}x${(params.h * 100).toFixed(0)}x${(params.t * 1000).toFixed(0)} mm`;
+      return `${t('section.hollowRect')} ${(params.b * 100).toFixed(0)}x${(params.h * 100).toFixed(0)}x${(params.t * 1000).toFixed(0)} mm`;
     case 'hollow-circular':
       return `CHS \u2300${(params.d * 100).toFixed(0)}x${(params.t * 1000).toFixed(0)} mm`;
     case 'I-custom':
@@ -462,6 +464,6 @@ export function generateSectionName(shapeType: ShapeType, params: Record<string,
     case 'concrete-invL':
       return `H.A. L inv ${(params.bw * 100).toFixed(0)}x${((params.hw + params.hf) * 100).toFixed(0)} bf=${(params.bf * 100).toFixed(0)}`;
     default:
-      return 'Sección personalizada';
+      return 'section.customName';
   }
 }

--- a/web/src/lib/dxf/__tests__/plan-import.test.ts
+++ b/web/src/lib/dxf/__tests__/plan-import.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import { parseDxf } from '../parser';
+import { mapPlanToModel, defaultPlanMapperOptions } from '../plan-mapper';
+import { generatePlanTemplate } from '../plan-template';
+
+describe('Plan → 3D DXF import (end-to-end)', () => {
+  // Parse the template once for all tests
+  const dxfText = generatePlanTemplate();
+  const parsed = parseDxf(dxfText);
+
+  it('template generates valid DXF that parser can read', () => {
+    expect(parsed.lines.length).toBeGreaterThan(0);
+    expect(parsed.texts.length).toBeGreaterThan(0);
+    expect(parsed.layers.length).toBeGreaterThan(0);
+  });
+
+  it('parser detects all expected layers', () => {
+    const layerNames = parsed.layers.map(l => l.toUpperCase());
+    expect(layerNames).toContain('DED_P_VIGAS');
+    expect(layerNames).toContain('DED_P_COLUMNAS');
+    expect(layerNames).toContain('DED_P_APOYOS_FIJOS');
+    expect(layerNames).toContain('DED_P_TEXTO');
+    expect(layerNames).toContain('DED_P_AYUDA');
+  });
+
+  it('parser reads LINE segments on beam and column layers', () => {
+    const beamLines = parsed.lines.filter(l => l.layer === 'DED_P_VIGAS');
+    const colLines = parsed.lines.filter(l => l.layer === 'DED_P_COLUMNAS');
+    // Template has 7 beam rectangles (4 sides each = 28 lines) + 5 rect columns (4 sides each = 20 lines)
+    expect(beamLines.length).toBeGreaterThanOrEqual(20); // at least 5 beams × 4 sides
+    expect(colLines.length).toBeGreaterThanOrEqual(16); // at least 4 rect columns × 4 sides
+  });
+
+  it('parser reads CIRCLE entities on column layer', () => {
+    const colCircles = parsed.circles.filter(c => c.layer === 'DED_P_COLUMNAS');
+    // Template has 1 circular column (C05 D40)
+    expect(colCircles.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('parser reads TEXT annotations', () => {
+    const textos = parsed.texts.filter(t => t.layer === 'DED_P_TEXTO');
+    expect(textos.length).toBeGreaterThan(0);
+    // Should have column and beam labels
+    const values = textos.map(t => t.value);
+    const hasColumnLabel = values.some(v => /C\d+/.test(v));
+    const hasBeamLabel = values.some(v => /V\d+/.test(v));
+    expect(hasColumnLabel).toBe(true);
+    expect(hasBeamLabel).toBe(true);
+  });
+
+  describe('plan mapper', () => {
+    const result = mapPlanToModel(parsed, {
+      ...defaultPlanMapperOptions,
+      unit: 'm',
+      columnHeight: 3.0,
+      floorZ: 0.0,
+    });
+
+    it('detects columns from template', () => {
+      // Template has 6 columns (5 rectangular + 1 circular)
+      expect(result.columns.length).toBe(6);
+    });
+
+    it('detects rectangular and circular columns', () => {
+      const rectCols = result.columns.filter(c => c.shape === 'rect');
+      const circCols = result.columns.filter(c => c.shape === 'circular');
+      expect(rectCols.length).toBe(5);
+      expect(circCols.length).toBe(1);
+      // Circular column should have diameter ~0.40m
+      expect(circCols[0].diameter).toBeCloseTo(0.40, 1);
+    });
+
+    it('detects beams from template', () => {
+      // Template has 7 beams
+      expect(result.beams.length).toBe(7);
+    });
+
+    it('creates 3D nodes at floor level and column base', () => {
+      const floorNodes = result.nodes.filter(n => Math.abs(n.z) < 0.01);
+      const baseNodes = result.nodes.filter(n => Math.abs(n.z + 3.0) < 0.01);
+      // Should have nodes at z=0 (floor) and z=-3 (column base)
+      expect(floorNodes.length).toBeGreaterThan(0);
+      expect(baseNodes.length).toBeGreaterThan(0);
+      // Each column creates a base node
+      expect(baseNodes.length).toBe(6);
+    });
+
+    it('creates frame elements for beams and columns', () => {
+      expect(result.elements.length).toBeGreaterThan(0);
+      // At minimum: 6 columns + some beam segments
+      expect(result.elements.length).toBeGreaterThanOrEqual(6 + 7);
+    });
+
+    it('all elements are frame type', () => {
+      for (const el of result.elements) {
+        expect(el.type).toBe('frame');
+      }
+    });
+
+    it('creates supports at column bases', () => {
+      // Template has 6 fixed supports
+      expect(result.supports.length).toBe(6);
+      for (const s of result.supports) {
+        expect(s.type).toBe('fixed');
+      }
+      // Supports should be at base nodes (z = -3)
+      for (const s of result.supports) {
+        const node = result.nodes.find(n => n.id === s.nodeId);
+        expect(node).toBeDefined();
+        expect(node!.z).toBeCloseTo(-3.0, 1);
+      }
+    });
+
+    it('creates sections for beams and columns', () => {
+      expect(result.sections.length).toBeGreaterThanOrEqual(2);
+      // Should have at least a beam section and a column section
+      for (const sec of result.sections) {
+        expect(sec.a).toBeGreaterThan(0);
+        expect(sec.iz).toBeGreaterThan(0);
+      }
+    });
+
+    it('creates at least one material', () => {
+      expect(result.materials.length).toBeGreaterThanOrEqual(1);
+      expect(result.materials[0].e).toBe(30000); // default concrete
+    });
+
+    it('detects distributed load from template', () => {
+      // Debug: check warnings related to loads
+      const loadWarnings = result.warnings.filter(w => w.toLowerCase().includes('load') || w.toLowerCase().includes('carga') || w.toLowerCase().includes('magnitude') || w.toLowerCase().includes('overlap'));
+      console.log('Load warnings:', loadWarnings);
+      console.log('Total warnings:', result.warnings.length);
+      // Template has 1 distributed load on V1
+      expect(result.distributedLoads.length).toBeGreaterThanOrEqual(1);
+      // Load should be in -Z direction (gravity)
+      for (const dl of result.distributedLoads) {
+        expect(dl.qz).toBeLessThan(0); // negative = downward
+      }
+    });
+
+    it('element node references are valid', () => {
+      const nodeIds = new Set(result.nodes.map(n => n.id));
+      for (const el of result.elements) {
+        expect(nodeIds.has(el.nodeI)).toBe(true);
+        expect(nodeIds.has(el.nodeJ)).toBe(true);
+        expect(el.nodeI).not.toBe(el.nodeJ);
+      }
+    });
+
+    it('support node references are valid', () => {
+      const nodeIds = new Set(result.nodes.map(n => n.id));
+      for (const s of result.supports) {
+        expect(nodeIds.has(s.nodeId)).toBe(true);
+      }
+    });
+
+    it('beam-column intersections split beams correctly', () => {
+      // The template has beams spanning between columns
+      // V1 goes from C1 to C2 (5m), V2 from C2 to C3 (5m)
+      // Each should produce at least 1 beam element
+      // Some beams may pass through intermediate columns and get split
+      const beamElements = result.elements.filter(el => {
+        const ni = result.nodes.find(n => n.id === el.nodeI)!;
+        const nj = result.nodes.find(n => n.id === el.nodeJ)!;
+        // Horizontal elements (same Z, at floor level)
+        return Math.abs(ni.z - nj.z) < 0.01 && Math.abs(ni.z) < 0.01;
+      });
+      expect(beamElements.length).toBeGreaterThanOrEqual(7);
+    });
+
+    it('columns are vertical elements', () => {
+      const columnElements = result.elements.filter(el => {
+        const ni = result.nodes.find(n => n.id === el.nodeI)!;
+        const nj = result.nodes.find(n => n.id === el.nodeJ)!;
+        // Vertical: same X,Y but different Z
+        return Math.abs(ni.x - nj.x) < 0.01 &&
+               Math.abs(ni.y - nj.y) < 0.01 &&
+               Math.abs(ni.z - nj.z) > 0.5;
+      });
+      expect(columnElements.length).toBe(6);
+    });
+
+    it('produces no critical warnings for the template', () => {
+      // Template should be well-formed, no text/geometry mismatches
+      const criticalWarnings = result.warnings.filter(
+        w => w.includes('differ') || w.includes('No columns') || w.includes('No beams')
+      );
+      expect(criticalWarnings).toEqual([]);
+    });
+  });
+});

--- a/web/src/lib/dxf/mapper.ts
+++ b/web/src/lib/dxf/mapper.ts
@@ -7,6 +7,7 @@ import type {
 } from './types';
 import { unitScale } from './types';
 import { searchProfiles, profileToSection } from '../data/steel-profiles';
+import { t } from '../i18n';
 
 export interface MapperOptions {
   unit: DxfUnit;
@@ -64,14 +65,14 @@ export function mapDxfToModel(
       if (!isElement) continue;
       const ni = findOrAddNode(line.start.x, line.start.y);
       const nj = findOrAddNode(line.end.x, line.end.y);
-      if (ni === nj) { warnings.push('Linea de longitud cero ignorada'); continue; }
+      if (ni === nj) { warnings.push(t('dxf.warnZeroLengthLine')); continue; }
       const type = TRUSS_LAYERS.has(line.layer) ? 'truss' as const : 'frame' as const;
       elements.push({ nodeI: ni, nodeJ: nj, type });
     }
   } else {
     // Fallback: treat all lines as frame elements
     if (parsed.lines.length > 0) {
-      warnings.push('No se detectaron capas BARRAS/ELEMENTOS. Se usan todas las lineas como elementos.');
+      warnings.push(t('dxf.warnNoElementLayers'));
     }
     for (const line of parsed.lines) {
       const ni = findOrAddNode(line.start.x, line.start.y);
@@ -89,13 +90,13 @@ export function mapDxfToModel(
 
   for (const st of supportTexts) {
     const nodeId = findNearestNode(st.position, nodes, scale, tol);
-    if (nodeId < 0) { warnings.push(`Apoyo "${st.value}" no coincide con ningun nodo`); continue; }
+    if (nodeId < 0) { warnings.push(`${t('dxf.warnSupportNoNode')} "${st.value}"`); continue; }
     supports.push({ nodeId, type: parseSupportType(st.value) });
   }
 
   for (const si of supportInserts) {
     const nodeId = findNearestNode(si.position, nodes, scale, tol);
-    if (nodeId < 0) { warnings.push(`Bloque apoyo "${si.blockName}" no coincide con ningun nodo`); continue; }
+    if (nodeId < 0) { warnings.push(`${t('dxf.warnSupportBlockNoNode')} "${si.blockName}"`); continue; }
     supports.push({ nodeId, type: parseSupportType(si.blockName) });
   }
 
@@ -121,7 +122,7 @@ export function mapDxfToModel(
         distributedLoads.push({ elementIndex: idx, q: parseFloat(qMatch[1]) });
         matched = true;
       } else {
-        warnings.push(`Carga distribuida q=${qMatch[1]} no asociada a ningun elemento`);
+        warnings.push(`${t('dxf.warnDistLoadNoElement')} q=${qMatch[1]}`);
       }
     }
 
@@ -137,7 +138,7 @@ export function mapDxfToModel(
           nodalLoads.push({ nodeId, fx: 0, fy: parseFloat(pMatch[1]), mz: 0 });
           matched = true;
         } else {
-          warnings.push(`Carga puntual P=${pMatch[1]} no asociada a ningun elemento o nodo`);
+          warnings.push(`${t('dxf.warnPointLoadNoElement')} P=${pMatch[1]}`);
         }
       }
     }
@@ -153,12 +154,12 @@ export function mapDxfToModel(
         });
         matched = true;
       } else {
-        warnings.push(`Carga nodal "${val}" no asociada a ningun nodo`);
+        warnings.push(`${t('dxf.warnNodalLoadNoNode')} "${val}"`);
       }
     }
 
     if (!matched && !qMatch && !pMatch && !fxMatch && !fyMatch && !mMatch) {
-      warnings.push(`Texto de carga no reconocido: "${val}"`);
+      warnings.push(`${t('dxf.warnUnrecognizedLoadText')} "${val}"`);
     }
   }
 
@@ -240,16 +241,16 @@ export function parseSectionText(text: string): { name: string; a: number; iz: n
 }
 
 export function parseMaterialText(text: string): { name: string; e: number; nu: number; rho: number; fy?: number } | null {
-  const t = text.trim().toUpperCase();
+  const txt = text.trim().toUpperCase();
 
-  if (t.includes('HA') || t.includes('HORMIG') || t.includes('CONCRET')) {
-    return { name: 'Hormigón', e: 30000, nu: 0.2, rho: 25 };
+  if (txt.includes('HA') || txt.includes('HORMIG') || txt.includes('CONCRET')) {
+    return { name: t('dxf.materialConcrete'), e: 30000, nu: 0.2, rho: 25 };
   }
-  if (t.includes('ACERO') || t.includes('STEEL') || t.includes('A36')) {
-    return { name: 'Acero A36', e: 200000, nu: 0.3, rho: 78.5, fy: 250 };
+  if (txt.includes('ACERO') || txt.includes('STEEL') || txt.includes('A36')) {
+    return { name: t('dxf.materialSteelA36'), e: 200000, nu: 0.3, rho: 78.5, fy: 250 };
   }
-  if (t.includes('MADERA') || t.includes('WOOD')) {
-    return { name: 'Madera', e: 12000, nu: 0.3, rho: 6 };
+  if (txt.includes('MADERA') || txt.includes('WOOD')) {
+    return { name: t('dxf.materialWood'), e: 12000, nu: 0.3, rho: 6 };
   }
 
   // Try explicit E=X (MPa)
@@ -264,13 +265,13 @@ export function parseMaterialText(text: string): { name: string; e: number; nu: 
 // ─── Helpers ───────────────────────────────────────────────────
 
 function parseSupportType(text: string): MappedSupport['type'] {
-  const t = text.toUpperCase();
-  if (t.includes('EMPOT') || t.includes('FIXED') || t === 'E') return 'fixed';
-  if (t.includes('MOVIL') || t.includes('ROLLER')) {
-    return t.includes('Y') ? 'rollerY' : 'rollerX';
+  const txt = text.toUpperCase();
+  if (txt.includes('EMPOT') || txt.includes('FIXED') || txt === 'E') return 'fixed';
+  if (txt.includes('MOVIL') || txt.includes('ROLLER')) {
+    return txt.includes('Y') ? 'rollerY' : 'rollerX';
   }
-  if (t === 'R' || t === 'RX') return 'rollerX';
-  if (t === 'RY') return 'rollerY';
+  if (txt === 'R' || txt === 'RX') return 'rollerX';
+  if (txt === 'RY') return 'rollerY';
   // Default: pinned
   return 'pinned';
 }

--- a/web/src/lib/dxf/plan-mapper.ts
+++ b/web/src/lib/dxf/plan-mapper.ts
@@ -1,0 +1,841 @@
+// Map a DXF plan view (top-down) to a 3D frame model
+// Converts 2D plan rectangles (beams, columns) into a spatial frame structure
+
+import type { DxfParseResult, DxfParsedLine, DxfUnit } from './types';
+import { unitScale } from './types';
+
+// ─── Layer names (all uppercase, prefix DED_P_) ──────────────
+
+const LAYER_VIGAS = 'DED_P_VIGAS';
+const LAYER_COLUMNAS = 'DED_P_COLUMNAS';
+const LAYER_APOYOS_FIJOS = 'DED_P_APOYOS_FIJOS';
+const LAYER_APOYOS_ART = 'DED_P_APOYOS_ART';
+const LAYER_CARGA_DIST = 'DED_P_CARGA_DIST';
+const LAYER_CARGA_NODAL = 'DED_P_CARGA_NODAL';
+// DED_P_TEXTO is ignored (user annotations only)
+
+// ─── Public types ────────────────────────────────────────────
+
+export interface PlanMapperOptions {
+  unit: DxfUnit;
+  snapTolerance: number;   // meters
+  columnHeight: number;    // meters (default 3.0)
+  floorZ: number;          // meters (default 0.0)
+  defaultBeamSection: { b: number; h: number };   // meters
+  defaultColumnSection: { b: number; h: number };  // meters
+  defaultMaterialE: number; // MPa (default 30000)
+}
+
+export const defaultPlanMapperOptions: PlanMapperOptions = {
+  unit: 'm',
+  snapTolerance: 0.05,
+  columnHeight: 3.0,
+  floorZ: 0.0,
+  defaultBeamSection: { b: 0.20, h: 0.40 },
+  defaultColumnSection: { b: 0.30, h: 0.30 },
+  defaultMaterialE: 30000,
+};
+
+export interface PlanColumn {
+  id: string;
+  cx: number; cy: number;  // center in plan (meters)
+  shape: 'rect' | 'circular';
+  b: number; h: number;     // rect dimensions (meters), 0 for circular
+  diameter: number;          // circular diameter (meters), 0 for rect
+  textSection: { b: number; h: number } | { diameter: number } | null;
+  textDiffersFromGeom: boolean;
+  hasSupport: boolean;
+  supportType: 'fixed' | 'pinned' | null;
+}
+
+export interface PlanBeam {
+  id: string;
+  x1: number; y1: number;
+  x2: number; y2: number;
+  geomWidth: number;      // width from rectangle (meters)
+  textSection: { b: number; h: number } | null;
+  textDiffersFromGeom: boolean;
+}
+
+export interface PlanMappingResult {
+  nodes: { id: number; x: number; y: number; z: number }[];
+  elements: { nodeI: number; nodeJ: number; type: 'frame'; sectionId: number }[];
+  supports: { nodeId: number; type: 'fixed' | 'pinned' }[];
+  nodalLoads: { nodeId: number; fx: number; fy: number; fz: number }[];
+  distributedLoads: { elementIndex: number; qy: number; qz: number }[];
+  sections: { id: number; name: string; a: number; iy: number; iz: number; j: number; b?: number; h?: number }[];
+  materials: { id: number; name: string; e: number; nu: number; rho: number }[];
+  columns: PlanColumn[];
+  beams: PlanBeam[];
+  warnings: string[];
+}
+
+// ─── Internal helpers ────────────────────────────────────────
+
+interface RectInfo {
+  cx: number; cy: number;       // center
+  width: number; height: number; // width <= height (short side = width)
+  angle: number;                 // angle of the long axis (radians)
+  corners: { x: number; y: number }[];
+}
+
+/** Distance between two 2D points */
+function dist2(ax: number, ay: number, bx: number, by: number): number {
+  return Math.sqrt((ax - bx) ** 2 + (ay - by) ** 2);
+}
+
+/** Check if two points are within tolerance */
+function ptEq(ax: number, ay: number, bx: number, by: number, tol: number): boolean {
+  return dist2(ax, ay, bx, by) < tol;
+}
+
+/**
+ * Reconstruct closed polygons from LINE segments on a given layer.
+ * Groups lines by connected endpoints (within tolerance), finds closed loops,
+ * and returns arrays of ordered vertex coordinates.
+ */
+function reconstructClosedPolygons(
+  lines: DxfParsedLine[],
+  layer: string,
+  scale: number,
+  tol: number,
+): { x: number; y: number }[][] {
+  const filtered = lines.filter(l => l.layer === layer);
+  if (filtered.length === 0) return [];
+
+  // Convert to scaled segments
+  const segments = filtered.map(l => ({
+    sx: l.start.x * scale, sy: l.start.y * scale,
+    ex: l.end.x * scale, ey: l.end.y * scale,
+    used: false,
+  }));
+
+  const polygons: { x: number; y: number }[][] = [];
+
+  // Greedily chain segments into closed loops
+  for (let seed = 0; seed < segments.length; seed++) {
+    if (segments[seed].used) continue;
+
+    const chain: { x: number; y: number }[] = [];
+    segments[seed].used = true;
+    chain.push({ x: segments[seed].sx, y: segments[seed].sy });
+    chain.push({ x: segments[seed].ex, y: segments[seed].ey });
+
+    let extended = true;
+    while (extended) {
+      extended = false;
+      const tail = chain[chain.length - 1];
+      for (let i = 0; i < segments.length; i++) {
+        if (segments[i].used) continue;
+        const s = segments[i];
+        if (ptEq(tail.x, tail.y, s.sx, s.sy, tol)) {
+          chain.push({ x: s.ex, y: s.ey });
+          s.used = true;
+          extended = true;
+          break;
+        }
+        if (ptEq(tail.x, tail.y, s.ex, s.ey, tol)) {
+          chain.push({ x: s.sx, y: s.sy });
+          s.used = true;
+          extended = true;
+          break;
+        }
+      }
+    }
+
+    // Check if closed (first ≈ last)
+    if (chain.length >= 4 && ptEq(chain[0].x, chain[0].y, chain[chain.length - 1].x, chain[chain.length - 1].y, tol)) {
+      // Remove the duplicated closing vertex
+      chain.pop();
+      polygons.push(chain);
+    }
+  }
+
+  return polygons;
+}
+
+/**
+ * Check if a polygon with exactly 4 vertices forms a rectangle.
+ * Returns rectangle info with width (shorter side) and height (longer side),
+ * or null if not a rectangle.
+ */
+function detectRectangle(vertices: { x: number; y: number }[]): RectInfo | null {
+  if (vertices.length !== 4) return null;
+
+  // Check that all 4 angles are ~90 degrees
+  for (let i = 0; i < 4; i++) {
+    const a = vertices[i];
+    const b = vertices[(i + 1) % 4];
+    const c = vertices[(i + 2) % 4];
+    const abx = b.x - a.x, aby = b.y - a.y;
+    const bcx = c.x - b.x, bcy = c.y - b.y;
+    const dot = abx * bcx + aby * bcy;
+    const magAB = Math.sqrt(abx * abx + aby * aby);
+    const magBC = Math.sqrt(bcx * bcx + bcy * bcy);
+    if (magAB < 1e-9 || magBC < 1e-9) return null;
+    const cosAngle = Math.abs(dot / (magAB * magBC));
+    if (cosAngle > 0.05) return null; // Not ~90 degrees (tolerance ~3 degrees)
+  }
+
+  // Side lengths
+  const side01 = dist2(vertices[0].x, vertices[0].y, vertices[1].x, vertices[1].y);
+  const side12 = dist2(vertices[1].x, vertices[1].y, vertices[2].x, vertices[2].y);
+
+  // Center
+  const cx = (vertices[0].x + vertices[1].x + vertices[2].x + vertices[3].x) / 4;
+  const cy = (vertices[0].y + vertices[1].y + vertices[2].y + vertices[3].y) / 4;
+
+  // Width = shorter side, height = longer side
+  let width: number, height: number, angle: number;
+  if (side01 <= side12) {
+    width = side01;
+    height = side12;
+    // Angle of the long axis (side 1→2 direction)
+    angle = Math.atan2(vertices[2].y - vertices[1].y, vertices[2].x - vertices[1].x);
+  } else {
+    width = side12;
+    height = side01;
+    // Angle of the long axis (side 0→1 direction)
+    angle = Math.atan2(vertices[1].y - vertices[0].y, vertices[1].x - vertices[0].x);
+  }
+
+  return { cx, cy, width, height, angle, corners: vertices };
+}
+
+/**
+ * Extract the centerline (long axis) of a rectangle.
+ * Returns the midpoints of the two short sides.
+ */
+function rectangleCenterline(rect: RectInfo): { x1: number; y1: number; x2: number; y2: number } {
+  const v = rect.corners;
+  const side01 = dist2(v[0].x, v[0].y, v[1].x, v[1].y);
+  const side12 = dist2(v[1].x, v[1].y, v[2].x, v[2].y);
+
+  if (side01 <= side12) {
+    // Short sides are 0-1 and 2-3; long sides are 1-2 and 3-0
+    // Centerline connects midpoints of short sides (0-1) and (2-3)
+    const mx1 = (v[0].x + v[1].x) / 2, my1 = (v[0].y + v[1].y) / 2;
+    const mx2 = (v[2].x + v[3].x) / 2, my2 = (v[2].y + v[3].y) / 2;
+    return { x1: mx1, y1: my1, x2: mx2, y2: my2 };
+  } else {
+    // Short sides are 1-2 and 3-0; long sides are 0-1 and 2-3
+    const mx1 = (v[1].x + v[2].x) / 2, my1 = (v[1].y + v[2].y) / 2;
+    const mx2 = (v[3].x + v[0].x) / 2, my2 = (v[3].y + v[0].y) / 2;
+    return { x1: mx1, y1: my1, x2: mx2, y2: my2 };
+  }
+}
+
+/**
+ * Project a point onto a line segment.
+ * Returns the parameter t (0..1), distance from the point to the segment,
+ * and the projected point coordinates.
+ */
+function projectPointOnSegment(
+  px: number, py: number,
+  x1: number, y1: number,
+  x2: number, y2: number,
+): { t: number; dist: number; projX: number; projY: number } {
+  const dx = x2 - x1, dy = y2 - y1;
+  const L2 = dx * dx + dy * dy;
+  if (L2 < 1e-12) {
+    return { t: 0, dist: dist2(px, py, x1, y1), projX: x1, projY: y1 };
+  }
+  let t = ((px - x1) * dx + (py - y1) * dy) / L2;
+  t = Math.max(0, Math.min(1, t));
+  const projX = x1 + t * dx;
+  const projY = y1 + t * dy;
+  return { t, dist: dist2(px, py, projX, projY), projX, projY };
+}
+
+/**
+ * Find the nearest text entity matching a regex pattern within maxDist of (x, y).
+ * Coordinates must already be in meters.
+ */
+function findNearbyText(
+  texts: { x: number; y: number; value: string }[],
+  x: number, y: number,
+  maxDist: number,
+  pattern: RegExp,
+): { match: RegExpMatchArray; textValue: string } | null {
+  let bestDist = maxDist;
+  let bestMatch: RegExpMatchArray | null = null;
+  let bestValue = '';
+
+  for (const t of texts) {
+    const d = dist2(t.x, t.y, x, y);
+    if (d >= bestDist) continue;
+    const m = t.value.match(pattern);
+    if (m) {
+      bestDist = d;
+      bestMatch = m;
+      bestValue = t.value;
+    }
+  }
+
+  return bestMatch ? { match: bestMatch, textValue: bestValue } : null;
+}
+
+/**
+ * Compute rectangular section properties (A, Iy, Iz, J) from b and h in meters.
+ */
+function rectSectionProps(b: number, h: number) {
+  const a = b * h;
+  // Iy = moment of inertia about local y (weak axis for beams)
+  const iy = (h * b * b * b) / 12;
+  // Iz = moment of inertia about local z (strong axis for beams)
+  const iz = (b * h * h * h) / 12;
+  // J = torsion constant (approximation for rectangular sections)
+  const longer = Math.max(b, h);
+  const shorter = Math.min(b, h);
+  const j = longer * shorter * shorter * shorter * (1 / 3 - 0.21 * (shorter / longer) * (1 - (shorter * shorter * shorter * shorter) / (12 * longer * longer * longer * longer)));
+  return { a, iy, iz, j };
+}
+
+// ─── Main mapping function ───────────────────────────────────
+
+export function mapPlanToModel(
+  parsed: DxfParseResult,
+  options: PlanMapperOptions = defaultPlanMapperOptions,
+): PlanMappingResult {
+  const scale = unitScale(options.unit);
+  const tol = options.snapTolerance;
+  const warnings: string[] = [];
+
+  // Pre-process all text entities (scale positions to meters)
+  const allTexts = parsed.texts.map(t => ({
+    x: t.position.x * scale,
+    y: t.position.y * scale,
+    value: t.value.trim(),
+    layer: t.layer,
+  }));
+
+  // ─── Step 1: Parse Columns ─────────────────────────────────
+
+  const columns: PlanColumn[] = [];
+  let colAutoId = 1;
+
+  // Reconstruct polygons from column layer lines
+  const colPolygons = reconstructClosedPolygons(parsed.lines, LAYER_COLUMNAS, scale, tol * 0.5);
+
+  // Text patterns for column annotations
+  const colRectPattern = /C(\d+)\s*[-–]\s*(\d+(?:\.\d+)?)\s*[xX]\s*(\d+(?:\.\d+)?)/;
+  const colCircPattern = /C(\d+)\s*[-–]\s*[DdØø∅](\d+(?:\.\d+)?)/;
+  // Broader search radius for text (columns can have labels a bit away)
+  const textSearchDist = 2.0; // meters
+
+  for (const poly of colPolygons) {
+    const rect = detectRectangle(poly);
+    if (!rect) {
+      warnings.push(`Column layer: polygon with ${poly.length} vertices is not a rectangle, skipped`);
+      continue;
+    }
+
+    // Determine column dimensions (smaller = b, larger = h)
+    const geomB = Math.min(rect.width, rect.height);
+    const geomH = Math.max(rect.width, rect.height);
+
+    // Search for text annotation
+    let id = `C${String(colAutoId++).padStart(3, '0')}`;
+    let textSection: PlanColumn['textSection'] = null;
+    let textDiffersFromGeom = false;
+    let finalB = geomB;
+    let finalH = geomH;
+
+    const rectTextResult = findNearbyText(allTexts, rect.cx, rect.cy, textSearchDist, colRectPattern);
+    if (rectTextResult) {
+      id = `C${rectTextResult.match[1]}`;
+      const tb = parseFloat(rectTextResult.match[2]) * 0.01; // cm → m
+      const th = parseFloat(rectTextResult.match[3]) * 0.01;
+      const sortedB = Math.min(tb, th);
+      const sortedH = Math.max(tb, th);
+      textSection = { b: sortedB, h: sortedH };
+      if (Math.abs(sortedB - geomB) > 0.01 || Math.abs(sortedH - geomH) > 0.01) {
+        textDiffersFromGeom = true;
+        warnings.push(`Column ${id}: text dimensions (${(sortedB * 100).toFixed(0)}x${(sortedH * 100).toFixed(0)}cm) differ from drawn geometry (${(geomB * 100).toFixed(0)}x${(geomH * 100).toFixed(0)}cm). Using text dimensions.`);
+        finalB = sortedB;
+        finalH = sortedH;
+      }
+    }
+
+    columns.push({
+      id, cx: rect.cx, cy: rect.cy,
+      shape: 'rect',
+      b: finalB, h: finalH,
+      diameter: 0,
+      textSection, textDiffersFromGeom,
+      hasSupport: false, supportType: null,
+    });
+  }
+
+  // Circular columns from CIRCLE entities on column layer
+  const colCircles = parsed.circles.filter(c => c.layer === LAYER_COLUMNAS);
+  for (const circ of colCircles) {
+    const cx = circ.center.x * scale;
+    const cy = circ.center.y * scale;
+    const geomDiam = circ.radius * 2 * scale;
+
+    let id = `C${String(colAutoId++).padStart(3, '0')}`;
+    let textSection: PlanColumn['textSection'] = null;
+    let textDiffersFromGeom = false;
+    let finalDiam = geomDiam;
+
+    const circTextResult = findNearbyText(allTexts, cx, cy, textSearchDist, colCircPattern);
+    if (circTextResult) {
+      id = `C${circTextResult.match[1]}`;
+      const td = parseFloat(circTextResult.match[2]) * 0.01; // cm → m
+      textSection = { diameter: td };
+      if (Math.abs(td - geomDiam) > 0.01) {
+        textDiffersFromGeom = true;
+        warnings.push(`Column ${id}: text diameter (Ø${(td * 100).toFixed(0)}cm) differs from drawn geometry (Ø${(geomDiam * 100).toFixed(0)}cm). Using text dimensions.`);
+        finalDiam = td;
+      }
+    }
+
+    columns.push({
+      id, cx, cy,
+      shape: 'circular',
+      b: 0, h: 0,
+      diameter: finalDiam,
+      textSection, textDiffersFromGeom,
+      hasSupport: false, supportType: null,
+    });
+  }
+
+  if (columns.length === 0) {
+    warnings.push(`No columns found on layer ${LAYER_COLUMNAS}. The model will have no vertical elements.`);
+  }
+
+  // ─── Step 2: Parse Beams ───────────────────────────────────
+
+  const beams: PlanBeam[] = [];
+  let beamAutoId = 1;
+
+  const beamPolygons = reconstructClosedPolygons(parsed.lines, LAYER_VIGAS, scale, tol * 0.5);
+  const beamTextPattern = /V(\d+)\s*[-–]\s*(\d+(?:\.\d+)?)\s*[xX]\s*(\d+(?:\.\d+)?)/;
+
+  for (const poly of beamPolygons) {
+    const rect = detectRectangle(poly);
+    if (!rect) {
+      warnings.push(`Beam layer: polygon with ${poly.length} vertices is not a rectangle, skipped`);
+      continue;
+    }
+
+    const cl = rectangleCenterline(rect);
+    const geomWidth = rect.width; // short dimension = section width
+
+    let id = `V${String(beamAutoId++).padStart(3, '0')}`;
+    let textSection: PlanBeam['textSection'] = null;
+    let textDiffersFromGeom = false;
+
+    // Search for text near the beam centerline midpoint
+    const midX = (cl.x1 + cl.x2) / 2;
+    const midY = (cl.y1 + cl.y2) / 2;
+    const beamTextResult = findNearbyText(allTexts, midX, midY, textSearchDist, beamTextPattern);
+
+    if (beamTextResult) {
+      id = `V${beamTextResult.match[1]}`;
+      const tb = parseFloat(beamTextResult.match[2]) * 0.01; // cm → m
+      const th = parseFloat(beamTextResult.match[3]) * 0.01;
+      textSection = { b: tb, h: th };
+      if (Math.abs(tb - geomWidth) > 0.01) {
+        textDiffersFromGeom = true;
+        warnings.push(`Beam ${id}: text width (${(tb * 100).toFixed(0)}cm) differs from drawn width (${(geomWidth * 100).toFixed(0)}cm). Using text dimensions.`);
+      }
+    }
+
+    beams.push({
+      id,
+      x1: cl.x1, y1: cl.y1,
+      x2: cl.x2, y2: cl.y2,
+      geomWidth,
+      textSection, textDiffersFromGeom,
+    });
+  }
+
+  if (beams.length === 0) {
+    warnings.push(`No beams found on layer ${LAYER_VIGAS}.`);
+  }
+
+  // ─── Step 3: Find Intersections & Create Nodes ─────────────
+
+  const nodes: { id: number; x: number; y: number; z: number }[] = [];
+
+  /** Find or create a node, merging if within tolerance */
+  function findOrAddNode(x: number, y: number, z: number): number {
+    for (const n of nodes) {
+      if (Math.abs(n.x - x) < tol && Math.abs(n.y - y) < tol && Math.abs(n.z - z) < tol) {
+        return n.id;
+      }
+    }
+    const id = nodes.length;
+    nodes.push({ id, x, y, z });
+    return id;
+  }
+
+  const floorZ = options.floorZ;
+  const baseZ = floorZ - options.columnHeight;
+
+  // For each beam, find columns it passes through and record intersection points
+  // beamSegments[i] = sorted list of parameter t values (0 = beam start, 1 = beam end)
+  // plus the column index that intersection comes from
+  interface BeamIntersection {
+    t: number;
+    projX: number;
+    projY: number;
+    columnIdx: number;
+  }
+  const beamIntersections: BeamIntersection[][] = beams.map(() => []);
+
+  // Track which columns are connected to at least one beam
+  const columnConnected = new Array(columns.length).fill(false);
+
+  for (let bi = 0; bi < beams.length; bi++) {
+    const beam = beams[bi];
+    for (let ci = 0; ci < columns.length; ci++) {
+      const col = columns[ci];
+      // Compute half-width of column in plan for snap tolerance
+      let colHalf: number;
+      if (col.shape === 'rect') {
+        colHalf = Math.max(col.b, col.h) / 2;
+      } else {
+        colHalf = col.diameter / 2;
+      }
+      const proj = projectPointOnSegment(col.cx, col.cy, beam.x1, beam.y1, beam.x2, beam.y2);
+      if (proj.dist < tol + colHalf) {
+        beamIntersections[bi].push({
+          t: proj.t,
+          projX: proj.projX,
+          projY: proj.projY,
+          columnIdx: ci,
+        });
+        columnConnected[ci] = true;
+      }
+    }
+    // Sort intersections by parameter t
+    beamIntersections[bi].sort((a, b) => a.t - b.t);
+  }
+
+  // Warn about disconnected columns
+  for (let ci = 0; ci < columns.length; ci++) {
+    if (!columnConnected[ci]) {
+      warnings.push(`Column ${columns[ci].id} at (${columns[ci].cx.toFixed(2)}, ${columns[ci].cy.toFixed(2)}) does not intersect any beam.`);
+    }
+  }
+
+  // Create floor-level nodes at beam endpoints and intersection points
+  // Also create column base nodes
+  // Map: columnIdx → { topNodeId, baseNodeId }
+  const columnNodes = new Map<number, { topNodeId: number; baseNodeId: number }>();
+
+  // Ensure each column has floor-level and base-level nodes
+  for (let ci = 0; ci < columns.length; ci++) {
+    const col = columns[ci];
+    const topId = findOrAddNode(col.cx, col.cy, floorZ);
+    const baseId = findOrAddNode(col.cx, col.cy, baseZ);
+    columnNodes.set(ci, { topNodeId: topId, baseNodeId: baseId });
+  }
+
+  // For each beam, create nodes at endpoints and at each intersection
+  // beamNodeSequence[i] = ordered list of node IDs along the beam axis
+  const beamNodeSequences: number[][] = [];
+
+  for (let bi = 0; bi < beams.length; bi++) {
+    const beam = beams[bi];
+    const inters = beamIntersections[bi];
+
+    // Collect all t-values: 0 (start), intersections, 1 (end)
+    interface TPoint { t: number; x: number; y: number; }
+    const tPoints: TPoint[] = [];
+
+    // Beam start
+    tPoints.push({ t: 0, x: beam.x1, y: beam.y1 });
+
+    // Column intersections
+    for (const inter of inters) {
+      // Skip if very close to start or end (will be merged by findOrAddNode anyway)
+      tPoints.push({ t: inter.t, x: inter.projX, y: inter.projY });
+    }
+
+    // Beam end
+    tPoints.push({ t: 1, x: beam.x2, y: beam.y2 });
+
+    // Remove duplicates (by t proximity)
+    const uniquePoints: TPoint[] = [tPoints[0]];
+    for (let i = 1; i < tPoints.length; i++) {
+      if (Math.abs(tPoints[i].t - uniquePoints[uniquePoints.length - 1].t) > 0.001) {
+        uniquePoints.push(tPoints[i]);
+      }
+    }
+
+    const nodeSeq = uniquePoints.map(p => findOrAddNode(p.x, p.y, floorZ));
+    beamNodeSequences.push(nodeSeq);
+  }
+
+  // ─── Step 4: Create Elements ───────────────────────────────
+
+  // Create sections
+  const sections: PlanMappingResult['sections'] = [];
+  const sectionMap = new Map<string, number>(); // key → sectionId
+
+  function getOrCreateSection(name: string, b: number, h: number): number {
+    const key = `${name}_${b.toFixed(4)}_${h.toFixed(4)}`;
+    const existing = sectionMap.get(key);
+    if (existing !== undefined) return existing;
+    const props = rectSectionProps(b, h);
+    const id = sections.length;
+    sections.push({ id, name, a: props.a, iy: props.iy, iz: props.iz, j: props.j, b, h });
+    sectionMap.set(key, id);
+    return id;
+  }
+
+  function getOrCreateCircularSection(name: string, diameter: number): number {
+    const key = `circ_${name}_${diameter.toFixed(4)}`;
+    const existing = sectionMap.get(key);
+    if (existing !== undefined) return existing;
+    const r = diameter / 2;
+    const a = Math.PI * r * r;
+    const i = (Math.PI * r * r * r * r) / 4;
+    const j = (Math.PI * r * r * r * r) / 2;
+    const id = sections.length;
+    sections.push({ id, name, a, iy: i, iz: i, j });
+    sectionMap.set(key, id);
+    return id;
+  }
+
+  const elements: PlanMappingResult['elements'] = [];
+
+  // Beam elements (horizontal at floor level)
+  for (let bi = 0; bi < beams.length; bi++) {
+    const beam = beams[bi];
+    const seq = beamNodeSequences[bi];
+
+    // Determine beam section
+    let bVal: number, hVal: number;
+    if (beam.textSection) {
+      bVal = beam.textSection.b;
+      hVal = beam.textSection.h;
+    } else {
+      bVal = beam.geomWidth;
+      hVal = options.defaultBeamSection.h;
+    }
+    const secId = getOrCreateSection(`Beam ${beam.id} (${(bVal * 100).toFixed(0)}x${(hVal * 100).toFixed(0)})`, bVal, hVal);
+
+    // Create segments between consecutive nodes
+    for (let i = 0; i < seq.length - 1; i++) {
+      if (seq[i] === seq[i + 1]) continue; // skip zero-length
+      elements.push({ nodeI: seq[i], nodeJ: seq[i + 1], type: 'frame', sectionId: secId });
+    }
+  }
+
+  // Column elements (vertical from base to floor)
+  for (let ci = 0; ci < columns.length; ci++) {
+    const col = columns[ci];
+    const cn = columnNodes.get(ci);
+    if (!cn) continue;
+
+    let secId: number;
+    if (col.shape === 'circular') {
+      secId = getOrCreateCircularSection(
+        `Col ${col.id} (Ø${(col.diameter * 100).toFixed(0)})`,
+        col.diameter,
+      );
+    } else {
+      secId = getOrCreateSection(
+        `Col ${col.id} (${(col.b * 100).toFixed(0)}x${(col.h * 100).toFixed(0)})`,
+        col.b, col.h,
+      );
+    }
+
+    elements.push({ nodeI: cn.baseNodeId, nodeJ: cn.topNodeId, type: 'frame', sectionId: secId });
+  }
+
+  // ─── Step 5: Parse Supports ────────────────────────────────
+
+  const supports: PlanMappingResult['supports'] = [];
+
+  // Fixed supports
+  const fixedPoints = parsed.points.filter(p => p.layer === LAYER_APOYOS_FIJOS);
+  const fixedCircles = parsed.circles.filter(c => c.layer === LAYER_APOYOS_FIJOS);
+
+  for (const fp of fixedPoints) {
+    assignSupport(fp.position.x * scale, fp.position.y * scale, 'fixed');
+  }
+  for (const fc of fixedCircles) {
+    assignSupport(fc.center.x * scale, fc.center.y * scale, 'fixed');
+  }
+
+  // Pinned supports
+  const pinnedPoints = parsed.points.filter(p => p.layer === LAYER_APOYOS_ART);
+  const pinnedCircles = parsed.circles.filter(c => c.layer === LAYER_APOYOS_ART);
+
+  for (const pp of pinnedPoints) {
+    assignSupport(pp.position.x * scale, pp.position.y * scale, 'pinned');
+  }
+  for (const pc of pinnedCircles) {
+    assignSupport(pc.center.x * scale, pc.center.y * scale, 'pinned');
+  }
+
+  function assignSupport(sx: number, sy: number, type: 'fixed' | 'pinned') {
+    // Find nearest column
+    let bestDist = tol * 10; // generous search radius
+    let bestCol = -1;
+    for (let ci = 0; ci < columns.length; ci++) {
+      const d = dist2(sx, sy, columns[ci].cx, columns[ci].cy);
+      if (d < bestDist) {
+        bestDist = d;
+        bestCol = ci;
+      }
+    }
+
+    if (bestCol < 0) {
+      warnings.push(`Support marker (${type}) at (${sx.toFixed(2)}, ${sy.toFixed(2)}) has no nearby column.`);
+      return;
+    }
+
+    const cn = columnNodes.get(bestCol);
+    if (!cn) return;
+
+    // Support is at column BASE
+    const existing = supports.find(s => s.nodeId === cn.baseNodeId);
+    if (existing) {
+      warnings.push(`Duplicate support at column ${columns[bestCol].id} base. Keeping ${existing.type}, ignoring ${type}.`);
+      return;
+    }
+
+    supports.push({ nodeId: cn.baseNodeId, type });
+    columns[bestCol].hasSupport = true;
+    columns[bestCol].supportType = type;
+  }
+
+  // Warn about columns without supports
+  for (const col of columns) {
+    if (!col.hasSupport) {
+      warnings.push(`Column ${col.id} has no support at its base. Consider adding one on ${LAYER_APOYOS_FIJOS} or ${LAYER_APOYOS_ART}.`);
+    }
+  }
+
+  // ─── Step 6: Parse Loads ───────────────────────────────────
+
+  const nodalLoads: PlanMappingResult['nodalLoads'] = [];
+  const distributedLoads: PlanMappingResult['distributedLoads'] = [];
+
+  // Distributed loads: rectangles on DED_P_CARGA_DIST + nearby TEXT with magnitude
+  const distLoadPolygons = reconstructClosedPolygons(parsed.lines, LAYER_CARGA_DIST, scale, tol * 0.5);
+  const loadMagnitudePattern = /([-+]?\d+(?:\.\d+)?)/;
+
+  // Build beam→element index map so we can assign loads to all elements of a beam
+  const beamElementIndices: number[][] = [];
+  let elementIdx = 0;
+  for (let bi = 0; bi < beams.length; bi++) {
+    const seq = beamNodeSequences[bi];
+    const indices: number[] = [];
+    for (let i = 0; i < seq.length - 1; i++) {
+      if (seq[i] === seq[i + 1]) continue;
+      indices.push(elementIdx);
+      elementIdx++;
+    }
+    beamElementIndices.push(indices);
+  }
+
+  for (const poly of distLoadPolygons) {
+    const rect = detectRectangle(poly);
+    if (!rect) {
+      warnings.push('Distributed load layer: non-rectangular polygon, skipped');
+      continue;
+    }
+
+    // The load rectangle centerline should overlap a beam
+    const cl = rectangleCenterline(rect);
+    const loadMidX = (cl.x1 + cl.x2) / 2;
+    const loadMidY = (cl.y1 + cl.y2) / 2;
+
+    // Find magnitude from nearby text on the load layer or any layer
+    const distLoadTexts = allTexts.filter(t => t.layer === LAYER_CARGA_DIST);
+    const allSearchTexts = distLoadTexts.length > 0 ? distLoadTexts : allTexts;
+    const magResult = findNearbyText(allSearchTexts, loadMidX, loadMidY, textSearchDist, loadMagnitudePattern);
+
+    if (!magResult) {
+      warnings.push(`Distributed load at (${loadMidX.toFixed(2)}, ${loadMidY.toFixed(2)}): no magnitude text found, skipped`);
+      continue;
+    }
+
+    const magnitude = parseFloat(magResult.match[1]);
+
+    // Match load against beam axes (not individual elements) to use beam geometry width
+    let matched = false;
+    for (let bi = 0; bi < beams.length; bi++) {
+      const beam = beams[bi];
+      // Project load midpoint onto beam axis
+      const proj = projectPointOnSegment(loadMidX, loadMidY, beam.x1, beam.y1, beam.x2, beam.y2);
+      // Tolerance: beam half-width + load rect half-width + snap tolerance
+      const matchDist = beam.geomWidth / 2 + rect.width / 2 + tol;
+      if (proj.dist < matchDist) {
+        // Assign load to all elements of this beam
+        for (const ei of beamElementIndices[bi]) {
+          distributedLoads.push({ elementIndex: ei, qy: 0, qz: -Math.abs(magnitude) }); // gravity = -Z
+        }
+        matched = true;
+        break;
+      }
+    }
+
+    if (!matched) {
+      warnings.push(`Distributed load (${magnitude} kN/m) at (${loadMidX.toFixed(2)}, ${loadMidY.toFixed(2)}) does not overlap any beam.`);
+    }
+  }
+
+  // Nodal loads: POINT on DED_P_CARGA_NODAL + nearby TEXT with magnitude
+  const nodalLoadPoints = parsed.points.filter(p => p.layer === LAYER_CARGA_NODAL);
+
+  for (const nlp of nodalLoadPoints) {
+    const px = nlp.position.x * scale;
+    const py = nlp.position.y * scale;
+
+    // Find magnitude text
+    const nodalLoadTexts = allTexts.filter(t => t.layer === LAYER_CARGA_NODAL);
+    const searchTexts = nodalLoadTexts.length > 0 ? nodalLoadTexts : allTexts;
+    const magResult = findNearbyText(searchTexts, px, py, textSearchDist, loadMagnitudePattern);
+
+    if (!magResult) {
+      warnings.push(`Nodal load at (${px.toFixed(2)}, ${py.toFixed(2)}): no magnitude text found, skipped`);
+      continue;
+    }
+
+    const magnitude = parseFloat(magResult.match[1]);
+
+    // Find nearest floor-level node
+    let bestDist = tol * 10;
+    let bestNodeId = -1;
+    for (const n of nodes) {
+      if (Math.abs(n.z - floorZ) > tol) continue;
+      const d = dist2(px, py, n.x, n.y);
+      if (d < bestDist) {
+        bestDist = d;
+        bestNodeId = n.id;
+      }
+    }
+
+    if (bestNodeId < 0) {
+      warnings.push(`Nodal load (${magnitude} kN) at (${px.toFixed(2)}, ${py.toFixed(2)}) has no nearby node.`);
+      continue;
+    }
+
+    nodalLoads.push({ nodeId: bestNodeId, fx: 0, fy: 0, fz: -Math.abs(magnitude) }); // gravity = -Z
+  }
+
+  // ─── Create material ──────────────────────────────────────
+
+  const materials: PlanMappingResult['materials'] = [{
+    id: 0,
+    name: `Concrete E=${options.defaultMaterialE} MPa`,
+    e: options.defaultMaterialE,
+    nu: 0.2,
+    rho: 25, // kN/m³
+  }];
+
+  return {
+    nodes, elements, supports, nodalLoads, distributedLoads,
+    sections, materials,
+    columns, beams, warnings,
+  };
+}

--- a/web/src/lib/dxf/plan-template.ts
+++ b/web/src/lib/dxf/plan-template.ts
@@ -1,0 +1,264 @@
+// Generate a downloadable DXF template for Mode 1: Plan -> 3D structural import
+// Format: AutoCAD R12 (AC1009) — universally readable
+
+// ─── Layer definitions ──────────────────────────────────────────
+
+const LAYERS = {
+  VIGAS:        { name: 'DED_P_VIGAS',        color: 4 },  // Cyan
+  COLUMNAS:     { name: 'DED_P_COLUMNAS',     color: 6 },  // Magenta
+  APOYOS_FIJOS: { name: 'DED_P_APOYOS_FIJOS', color: 1 },  // Red
+  APOYOS_ART:   { name: 'DED_P_APOYOS_ART',   color: 1 },  // Red
+  CARGA_DIST:   { name: 'DED_P_CARGA_DIST',   color: 3 },  // Green
+  CARGA_NODAL:  { name: 'DED_P_CARGA_NODAL',  color: 3 },  // Green
+  TEXTO:        { name: 'DED_P_TEXTO',         color: 7 },  // White
+  AYUDA:        { name: 'DED_P_AYUDA',         color: 8 },  // Gray
+} as const;
+
+// ─── Low-level DXF helpers (R12 AC1009 compatible) ──────────────
+
+function str(n: number): string {
+  return n.toFixed(6);
+}
+
+function dxfHeader(): string[] {
+  return ['0', 'SECTION', '2', 'HEADER', '9', '$ACADVER', '1', 'AC1009', '0', 'ENDSEC'];
+}
+
+function dxfLayerTable(layers: Array<{ name: string; color: number }>): string[] {
+  const out: string[] = ['0', 'SECTION', '2', 'TABLES'];
+  out.push('0', 'TABLE', '2', 'LAYER', '70', layers.length.toString());
+  for (const l of layers) {
+    out.push('0', 'LAYER', '2', l.name, '70', '0', '62', l.color.toString(), '6', 'CONTINUOUS');
+  }
+  out.push('0', 'ENDTAB', '0', 'ENDSEC');
+  return out;
+}
+
+function dxfText(layer: string, x: number, y: number, height: number, text: string): string[] {
+  return [
+    '0', 'TEXT', '8', layer,
+    '10', str(x), '20', str(y), '30', str(0),
+    '40', str(height),
+    '1', text,
+  ];
+}
+
+function dxfPoint(layer: string, x: number, y: number): string[] {
+  return ['0', 'POINT', '8', layer, '10', str(x), '20', str(y), '30', str(0)];
+}
+
+function dxfCircle(layer: string, cx: number, cy: number, radius: number): string[] {
+  return [
+    '0', 'CIRCLE', '8', layer,
+    '10', str(cx), '20', str(cy), '30', str(0),
+    '40', str(radius),
+  ];
+}
+
+/** R12-compatible closed rectangle using POLYLINE + VERTEX + SEQEND */
+function dxfRect(layer: string, x: number, y: number, w: number, h: number): string[] {
+  const x2 = x + w;
+  const y2 = y + h;
+  const corners = [
+    { x, y },
+    { x: x2, y },
+    { x: x2, y: y2 },
+    { x, y: y2 },
+  ];
+  return dxfPolyline(layer, corners, true);
+}
+
+/** R12-compatible polyline using POLYLINE + VERTEX + SEQEND */
+function dxfPolyline(layer: string, points: Array<{ x: number; y: number }>, closed = false): string[] {
+  if (points.length < 2) return [];
+  const out: string[] = [
+    '0', 'POLYLINE',
+    '8', layer,
+    '66', '1',          // vertices-follow flag
+    '70', closed ? '1' : '0',
+  ];
+  for (const p of points) {
+    out.push(
+      '0', 'VERTEX',
+      '8', layer,
+      '10', str(p.x), '20', str(p.y), '30', str(0),
+    );
+  }
+  out.push('0', 'SEQEND', '8', layer);
+  return out;
+}
+
+// ─── Template generation ────────────────────────────────────────
+
+export function generatePlanTemplate(): string {
+  const lines: string[] = [];
+
+  // Header
+  lines.push(...dxfHeader());
+
+  // Layer table
+  const allLayers = Object.values(LAYERS).map(l => ({ name: l.name, color: l.color }));
+  lines.push(...dxfLayerTable(allLayers));
+
+  // Entities section
+  lines.push('0', 'SECTION', '2', 'ENTITIES');
+
+  // ── Grid layout (meters) ──
+  //
+  //   C1 (0,4) ── V1 ── C2 (5,4) ── V2 ── C3 (10,4)
+  //   |                  |                   |
+  //   V5                 V6                  V7
+  //   |                  |                   |
+  //   C4 (0,0) ── V3 ── C5 (5,0) ── V4 ── C6 (10,0)
+
+  const cols: Record<string, { x: number; y: number; w: number; h: number; label: string; circular: boolean; diameter?: number }> = {
+    C1: { x: 0,  y: 4, w: 0.30, h: 0.30, label: 'C01 - 30x30', circular: false },
+    C2: { x: 5,  y: 4, w: 0.30, h: 0.30, label: 'C02 - 30x30', circular: false },
+    C3: { x: 10, y: 4, w: 0.30, h: 0.30, label: 'C03 - 30x30', circular: false },
+    C4: { x: 0,  y: 0, w: 0.30, h: 0.40, label: 'C04 - 30x40', circular: false },
+    C5: { x: 5,  y: 0, w: 0,    h: 0,    label: 'C05 - D40',    circular: true, diameter: 0.40 },
+    C6: { x: 10, y: 0, w: 0.30, h: 0.40, label: 'C06 - 30x40', circular: false },
+  };
+
+  // Beams: each defined by start column, end column, width (bxh in m), label
+  const beams = [
+    // Horizontal beams (top row)
+    { x1: 0, y1: 4, x2: 5,  y2: 4, bw: 0.20, bh: 0.40, label: 'V01 - 20x40' },
+    { x1: 5, y1: 4, x2: 10, y2: 4, bw: 0.20, bh: 0.40, label: 'V02 - 20x40' },
+    // Horizontal beams (bottom row)
+    { x1: 0, y1: 0, x2: 5,  y2: 0, bw: 0.25, bh: 0.50, label: 'V03 - 25x50' },
+    { x1: 5, y1: 0, x2: 10, y2: 0, bw: 0.25, bh: 0.50, label: 'V04 - 25x50' },
+    // Vertical beams (left, center, right)
+    { x1: 0,  y1: 0, x2: 0,  y2: 4, bw: 0.20, bh: 0.40, label: 'V05 - 20x40' },
+    { x1: 5,  y1: 0, x2: 5,  y2: 4, bw: 0.20, bh: 0.40, label: 'V06 - 20x40' },
+    { x1: 10, y1: 0, x2: 10, y2: 4, bw: 0.20, bh: 0.40, label: 'V07 - 20x40' },
+  ];
+
+  const LY_VIGAS = LAYERS.VIGAS.name;
+  const LY_COLUMNAS = LAYERS.COLUMNAS.name;
+  const LY_APOYOS = LAYERS.APOYOS_FIJOS.name;
+  const LY_CARGA_DIST = LAYERS.CARGA_DIST.name;
+  const LY_TEXTO = LAYERS.TEXTO.name;
+  const LY_AYUDA = LAYERS.AYUDA.name;
+
+  // ── Draw beams (closed rectangles on DED_P_VIGAS) ──
+
+  for (const b of beams) {
+    const dx = b.x2 - b.x1;
+    const dy = b.y2 - b.y1;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    if (len < 1e-6) continue;
+
+    // Unit direction along beam
+    const ux = dx / len;
+    const uy = dy / len;
+    // Perpendicular (to the left)
+    const px = -uy;
+    const py = ux;
+
+    // Half-width offset perpendicular to beam axis
+    const hw = b.bw / 2;
+
+    // Four corners of the beam rectangle
+    const corners = [
+      { x: b.x1 + px * hw, y: b.y1 + py * hw },
+      { x: b.x2 + px * hw, y: b.y2 + py * hw },
+      { x: b.x2 - px * hw, y: b.y2 - py * hw },
+      { x: b.x1 - px * hw, y: b.y1 - py * hw },
+    ];
+    lines.push(...dxfPolyline(LY_VIGAS, corners, true));
+
+    // Text label near midpoint, offset to avoid overlapping the rectangle
+    const mx = (b.x1 + b.x2) / 2;
+    const my = (b.y1 + b.y2) / 2;
+    const textOffset = hw + 0.15;
+    lines.push(...dxfText(LY_TEXTO, mx + px * textOffset, my + py * textOffset, 0.12, b.label));
+  }
+
+  // ── Draw columns (rectangles or circles on DED_P_COLUMNAS) ──
+
+  for (const [, col] of Object.entries(cols)) {
+    if (col.circular) {
+      const r = col.diameter! / 2;
+      lines.push(...dxfCircle(LY_COLUMNAS, col.x, col.y, r));
+    } else {
+      // Draw rectangle centered on column position
+      lines.push(...dxfRect(LY_COLUMNAS, col.x - col.w / 2, col.y - col.h / 2, col.w, col.h));
+    }
+
+    // Column label
+    lines.push(...dxfText(LY_TEXTO, col.x + 0.25, col.y + 0.25, 0.12, col.label));
+  }
+
+  // ── Draw supports (POINT on DED_P_APOYOS_FIJOS at column centers) ──
+
+  for (const [, col] of Object.entries(cols)) {
+    lines.push(...dxfPoint(LY_APOYOS, col.x, col.y));
+  }
+
+  // ── Distributed load example on V1 ──
+  // V1 runs from (0,4) to (5,4), width 0.20m
+  // Draw a thin rectangle on top of the beam to represent the load
+  {
+    const loadThickness = 0.08; // thin visual indicator
+    const beamHw = 0.20 / 2;   // half-width of V1
+    const yBase = 4 + beamHw;  // top edge of beam
+    lines.push(...dxfRect(LY_CARGA_DIST, 0, yBase, 5, loadThickness));
+    // Load magnitude text
+    lines.push(...dxfText(LY_CARGA_DIST, 2.0, yBase + loadThickness + 0.10, 0.12, '15'));
+  }
+
+  // ── Help text on DED_P_AYUDA ──
+
+  const helpLines = [
+    'TEMPLATE DEDALIANO - Planta Estructural',
+    '',
+    'Capas disponibles:',
+    '  DED_P_VIGAS        - Vigas (rectangulos cerrados POLYLINE)',
+    '  DED_P_COLUMNAS     - Columnas (rectangulos o circulos)',
+    '  DED_P_APOYOS_FIJOS - Apoyos empotrados (POINT en centro de columna)',
+    '  DED_P_APOYOS_ART   - Apoyos articulados (POINT en centro de columna)',
+    '  DED_P_CARGA_DIST   - Cargas distribuidas (rectangulo + texto kN/m)',
+    '  DED_P_CARGA_NODAL  - Cargas nodales',
+    '  DED_P_TEXTO        - Anotaciones de seccion',
+    '  DED_P_AYUDA        - Texto de ayuda (ignorado al importar)',
+    '',
+    'Las vigas se dibujan como rectangulos (POLYLINE cerrada)',
+    'Las columnas rectangulares como rectangulos, circulares como CIRCLE',
+    'Textos de seccion: \'V01 - 20x40\' (bxh en cm) o \'C01 - D40\' (diametro en cm)',
+    'Cargas distribuidas: rectangulo fino sobre viga + texto con magnitud en kN/m',
+  ];
+
+  const helpX = -2;
+  let helpY = -1.5;
+  const helpLineSpacing = 0.30;
+  const helpTextHeight = 0.15;
+
+  for (const hl of helpLines) {
+    if (hl === '') {
+      helpY -= helpLineSpacing;
+      continue;
+    }
+    lines.push(...dxfText(LY_AYUDA, helpX, helpY, helpTextHeight, hl));
+    helpY -= helpLineSpacing;
+  }
+
+  // End entities + EOF
+  lines.push('0', 'ENDSEC');
+  lines.push('0', 'EOF');
+
+  return lines.join('\n');
+}
+
+// ─── Download helper ────────────────────────────────────────────
+
+export function downloadPlanTemplate(): void {
+  const dxf = generatePlanTemplate();
+  const blob = new Blob([dxf], { type: 'application/dxf' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'dedaliano-planta-template.dxf';
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/web/src/lib/dxf/writer.ts
+++ b/web/src/lib/dxf/writer.ts
@@ -6,6 +6,7 @@ import type { DxfExportOptions } from './types';
 import { DXF_COLORS } from './types';
 import type { ElementForces } from '../engine/types';
 import { computeDeformedShape } from '../engine/diagrams';
+import { t } from '../i18n';
 
 // ─── Low-level DXF helpers (R12 AC1009 compatible) ────────────
 
@@ -102,11 +103,11 @@ function shearAtX(ef: ElementForces, x: number): number {
 
 function supportLabel(type: string): string {
   switch (type) {
-    case 'fixed': return 'EMPOTRADO';
-    case 'pinned': return 'ARTICULADO';
-    case 'rollerX': return 'MOVIL X';
-    case 'rollerY': return 'MOVIL Y';
-    case 'spring': return 'RESORTE';
+    case 'fixed': return t('dxf.supportFixed');
+    case 'pinned': return t('dxf.supportPinned');
+    case 'rollerX': return t('dxf.supportRollerX');
+    case 'rollerY': return t('dxf.supportRollerY');
+    case 'spring': return t('dxf.supportSpring');
     default: return type.toUpperCase();
   }
 }
@@ -121,21 +122,31 @@ export function exportDxfWithResults(options: DxfExportOptions): string {
 
   // Layer definitions
   const layerDefs: Array<{ name: string; color: number }> = [
-    { name: 'ESTRUCTURA', color: DXF_COLORS.ESTRUCTURA },
-    { name: 'APOYOS_OUT', color: DXF_COLORS.APOYOS_OUT },
+    { name: t('dxf.layerStructure'), color: DXF_COLORS.ESTRUCTURA },
+    { name: t('dxf.layerSupports'), color: DXF_COLORS.APOYOS_OUT },
   ];
 
   const hasResults = options.includeResults && resultsStore.results;
   if (hasResults) {
     layerDefs.push(
-      { name: 'MOMENTOS', color: DXF_COLORS.MOMENTOS },
-      { name: 'CORTANTES', color: DXF_COLORS.CORTANTES },
-      { name: 'AXILES', color: DXF_COLORS.AXILES },
-      { name: 'DEFORMADA', color: DXF_COLORS.DEFORMADA },
-      { name: 'REACCIONES', color: DXF_COLORS.REACCIONES },
-      { name: 'RESULTADOS', color: DXF_COLORS.RESULTADOS },
+      { name: t('dxf.layerMoments'), color: DXF_COLORS.MOMENTOS },
+      { name: t('dxf.layerShear'), color: DXF_COLORS.CORTANTES },
+      { name: t('dxf.layerAxial'), color: DXF_COLORS.AXILES },
+      { name: t('dxf.layerDeformed'), color: DXF_COLORS.DEFORMADA },
+      { name: t('dxf.layerReactions'), color: DXF_COLORS.REACCIONES },
+      { name: t('dxf.layerResults'), color: DXF_COLORS.RESULTADOS },
     );
   }
+  // Resolve layer names once for entity use
+  const LY_STRUCTURE = t('dxf.layerStructure');
+  const LY_SUPPORTS = t('dxf.layerSupports');
+  const LY_MOMENTS = t('dxf.layerMoments');
+  const LY_SHEAR = t('dxf.layerShear');
+  const LY_AXIAL = t('dxf.layerAxial');
+  const LY_DEFORMED = t('dxf.layerDeformed');
+  const LY_REACTIONS = t('dxf.layerReactions');
+  const LY_RESULTS = t('dxf.layerResults');
+
   lines.push(...dxfLayerTable(layerDefs));
 
   // Entities
@@ -147,12 +158,12 @@ export function exportDxfWithResults(options: DxfExportOptions): string {
     const ni = modelStore.getNode(elem.nodeI);
     const nj = modelStore.getNode(elem.nodeJ);
     if (!ni || !nj) continue;
-    lines.push(...dxfLine('ESTRUCTURA', ni.x, ni.y, nj.x, nj.y, ni.z ?? 0, nj.z ?? 0));
+    lines.push(...dxfLine(LY_STRUCTURE, ni.x, ni.y, nj.x, nj.y, ni.z ?? 0, nj.z ?? 0));
   }
 
   // Nodes as points
   for (const [, node] of modelStore.nodes) {
-    lines.push(...dxfPoint('ESTRUCTURA', node.x, node.y, node.z ?? 0));
+    lines.push(...dxfPoint(LY_STRUCTURE, node.x, node.y, node.z ?? 0));
   }
 
   // ── Supports ──
@@ -160,8 +171,8 @@ export function exportDxfWithResults(options: DxfExportOptions): string {
   for (const [, sup] of modelStore.supports) {
     const node = modelStore.getNode(sup.nodeId);
     if (!node) continue;
-    lines.push(...dxfPoint('APOYOS_OUT', node.x, node.y, node.z ?? 0));
-    lines.push(...dxfText('APOYOS_OUT', node.x + 0.1, node.y - 0.3, 0.15, supportLabel(sup.type), node.z ?? 0));
+    lines.push(...dxfPoint(LY_SUPPORTS, node.x, node.y, node.z ?? 0));
+    lines.push(...dxfText(LY_SUPPORTS, node.x + 0.1, node.y - 0.3, 0.15, supportLabel(sup.type), node.z ?? 0));
   }
 
   // ── Result diagrams ──
@@ -211,12 +222,12 @@ export function exportDxfWithResults(options: DxfExportOptions): string {
         ...mPts,
         { x: nj.x, y: nj.y },
       ];
-      lines.push(...dxfPolyline('MOMENTOS', mClosed, true));
+      lines.push(...dxfPolyline(LY_MOMENTS, mClosed, true));
 
       if (options.includeValues && mMax > 0.01) {
         const tx = ni.x + mMaxX * dx + mMaxVal * ds * px;
         const ty = ni.y + mMaxX * dy + mMaxVal * ds * py;
-        lines.push(...dxfText('MOMENTOS', tx, ty + 0.05, 0.1, mMaxVal.toFixed(2)));
+        lines.push(...dxfText(LY_MOMENTS, tx, ty + 0.05, 0.1, mMaxVal.toFixed(2)));
       }
 
       // Shear diagram
@@ -239,12 +250,12 @@ export function exportDxfWithResults(options: DxfExportOptions): string {
         ...vPts,
         { x: nj.x, y: nj.y },
       ];
-      lines.push(...dxfPolyline('CORTANTES', vClosed, true));
+      lines.push(...dxfPolyline(LY_SHEAR, vClosed, true));
 
       if (options.includeValues && vMax > 0.01) {
         const tx = ni.x + vMaxX * dx + vMaxVal * ds * px;
         const ty = ni.y + vMaxX * dy + vMaxVal * ds * py;
-        lines.push(...dxfText('CORTANTES', tx, ty + 0.05, 0.1, vMaxVal.toFixed(2)));
+        lines.push(...dxfText(LY_SHEAR, tx, ty + 0.05, 0.1, vMaxVal.toFixed(2)));
       }
 
       // Axial diagram (constant for uniform load case)
@@ -256,12 +267,12 @@ export function exportDxfWithResults(options: DxfExportOptions): string {
           { x: nj.x + N * ds * px, y: nj.y + N * ds * py },
           { x: nj.x, y: nj.y },
         ];
-        lines.push(...dxfPolyline('AXILES', aPts, true));
+        lines.push(...dxfPolyline(LY_AXIAL, aPts, true));
 
         if (options.includeValues) {
           const mx = (ni.x + nj.x) / 2 + N * ds * px;
           const my = (ni.y + nj.y) / 2 + N * ds * py;
-          lines.push(...dxfText('AXILES', mx, my + 0.05, 0.1, N.toFixed(2)));
+          lines.push(...dxfText(LY_AXIAL, mx, my + 0.05, 0.1, N.toFixed(2)));
         }
       }
     }
@@ -291,7 +302,7 @@ export function exportDxfWithResults(options: DxfExportOptions): string {
           dj.ux, dj.uy, dj.rz,
           defScale, ef.length,
         );
-        lines.push(...dxfPolyline('DEFORMADA', defPts));
+        lines.push(...dxfPolyline(LY_DEFORMED, defPts));
       }
     }
 
@@ -305,7 +316,7 @@ export function exportDxfWithResults(options: DxfExportOptions): string {
       if (Math.abs(rx.ry) > 0.001) parts.push(`Ry=${rx.ry.toFixed(2)}`);
       if (Math.abs(rx.mz) > 0.001) parts.push(`Mz=${rx.mz.toFixed(2)}`);
       if (parts.length > 0) {
-        lines.push(...dxfText('REACCIONES', node.x, node.y - 0.5, 0.12, parts.join(' ')));
+        lines.push(...dxfText(LY_REACTIONS, node.x, node.y - 0.5, 0.12, parts.join(' ')));
       }
     }
 
@@ -321,9 +332,9 @@ export function exportDxfWithResults(options: DxfExportOptions): string {
       if (isFinite(minX)) {
         const sx = minX;
         const sy = maxY + 1.5;
-        lines.push(...dxfText('RESULTADOS', sx, sy, 0.2, `Max delta: ${(resultsStore.maxDisplacement * 1000).toFixed(3)} mm`));
-        lines.push(...dxfText('RESULTADOS', sx, sy - 0.4, 0.2, `Max M: ${resultsStore.maxMoment.toFixed(2)} kN.m`));
-        lines.push(...dxfText('RESULTADOS', sx, sy - 0.8, 0.2, `Max V: ${resultsStore.maxShear.toFixed(2)} kN`));
+        lines.push(...dxfText(LY_RESULTS, sx, sy, 0.2, `${t('dxf.summaryMaxDelta')} ${(resultsStore.maxDisplacement * 1000).toFixed(3)} mm`));
+        lines.push(...dxfText(LY_RESULTS, sx, sy - 0.4, 0.2, `${t('dxf.summaryMaxM')} ${resultsStore.maxMoment.toFixed(2)} kN.m`));
+        lines.push(...dxfText(LY_RESULTS, sx, sy - 0.8, 0.2, `${t('dxf.summaryMaxV')} ${resultsStore.maxShear.toFixed(2)} kN`));
       }
     }
   }

--- a/web/src/lib/engine/__tests__/moving-loads-symmetry.test.ts
+++ b/web/src/lib/engine/__tests__/moving-loads-symmetry.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { solveMovingLoads } from '../moving-loads';
+import type { SolverInput } from '../types';
+import type { MovingLoadEnvelope } from '../moving-loads';
+
+/** Simply supported beam: L m span, single element */
+function makeSimpleBeam(L = 10): SolverInput {
+  return {
+    nodes: new Map([
+      [1, { id: 1, x: 0, y: 0 }],
+      [2, { id: 2, x: L, y: 0 }],
+    ]),
+    elements: new Map([
+      [1, { id: 1, type: 'frame' as const, nodeI: 1, nodeJ: 2, materialId: 1, sectionId: 1, hingeStart: false, hingeEnd: false }],
+    ]),
+    materials: new Map([
+      [1, { id: 1, e: 200000, nu: 0.3 }],
+    ]),
+    sections: new Map([
+      [1, { id: 1, a: 0.005381, iz: 0.00008356 }],
+    ]),
+    supports: new Map([
+      [1, { id: 1, nodeId: 1, type: 'pinned' as const }],
+      [2, { id: 2, nodeId: 2, type: 'rollerX' as const }],
+    ]),
+    loads: [],
+  };
+}
+
+describe('Moving loads symmetry', () => {
+  it('single axle on symmetric beam produces symmetric envelope', () => {
+    const input = makeSimpleBeam(10);
+    const result = solveMovingLoads(input, {
+      train: { name: 'Single', axles: [{ offset: 0, weight: 100 }] },
+      step: 0.5,
+    });
+
+    expect(typeof result).not.toBe('string');
+    const env = result as MovingLoadEnvelope;
+    expect(env.fullEnvelope).toBeDefined();
+
+    const mData = env.fullEnvelope!.moment.elements[0];
+    const n = mData.negValues.length;
+    const mid = Math.floor(n / 2);
+
+    for (let i = 0; i <= mid; i++) {
+      expect(mData.negValues[i]).toBeCloseTo(mData.negValues[n - 1 - i], 3);
+    }
+  });
+
+  it('HL-93 truck (asymmetric) on symmetric beam produces symmetric envelope', () => {
+    const input = makeSimpleBeam(6);
+    const hl93 = {
+      name: 'HL-93',
+      axles: [
+        { offset: 0, weight: 35 },
+        { offset: 4.3, weight: 145 },
+        { offset: 8.6, weight: 145 },
+      ],
+    };
+    const result = solveMovingLoads(input, { train: hl93, step: 0.25 });
+
+    expect(typeof result).not.toBe('string');
+    const env = result as MovingLoadEnvelope;
+    expect(env.fullEnvelope).toBeDefined();
+
+    const mData = env.fullEnvelope!.moment.elements[0];
+    const n = mData.negValues.length;
+    const mid = Math.floor(n / 2);
+
+    // With mirrored reverse pass, envelope must be perfectly symmetric
+    for (let i = 0; i <= mid; i++) {
+      expect(mData.negValues[i]).toBeCloseTo(mData.negValues[n - 1 - i], 1);
+    }
+  });
+
+  it('tandem (symmetric train) skips reverse pass', () => {
+    const input = makeSimpleBeam(10);
+    const tandem = {
+      name: 'Tandem',
+      axles: [
+        { offset: 0, weight: 110 },
+        { offset: 1.2, weight: 110 },
+      ],
+    };
+    const result = solveMovingLoads(input, { train: tandem, step: 0.5 });
+
+    expect(typeof result).not.toBe('string');
+    const env = result as MovingLoadEnvelope;
+
+    // Tandem is symmetric → only forward pass
+    const maxAxleOffset = 1.2;
+    const expectedCount = Math.floor((10 + maxAxleOffset) / 0.5) + 1;
+    expect(env.positions.length).toBe(expectedCount);
+  });
+
+  it('midspan moment for single axle matches analytical PL/4', () => {
+    const L = 6;
+    const P = 100;
+    const input = makeSimpleBeam(L);
+    const result = solveMovingLoads(input, {
+      train: { name: 'P', axles: [{ offset: 0, weight: P }] },
+      step: 1.0,
+    });
+
+    expect(typeof result).not.toBe('string');
+    const env = result as MovingLoadEnvelope;
+
+    // Envelope at midspan should capture M_max = PL/4
+    const mData = env.fullEnvelope!.moment.elements[0];
+    const midIdx = Math.floor(mData.negValues.length / 2);
+    // Moment is negative in our convention (load pushes down)
+    expect(Math.abs(mData.negValues[midIdx])).toBeCloseTo(P * L / 4, 0);
+  });
+});

--- a/web/src/lib/engine/buckling-3d.ts
+++ b/web/src/lib/engine/buckling-3d.ts
@@ -1,0 +1,467 @@
+// Linear buckling analysis for 3D structures
+//
+// Solves generalized eigenvalue problem: K * phi = lambda * (-Kg) * phi
+// where lambda_cr = critical load factor (smallest positive eigenvalue)
+//
+// Algorithm:
+// 1. Linear solve -> get axial forces N per element
+// 2. Build geometric stiffness Kg3D (12x12 element Kg)
+// 3. Solve generalized eigenvalue problem
+// 4. lambda_cr = critical load factor
+//
+// Reference: Przemieniecki, "Theory of Matrix Structural Analysis" Ch. 11
+
+import {
+  solve3D, assemble3D, buildDofNumbering3D,
+  computeInternalForces3D, computeLocalAxes3D,
+  frameTransformationMatrix3D, trussTransformationMatrix3D,
+  globalDof3D,
+} from './solver-3d';
+import type { DofNumbering3D } from './solver-3d';
+import type { SolverInput3D, AnalysisResults3D, ElementForces3D } from './types-3d';
+import type { SolverDiagnostic } from './types';
+import { solveGeneralizedEigen, choleskySolve } from './matrix-utils';
+
+// ─── Result types ────────────────────────────────────────────────
+
+export interface BucklingMode3D {
+  loadFactor: number;  // lambda_cr
+  displacements: Array<{
+    nodeId: number;
+    ux: number; uy: number; uz: number;
+    rx: number; ry: number; rz: number;
+  }>;
+}
+
+export interface ElementBucklingData3D {
+  elementId: number;
+  axialForce: number;     // kN (from linear analysis)
+  criticalForce: number;  // kN = lambda_cr * |N|
+  kEffective: number;     // effective length factor
+  effectiveLength: number; // m
+  length: number;         // m
+  slendernessY: number;   // KL/ry
+  slendernessZ: number;   // KL/rz
+}
+
+export interface BucklingResult3D {
+  modes: BucklingMode3D[];
+  nDof: number;
+  elementData: ElementBucklingData3D[];
+  diagnostics?: SolverDiagnostic[];
+}
+
+// ─── 3D Geometric Stiffness Matrices ─────────────────────────────
+
+/**
+ * 12x12 geometric stiffness matrix for a 3D frame element in local coords.
+ *
+ * DOFs: [u1, v1, w1, theta_x1, theta_y1, theta_z1,
+ *        u2, v2, w2, theta_x2, theta_y2, theta_z2]
+ *
+ * Consistent formulation (Przemieniecki):
+ * Bending about Z (v, theta_z) and bending about Y (w, theta_y) each get
+ * the standard 4x4 geometric stiffness sub-block.
+ *
+ * N = axial force (positive = tension)
+ * L = element length
+ */
+function frameGeometricStiffness3D(N: number, L: number): Float64Array {
+  const n = 12;
+  const kg = new Float64Array(n * n);
+  const c = N / (30 * L);
+  const L2 = L * L;
+
+  // ── Bending about Z-axis (v1=1, theta_z1=5, v2=7, theta_z2=11) ──
+  //       v1    theta_z1   v2     theta_z2
+  //  v1:  36     3L       -36     3L
+  //  tz1: 3L     4L^2     -3L    -L^2
+  //  v2: -36    -3L        36    -3L
+  //  tz2: 3L    -L^2      -3L     4L^2
+  kg[1 * n + 1]   =  36 * c;
+  kg[1 * n + 5]   =  3 * L * c;
+  kg[1 * n + 7]   = -36 * c;
+  kg[1 * n + 11]  =  3 * L * c;
+
+  kg[5 * n + 1]   =  3 * L * c;
+  kg[5 * n + 5]   =  4 * L2 * c;
+  kg[5 * n + 7]   = -3 * L * c;
+  kg[5 * n + 11]  = -L2 * c;
+
+  kg[7 * n + 1]   = -36 * c;
+  kg[7 * n + 5]   = -3 * L * c;
+  kg[7 * n + 7]   =  36 * c;
+  kg[7 * n + 11]  = -3 * L * c;
+
+  kg[11 * n + 1]  =  3 * L * c;
+  kg[11 * n + 5]  = -L2 * c;
+  kg[11 * n + 7]  = -3 * L * c;
+  kg[11 * n + 11] =  4 * L2 * c;
+
+  // ── Bending about Y-axis (w1=2, theta_y1=4, w2=8, theta_y2=10) ──
+  // Same structure but for w-theta_y plane.
+  // Sign convention: theta_y = -dw/dx, so cross-terms have opposite sign
+  //       w1     theta_y1   w2     theta_y2
+  //  w1:  36    -3L        -36    -3L
+  //  ty1:-3L     4L^2       3L    -L^2
+  //  w2: -36     3L         36     3L
+  //  ty2:-3L    -L^2        3L     4L^2
+  kg[2 * n + 2]   =  36 * c;
+  kg[2 * n + 4]   = -3 * L * c;
+  kg[2 * n + 8]   = -36 * c;
+  kg[2 * n + 10]  = -3 * L * c;
+
+  kg[4 * n + 2]   = -3 * L * c;
+  kg[4 * n + 4]   =  4 * L2 * c;
+  kg[4 * n + 8]   =  3 * L * c;
+  kg[4 * n + 10]  = -L2 * c;
+
+  kg[8 * n + 2]   = -36 * c;
+  kg[8 * n + 4]   =  3 * L * c;
+  kg[8 * n + 8]   =  36 * c;
+  kg[8 * n + 10]  =  3 * L * c;
+
+  kg[10 * n + 2]  = -3 * L * c;
+  kg[10 * n + 4]  = -L2 * c;
+  kg[10 * n + 8]  =  3 * L * c;
+  kg[10 * n + 10] =  4 * L2 * c;
+
+  return kg;
+}
+
+/**
+ * 6x6 geometric stiffness matrix for a 3D truss element in local coords.
+ * DOFs: [u1, v1, w1, u2, v2, w2]
+ * N = axial force (positive = tension)
+ * L = element length
+ */
+function trussGeometricStiffness3D(N: number, L: number): Float64Array {
+  const n = 6;
+  const kg = new Float64Array(n * n);
+  const c = N / L;
+
+  // Transverse terms only (v and w directions)
+  //       v1    v2
+  // v1:   1    -1
+  // v2:  -1     1
+  kg[1 * n + 1] =  c;
+  kg[1 * n + 4] = -c;
+  kg[4 * n + 1] = -c;
+  kg[4 * n + 4] =  c;
+
+  //       w1    w2
+  // w1:   1    -1
+  // w2:  -1     1
+  kg[2 * n + 2] =  c;
+  kg[2 * n + 5] = -c;
+  kg[5 * n + 2] = -c;
+  kg[5 * n + 5] =  c;
+
+  return kg;
+}
+
+// ─── Transform and assemble geometric stiffness ──────────────────
+
+/** Kg_global = T^T * Kg_local * T */
+function transformKgToGlobal(kgLocal: Float64Array, T: Float64Array, ndof: number): Float64Array {
+  // temp = Kg_local * T
+  const temp = new Float64Array(ndof * ndof);
+  for (let i = 0; i < ndof; i++) {
+    for (let j = 0; j < ndof; j++) {
+      let sum = 0;
+      for (let k = 0; k < ndof; k++) {
+        sum += kgLocal[i * ndof + k] * T[k * ndof + j];
+      }
+      temp[i * ndof + j] = sum;
+    }
+  }
+
+  // Kg_global = T^T * temp
+  const kgGlobal = new Float64Array(ndof * ndof);
+  for (let i = 0; i < ndof; i++) {
+    for (let j = 0; j < ndof; j++) {
+      let sum = 0;
+      for (let k = 0; k < ndof; k++) {
+        sum += T[k * ndof + i] * temp[k * ndof + j];
+      }
+      kgGlobal[i * ndof + j] = sum;
+    }
+  }
+
+  return kgGlobal;
+}
+
+/**
+ * Assemble the global geometric stiffness matrix Kg (nFree x nFree).
+ * Uses axial forces from a prior linear solve.
+ */
+export function assembleGeometricStiffness3D(
+  input: SolverInput3D,
+  dofNum: DofNumbering3D,
+  elementForces: ElementForces3D[],
+): Float64Array {
+  const nf = dofNum.nFree;
+  const Kg = new Float64Array(nf * nf);
+
+  // Build lookup: elementId -> ElementForces3D
+  const forcesById = new Map<number, ElementForces3D>();
+  for (const ef of elementForces) {
+    forcesById.set(ef.elementId, ef);
+  }
+
+  for (const [elemId, elem] of input.elements) {
+    const nodeI = input.nodes.get(elem.nodeI)!;
+    const nodeJ = input.nodes.get(elem.nodeJ)!;
+
+    const localY = (elem.localYx !== undefined && elem.localYy !== undefined && elem.localYz !== undefined)
+      ? { x: elem.localYx, y: elem.localYy, z: elem.localYz }
+      : undefined;
+    const axes = computeLocalAxes3D(nodeI, nodeJ, localY, elem.rollAngle);
+    const L = axes.L;
+    if (L < 1e-12) continue;
+
+    // Get axial force (average of start and end)
+    const ef = forcesById.get(elemId);
+    const N = ef ? (ef.nStart + ef.nEnd) / 2 : 0;
+    if (Math.abs(N) < 1e-12) continue;
+
+    if (elem.type === 'frame') {
+      const kgLocal = frameGeometricStiffness3D(N, L);
+      const T = frameTransformationMatrix3D(axes.ex, axes.ey, axes.ez);
+      const kgGlobal = transformKgToGlobal(kgLocal, T, 12);
+
+      // Scatter into global Kg (free DOFs only)
+      const dofs: number[] = [];
+      for (let d = 0; d < dofNum.dofsPerNode; d++) {
+        const idx = globalDof3D(dofNum, elem.nodeI, d);
+        if (idx !== undefined) dofs.push(idx);
+      }
+      for (let d = 0; d < dofNum.dofsPerNode; d++) {
+        const idx = globalDof3D(dofNum, elem.nodeJ, d);
+        if (idx !== undefined) dofs.push(idx);
+      }
+
+      for (let i = 0; i < dofs.length; i++) {
+        const gi = dofs[i];
+        if (gi >= nf) continue;
+        for (let j = 0; j < dofs.length; j++) {
+          const gj = dofs[j];
+          if (gj >= nf) continue;
+          Kg[gi * nf + gj] += kgGlobal[i * 12 + j];
+        }
+      }
+    } else {
+      // Truss: 6x6
+      const kgLocal = trussGeometricStiffness3D(N, L);
+      const T = trussTransformationMatrix3D(axes.ex, axes.ey, axes.ez);
+      const kgGlobal = transformKgToGlobal(kgLocal, T, 6);
+
+      const diI0 = globalDof3D(dofNum, elem.nodeI, 0)!;
+      const diI1 = globalDof3D(dofNum, elem.nodeI, 1)!;
+      const diI2 = globalDof3D(dofNum, elem.nodeI, 2)!;
+      const diJ0 = globalDof3D(dofNum, elem.nodeJ, 0)!;
+      const diJ1 = globalDof3D(dofNum, elem.nodeJ, 1)!;
+      const diJ2 = globalDof3D(dofNum, elem.nodeJ, 2)!;
+      const dofs = [diI0, diI1, diI2, diJ0, diJ1, diJ2];
+
+      for (let i = 0; i < 6; i++) {
+        const gi = dofs[i];
+        if (gi >= nf) continue;
+        for (let j = 0; j < 6; j++) {
+          const gj = dofs[j];
+          if (gj >= nf) continue;
+          Kg[gi * nf + gj] += kgGlobal[i * 6 + j];
+        }
+      }
+    }
+  }
+
+  return Kg;
+}
+
+// ─── Main solver ─────────────────────────────────────────────────
+
+/**
+ * Linear buckling analysis for 3D structures.
+ *
+ * 1. Linear solve -> get axial forces N
+ * 2. Build Kg from N
+ * 3. Solve eigenvalue: K*phi = lambda*(-Kg)*phi
+ * 4. lambda_cr = smallest positive eigenvalue
+ */
+export function solveBuckling3D(
+  input: SolverInput3D,
+  numModes?: number,
+): BucklingResult3D | string {
+  const dofNum = buildDofNumbering3D(input);
+  const nf = dofNum.nFree;
+  const nt = dofNum.nTotal;
+
+  if (nf === 0) return 'No free DOFs for buckling analysis.';
+  if (nf > 500) return 'Model too large for buckling analysis (max 500 DOF).';
+
+  // Step 1: Linear solve
+  const linearResult = solve3D(input);
+  if (typeof linearResult === 'string') return `Linear solve failed: ${linearResult}`;
+
+  // Extract Kff from assembled system
+  const { K, F } = assemble3D(input, dofNum);
+  const Kff = new Float64Array(nf * nf);
+  for (let i = 0; i < nf; i++) {
+    for (let j = 0; j < nf; j++) {
+      Kff[i * nf + j] = K[i * nt + j];
+    }
+  }
+
+  // Step 2: Build Kg from element forces
+  const elementForces = linearResult.elementForces;
+  const Kg = assembleGeometricStiffness3D(input, dofNum, elementForces);
+
+  // Check Kg is not zero
+  let kgNorm = 0;
+  for (let i = 0; i < nf * nf; i++) kgNorm += Kg[i] * Kg[i];
+  if (kgNorm < 1e-20) return 'No axial forces found — buckling analysis requires compression members.';
+
+  // Step 3: Generalized eigenvalue problem
+  // K*phi = lambda*(-Kg)*phi  ->  (-Kg)*phi = mu*K*phi  where mu = 1/lambda
+  const negKg = new Float64Array(nf * nf);
+  for (let i = 0; i < nf * nf; i++) negKg[i] = -Kg[i];
+
+  const eigen = solveGeneralizedEigen(negKg, Kff, nf);
+  if (!eigen) return 'Cholesky decomposition failed — stiffness matrix may not be positive definite.';
+
+  // eigenvalues mu satisfy (-Kg)*phi = mu*K*phi -> lambda = 1/mu
+  // We want positive lambda (smallest): from positive mu
+  const nModes = Math.min(numModes ?? 4, nf);
+  const modes: BucklingMode3D[] = [];
+
+  const candidates: Array<{ lambdaCr: number; modeIdx: number }> = [];
+  for (let i = 0; i < nf; i++) {
+    const mu = eigen.values[i];
+    if (mu > 1e-10) {
+      candidates.push({ lambdaCr: 1 / mu, modeIdx: i });
+    }
+  }
+  candidates.sort((a, b) => a.lambdaCr - b.lambdaCr);
+
+  for (let m = 0; m < Math.min(nModes, candidates.length); m++) {
+    const { lambdaCr, modeIdx } = candidates[m];
+
+    // Extract mode shape
+    const phi = new Float64Array(nf);
+    for (let i = 0; i < nf; i++) {
+      phi[i] = eigen.vectors[i * nf + modeIdx];
+    }
+
+    // Normalize to max = 1
+    let maxAbs = 0;
+    for (let i = 0; i < nf; i++) {
+      if (Math.abs(phi[i]) > maxAbs) maxAbs = Math.abs(phi[i]);
+    }
+    if (maxAbs > 0) {
+      for (let i = 0; i < nf; i++) phi[i] /= maxAbs;
+    }
+
+    // Map to node displacements
+    const displacements: BucklingMode3D['displacements'] = [];
+    for (const [nodeId] of input.nodes) {
+      displacements.push({
+        nodeId,
+        ux: getPhiVal(dofNum, phi, nodeId, 0, nf),
+        uy: getPhiVal(dofNum, phi, nodeId, 1, nf),
+        uz: getPhiVal(dofNum, phi, nodeId, 2, nf),
+        rx: getPhiVal(dofNum, phi, nodeId, 3, nf),
+        ry: getPhiVal(dofNum, phi, nodeId, 4, nf),
+        rz: getPhiVal(dofNum, phi, nodeId, 5, nf),
+      });
+    }
+
+    modes.push({ loadFactor: lambdaCr, displacements });
+  }
+
+  if (modes.length === 0) return 'No positive buckling modes found.';
+
+  // Step 4: Compute per-element buckling data using first (critical) mode
+  const lambdaCr1 = modes[0].loadFactor;
+  const elementData: ElementBucklingData3D[] = [];
+
+  for (const ef of elementForces) {
+    const elem = input.elements.get(ef.elementId);
+    if (!elem) continue;
+    const nodeI = input.nodes.get(elem.nodeI);
+    const nodeJ = input.nodes.get(elem.nodeJ);
+    if (!nodeI || !nodeJ) continue;
+
+    const N = (ef.nStart + ef.nEnd) / 2; // average axial force
+    if (N >= -1e-10) continue; // only compressed elements (N < 0)
+
+    const dx = nodeJ.x - nodeI.x;
+    const dy = nodeJ.y - nodeI.y;
+    const dz = nodeJ.z - nodeI.z;
+    const L = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (L < 1e-12) continue;
+
+    const sec = input.sections.get(elem.sectionId);
+    const mat = input.materials.get(elem.materialId);
+    if (!sec || !mat) continue;
+
+    const E_kNm2 = mat.e * 1000; // MPa -> kN/m²
+    const absN = Math.abs(N);
+    const Pcr = lambdaCr1 * absN;
+
+    // Effective length factor from Pcr = pi^2 * E * I / (K * L)^2
+    // Use the weaker axis for the overall K factor
+    const EIy = E_kNm2 * sec.iy;
+    const EIz = E_kNm2 * sec.iz;
+    const EImin = Math.min(EIy, EIz);
+
+    const kEff = Pcr > 1e-15 ? Math.PI * Math.sqrt(EImin / Pcr) / L : Infinity;
+    const Le = kEff * L;
+
+    // Radii of gyration
+    const ry = Math.sqrt(sec.iy / sec.a); // about Y axis
+    const rz = Math.sqrt(sec.iz / sec.a); // about Z axis
+
+    const slendernessY = Le / ry;
+    const slendernessZ = Le / rz;
+
+    elementData.push({
+      elementId: ef.elementId,
+      axialForce: N,
+      criticalForce: Pcr,
+      kEffective: kEff,
+      effectiveLength: Le,
+      length: L,
+      slendernessY,
+      slendernessZ,
+    });
+  }
+
+  const diags: SolverDiagnostic[] = [];
+  if (modes.length > 0) {
+    const firstFactor = modes[0].loadFactor;
+    if (firstFactor < 1.0) {
+      diags.push({ severity: 'error', code: 'BUCKLING_LOW_FACTOR', message: 'diag.bucklingLowFactor', source: 'stability', details: { loadFactor: firstFactor } });
+    } else if (firstFactor < 3.0) {
+      diags.push({ severity: 'warning', code: 'BUCKLING_LOW_FACTOR', message: 'diag.bucklingLowFactor', source: 'stability', details: { loadFactor: firstFactor } });
+    }
+  }
+
+  return { modes, nDof: nf, elementData, diagnostics: diags.length > 0 ? diags : undefined };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+function getPhiVal(
+  dofNum: DofNumbering3D,
+  phi: Float64Array,
+  nodeId: number,
+  localDof: number,
+  nFree: number,
+): number {
+  if (localDof >= dofNum.dofsPerNode) return 0;
+  const key = `${nodeId}:${localDof}`;
+  const idx = dofNum.map.get(key);
+  if (idx === undefined || idx >= nFree) return 0;
+  return phi[idx];
+}

--- a/web/src/lib/engine/buckling.ts
+++ b/web/src/lib/engine/buckling.ts
@@ -5,6 +5,7 @@ import type { SolverInput } from './types';
 import { buildDofNumbering, assemble, solveLU, computeInternalForces, nodeDistance } from './solver-js';
 import { assembleKg } from './geometric-stiffness';
 import { solveGeneralizedEigen, choleskySolve } from './matrix-utils';
+import { t } from '../i18n';
 
 export interface BucklingMode {
   /** Critical load factor (multiply applied loads by this to get buckling) */
@@ -52,8 +53,8 @@ export function solveBuckling(
   const nf = dofNum.nFree;
   const nt = dofNum.nTotal;
 
-  if (nf === 0) return 'No hay grados de libertad libres';
-  if (nf > 500) return 'Modelo demasiado grande para análisis de pandeo (máx ~500 DOFs libres)';
+  if (nf === 0) return t('buckling.noFreeDofs');
+  if (nf > 500) return t('buckling.modelTooLarge');
 
   // Step 1: Linear solve
   const { K, F } = assemble(input, dofNum);
@@ -73,7 +74,7 @@ export function solveBuckling(
     uFree = choleskySolve(new Float64Array(Kff), new Float64Array(Ff), nf)
           ?? solveLU(new Float64Array(Kff), new Float64Array(Ff), nf);
   } catch {
-    return 'Error en resolución lineal';
+    return t('buckling.linearSolveError');
   }
 
   // Build full displacement vector
@@ -87,7 +88,7 @@ export function solveBuckling(
   // Check Kg is not zero
   let kgNorm = 0;
   for (let i = 0; i < nf * nf; i++) kgNorm += Kg[i] * Kg[i];
-  if (kgNorm < 1e-20) return 'No hay fuerzas axiales de compresión en la estructura — el análisis de pandeo (Euler) requiere elementos comprimidos. Verifique que las cargas generen compresión axial.';
+  if (kgNorm < 1e-20) return t('buckling.noCompression');
 
   // Step 3: Generalized eigenvalue problem
   // K·φ = λ·(-Kg)·φ  →  (-Kg)·φ = μ·K·φ  where μ = 1/λ
@@ -97,7 +98,7 @@ export function solveBuckling(
   for (let i = 0; i < nf * nf; i++) negKg[i] = -Kg[i];
 
   const eigen = solveGeneralizedEigen(negKg, Kff, nf);
-  if (!eigen) return 'Error en descomposición de Cholesky de la matriz de rigidez';
+  if (!eigen) return t('buckling.choleskyError');
 
   // eigenvalues μ satisfy (-Kg)·φ = μ·K·φ → K·φ = (1/μ)·(-Kg)·φ → λ = 1/μ
   // We want positive λ (from positive μ): smallest λ = largest positive μ
@@ -144,7 +145,7 @@ export function solveBuckling(
     modes.push({ loadFactor: lambdaCr, displacements });
   }
 
-  if (modes.length === 0) return 'No se encontraron modos de pandeo';
+  if (modes.length === 0) return t('buckling.noModesFound');
 
   // Compute per-element buckling data using the first (critical) mode
   const lambdaCr1 = modes[0].loadFactor;

--- a/web/src/lib/engine/influence-service.ts
+++ b/web/src/lib/engine/influence-service.ts
@@ -5,6 +5,7 @@
 import { computeInfluenceLineWasm } from './wasm-solver';
 import type { ModelData } from './solver-service';
 import type { InfluenceQuantity, InfluenceLineResult } from '../store/model.svelte';
+import { t } from '../i18n';
 
 /**
  * Compute influence line: move unit load P=1 (downward) across elements.
@@ -18,8 +19,8 @@ export function computeInfluenceLine(
   targetPosition: number = 0.5,
   nPointsPerElement: number = 20,
 ): InfluenceLineResult | string {
-  if (model.nodes.size < 2 || model.elements.size < 1) return 'Necesita al menos 2 nodos y 1 elemento';
-  if (model.supports.size < 1) return 'Necesita al menos 1 apoyo';
+  if (model.nodes.size < 2 || model.elements.size < 1) return t('influence.needNodesElems');
+  if (model.supports.size < 1) return t('influence.needSupport');
 
   // Build base solver input (no loads)
   const solver = {
@@ -45,6 +46,6 @@ export function computeInfluenceLine(
       nPointsPerElement,
     });
   } catch (err: any) {
-    return `Error al calcular línea de influencia: ${err.message}`;
+    return t('influence.calcError').replace('{n}', err.message);
   }
 }

--- a/web/src/lib/engine/kinematic-2d.ts
+++ b/web/src/lib/engine/kinematic-2d.ts
@@ -8,6 +8,7 @@
 
 import type { SolverInput } from './types';
 import { buildDofNumbering, assemble, type DofNumbering } from './solver-js';
+import { t } from '../i18n';
 
 function dofKey(nodeId: number, localDof: number): string {
   return `${nodeId}:${localDof}`;
@@ -227,7 +228,7 @@ export function analyzeKinematics(input: SolverInput): KinematicResult {
       mechanismModes: 0,
       mechanismNodes: [],
       unconstrainedDofs: [],
-      diagnosis: 'Todos los GDL están restringidos.',
+      diagnosis: t('kin.allDofConstrained'),
       isSolvable: true,
     };
   }
@@ -315,32 +316,39 @@ function buildDiagnosis(
   unconstrainedDofs: Array<{ nodeId: number; dof: 'ux' | 'uy' | 'rz' }>,
 ): string {
   const dofNames: Record<string, string> = {
-    'ux': 'desplazamiento horizontal',
-    'uy': 'desplazamiento vertical',
-    'rz': 'rotación',
+    'ux': t('kin.dofHorizontal'),
+    'uy': t('kin.dofVertical'),
+    'rz': t('kin.dofRotation'),
   };
 
   if (mechanismModes === 0) {
-    if (degree > 0) return `Estructura hiperestática de grado ${degree}.`;
-    if (degree === 0) return 'Estructura isostática.';
-    // degree < 0 but rank is full — shouldn't happen, but handle gracefully
-    return `Estructura con grado ${degree} pero numéricamente estable.`;
+    if (degree > 0) return t('kin.diagHyperstatic').replace('{degree}', String(degree));
+    if (degree === 0) return t('kin.diagIsostatic');
+    return t('kin.diagStableButNeg').replace('{degree}', String(degree));
   }
 
   // Has mechanism modes
   const nodeList = mechanismNodes.slice(0, 8).join(', ');
   const dofList = unconstrainedDofs.slice(0, 8)
-    .map(d => `nodo ${d.nodeId} (${dofNames[d.dof]})`)
+    .map(d => `${t('kin.nodeLC')} ${d.nodeId} (${dofNames[d.dof]})`)
     .join('; ');
 
   if (mechanismNodes.length <= 3) {
-    return `Mecanismo en nodo${mechanismNodes.length > 1 ? 's' : ''} ${nodeList} ` +
-           `(${mechanismModes} modo${mechanismModes > 1 ? 's' : ''} de mecanismo). ` +
-           `GDL sin restringir: ${dofList}. ` +
-           `Revisá las articulaciones y apoyos en esa zona.`;
+    return t('kin.diagMechSmall')
+      .replace('{s}', mechanismNodes.length > 1 ? t('kin.plural_s') : '')
+      .replace('{nodes}', nodeList)
+      .replace('{modes}', String(mechanismModes))
+      .replace('{ms}', mechanismModes > 1 ? t('kin.plural_s') : '')
+      .replace('{dofs}', dofList);
   }
 
-  return `Estructura hipostática (grado ${degree}, ${mechanismModes} modo${mechanismModes > 1 ? 's' : ''} de mecanismo). ` +
-         `${mechanismNodes.length} nodos participan: ${nodeList}${mechanismNodes.length > 8 ? '...' : ''}. ` +
-         `GDL sin restringir: ${dofList}${unconstrainedDofs.length > 8 ? '...' : ''}.`;
+  return t('kin.diagMechLarge')
+    .replace('{degree}', String(degree))
+    .replace('{modes}', String(mechanismModes))
+    .replace('{ms}', mechanismModes > 1 ? t('kin.plural_s') : '')
+    .replace('{nNodes}', String(mechanismNodes.length))
+    .replace('{nodes}', nodeList)
+    .replace('{dots1}', mechanismNodes.length > 8 ? '...' : '')
+    .replace('{dofs}', dofList)
+    .replace('{dots2}', unconstrainedDofs.length > 8 ? '...' : '');
 }

--- a/web/src/lib/engine/kinematic-3d.ts
+++ b/web/src/lib/engine/kinematic-3d.ts
@@ -12,6 +12,7 @@ import {
   buildDofNumbering3D, assemble3D, dofKey,
   type DofNumbering3D,
 } from './solver-3d';
+import { t } from '../i18n';
 
 // ─── Result type ─────────────────────────────────────────────────
 
@@ -274,7 +275,7 @@ export function analyzeKinematics3D(input: SolverInput3D): KinematicResult3D {
       mechanismModes: 0,
       mechanismNodes: [],
       unconstrainedDofs: [],
-      diagnosis: 'Todos los GDL están restringidos.',
+      diagnosis: t('kin.allDofConstrained'),
       isSolvable: true,
     };
   }
@@ -395,35 +396,42 @@ function buildDiagnosis3D(
   unconstrainedDofs: Array<{ nodeId: number; dof: string }>,
 ): string {
   const dofNames: Record<string, string> = {
-    'ux': 'desplazamiento en X',
-    'uy': 'desplazamiento en Y',
-    'uz': 'desplazamiento en Z',
-    'rx': 'rotación en X (torsión)',
-    'ry': 'rotación en Y',
-    'rz': 'rotación en Z',
+    'ux': t('kin.dof3dUx'),
+    'uy': t('kin.dof3dUy'),
+    'uz': t('kin.dof3dUz'),
+    'rx': t('kin.dof3dRx'),
+    'ry': t('kin.dof3dRy'),
+    'rz': t('kin.dof3dRz'),
   };
 
   if (mechanismModes === 0) {
-    if (degree > 0) return `Estructura hiperestática de grado ${degree}.`;
-    if (degree === 0) return 'Estructura isostática.';
-    // degree < 0 but rank is full — shouldn't happen, but handle gracefully
-    return `Estructura con grado ${degree} pero numéricamente estable.`;
+    if (degree > 0) return t('kin.diagHyperstatic').replace('{degree}', String(degree));
+    if (degree === 0) return t('kin.diagIsostatic');
+    return t('kin.diagStableButNeg').replace('{degree}', String(degree));
   }
 
   // Has mechanism modes
   const nodeList = mechanismNodes.slice(0, 8).join(', ');
   const dofList = unconstrainedDofs.slice(0, 8)
-    .map(d => `nodo ${d.nodeId} (${dofNames[d.dof] ?? d.dof})`)
+    .map(d => `${t('kin.nodeLC')} ${d.nodeId} (${dofNames[d.dof] ?? d.dof})`)
     .join('; ');
 
   if (mechanismNodes.length <= 3) {
-    return `Mecanismo en nodo${mechanismNodes.length > 1 ? 's' : ''} ${nodeList} ` +
-           `(${mechanismModes} modo${mechanismModes > 1 ? 's' : ''} de mecanismo). ` +
-           `GDL sin restringir: ${dofList}. ` +
-           `Revisá las articulaciones y apoyos en esa zona.`;
+    return t('kin.diagMechSmall')
+      .replace('{s}', mechanismNodes.length > 1 ? t('kin.plural_s') : '')
+      .replace('{nodes}', nodeList)
+      .replace('{modes}', String(mechanismModes))
+      .replace('{ms}', mechanismModes > 1 ? t('kin.plural_s') : '')
+      .replace('{dofs}', dofList);
   }
 
-  return `Estructura hipostática (grado ${degree}, ${mechanismModes} modo${mechanismModes > 1 ? 's' : ''} de mecanismo). ` +
-         `${mechanismNodes.length} nodos participan: ${nodeList}${mechanismNodes.length > 8 ? '...' : ''}. ` +
-         `GDL sin restringir: ${dofList}${unconstrainedDofs.length > 8 ? '...' : ''}.`;
+  return t('kin.diagMechLarge')
+    .replace('{degree}', String(degree))
+    .replace('{modes}', String(mechanismModes))
+    .replace('{ms}', mechanismModes > 1 ? t('kin.plural_s') : '')
+    .replace('{nNodes}', String(mechanismNodes.length))
+    .replace('{nodes}', nodeList)
+    .replace('{dots1}', mechanismNodes.length > 8 ? '...' : '')
+    .replace('{dofs}', dofList)
+    .replace('{dots2}', unconstrainedDofs.length > 8 ? '...' : '');
 }

--- a/web/src/lib/engine/kinematic-report.ts
+++ b/web/src/lib/engine/kinematic-report.ts
@@ -9,6 +9,7 @@
 
 import type { SolverInput } from './types';
 import { computeStaticDegree, analyzeKinematics } from './kinematic-2d';
+import { t } from '../i18n';
 
 // ─── Public interfaces ─────────────────────────────────────────
 
@@ -122,33 +123,40 @@ export interface KinematicReport {
 
 // ─── Support type labels ────────────────────────────────────────
 
-const SUPPORT_LABELS: Record<string, { label: string; dofs: number; restrained: string }> = {
-  fixed:    { label: 'Empotramiento', dofs: 3, restrained: 'ux, uy, θz' },
-  pinned:   { label: 'Articulación fija', dofs: 2, restrained: 'ux, uy' },
-  rollerX:  { label: 'Roller horizontal', dofs: 1, restrained: 'uy' },
-  rollerY:  { label: 'Roller vertical', dofs: 1, restrained: 'ux' },
-  inclinedRoller: { label: 'Roller inclinado', dofs: 1, restrained: 'u_n' },
-};
+function getSupportLabels(): Record<string, { label: string; dofs: number; restrained: string }> {
+  return {
+    fixed:    { label: t('kin.supFixed'), dofs: 3, restrained: 'ux, uy, θz' },
+    pinned:   { label: t('kin.supPinned'), dofs: 2, restrained: 'ux, uy' },
+    rollerX:  { label: t('kin.supRollerX'), dofs: 1, restrained: 'uy' },
+    rollerY:  { label: t('kin.supRollerY'), dofs: 1, restrained: 'ux' },
+    inclinedRoller: { label: t('kin.supInclinedRoller'), dofs: 1, restrained: 'u_n' },
+  };
+}
 
-const DOF_NAMES: Record<string, string> = {
-  ux: 'desplazamiento horizontal',
-  uy: 'desplazamiento vertical',
-  rz: 'rotación',
-};
+function getDofNames(): Record<string, string> {
+  return {
+    ux: t('kin.dofHorizontal'),
+    uy: t('kin.dofVertical'),
+    rz: t('kin.dofRotation'),
+  };
+}
 
 // ─── Per-DOF support mapping ────────────────────────────────────
 
-const SUPPORT_DOFS: Record<string, ReadonlySet<DofLabel>> = {
-  Empotramiento:       new Set<DofLabel>(['ux', 'uy', 'θz']),
-  'Articulación fija': new Set<DofLabel>(['ux', 'uy']),
-  'Roller horizontal': new Set<DofLabel>(['uy']),
-  'Roller vertical':   new Set<DofLabel>(['ux']),
-  'Roller inclinado':  new Set<DofLabel>(['uy']),   // simplification: u_n ≈ uy
-};
+function getSupportDofs(): Record<string, ReadonlySet<DofLabel>> {
+  return {
+    [t('kin.supFixed')]:          new Set<DofLabel>(['ux', 'uy', 'θz']),
+    [t('kin.supPinned')]:         new Set<DofLabel>(['ux', 'uy']),
+    [t('kin.supRollerX')]:        new Set<DofLabel>(['uy']),
+    [t('kin.supRollerY')]:        new Set<DofLabel>(['ux']),
+    [t('kin.supInclinedRoller')]: new Set<DofLabel>(['uy']),   // simplification: u_n ≈ uy
+  };
+}
 
 /** Parse a SupportDetail into the set of DofLabels it constrains */
 function parseSupportDofs(sup: SupportDetail): Set<DofLabel> {
-  const preset = SUPPORT_DOFS[sup.type];
+  const supportDofs = getSupportDofs();
+  const preset = supportDofs[sup.type];
   if (preset) return new Set(preset);
   // Spring or unknown: parse from restrainedDofs string
   const dofs = new Set<DofLabel>();
@@ -184,9 +192,10 @@ export function generateKinematicReport(input: SolverInput): KinematicReport | n
   // Support details
   const supportDetails: SupportDetail[] = [];
   let totalR = 0;
+  const supLabels = getSupportLabels();
   for (const sup of input.supports.values()) {
-    const t = sup.type as string;
-    const preset = SUPPORT_LABELS[t];
+    const st = sup.type as string;
+    const preset = supLabels[st];
     if (preset) {
       supportDetails.push({
         nodeId: sup.nodeId,
@@ -195,7 +204,7 @@ export function generateKinematicReport(input: SolverInput): KinematicReport | n
         restrainedDofs: preset.restrained,
       });
       totalR += preset.dofs;
-    } else if (t === 'spring') {
+    } else if (st === 'spring') {
       const parts: string[] = [];
       let d = 0;
       if (sup.kx && sup.kx > 0) { parts.push('ux'); d++; }
@@ -203,9 +212,9 @@ export function generateKinematicReport(input: SolverInput): KinematicReport | n
       if (sup.kz && sup.kz > 0) { parts.push('θz'); d++; }
       supportDetails.push({
         nodeId: sup.nodeId,
-        type: 'Resorte',
+        type: t('kin.supSpring'),
         dofs: d,
-        restrainedDofs: parts.join(', ') || '(sin rigidez)',
+        restrainedDofs: parts.join(', ') || t('kin.noStiffness'),
       });
       totalR += d;
     }
@@ -247,13 +256,13 @@ export function generateKinematicReport(input: SolverInput): KinematicReport | n
 
     if (k <= 1) {
       ci = 0;
-      explanation = `${elemList} — extremo libre, no genera condición interna`;
+      explanation = `${elemList} — ${t('kin.hingeFreeEnd')}`;
     } else if (hasRot) {
       ci = j;
-      explanation = `${elemList} — nodo con restricción rotacional → c = ${j}`;
+      explanation = `${elemList} — ${t('kin.hingeRotRestraint').replace('{c}', String(j))}`;
     } else {
       ci = Math.min(j, k - 1);
-      explanation = `${elemList} — ${k} elementos frame, ${j} articulaciones → c = min(${j}, ${k}−1) = ${ci}`;
+      explanation = `${elemList} — ${t('kin.hingeFormula').replace('{k}', String(k)).replace('{j}', String(j)).replace('{ci}', String(ci))}`;
     }
 
     if (j > 0) {
@@ -307,33 +316,31 @@ export function generateKinematicReport(input: SolverInput): KinematicReport | n
   let classificationText: string;
   if (degree < 0) {
     classification = 'hypostatic';
-    classificationText = `Hipostática — faltan ${Math.abs(degree)} restricción${Math.abs(degree) > 1 ? 'es' : ''}. La estructura es un mecanismo.`;
+    classificationText = t('kin.classHypostatic').replace('{n}', String(Math.abs(degree))).replace('{s}', Math.abs(degree) > 1 ? t('kin.plural_s') : '');
   } else if (hasHiddenMechanism) {
     // g ≥ 0 but rank analysis reveals mechanism → override classification
     classification = 'hypostatic';
     if (degree === 0) {
-      classificationText = `La fórmula da g = 0 (condición necesaria para isostática), pero NO suficiente. ` +
-        `La verificación numérica (Paso 3) detectó ${mechanismModes} modo${mechanismModes > 1 ? 's' : ''} de mecanismo. ` +
-        `Esto ocurre cuando las restricciones están mal distribuidas: una zona tiene restricciones de sobra y otra zona no tiene las suficientes.`;
+      classificationText = t('kin.classHiddenMechZero').replace('{modes}', String(mechanismModes)).replace('{s}', mechanismModes > 1 ? t('kin.plural_s') : '');
     } else {
-      classificationText = `La fórmula da g = ${degree} > 0 (aparenta ser hiperestática), pero la verificación numérica (Paso 3) detectó ${mechanismModes} modo${mechanismModes > 1 ? 's' : ''} de mecanismo. ` +
-        `Esto ocurre cuando las restricciones están mal distribuidas: una zona es hiperestática (tiene restricciones de sobra) mientras otra es hipostática (le faltan restricciones). El exceso de una zona no compensa el déficit de otra.`;
+      classificationText = t('kin.classHiddenMechPos').replace('{degree}', String(degree)).replace('{modes}', String(mechanismModes)).replace('{s}', mechanismModes > 1 ? t('kin.plural_s') : '');
     }
   } else if (degree === 0) {
     classification = 'isostatic';
-    classificationText = 'Isostática — la cantidad de restricciones es exactamente la necesaria. No hay redundancia.';
+    classificationText = t('kin.classIsostatic');
   } else {
     classification = 'hyperstatic';
-    classificationText = `Hiperestática de grado ${degree} — hay ${degree} ecuación${degree > 1 ? 'es' : ''} de equilibrio más de las necesarias para garantizar estabilidad.`;
+    classificationText = t('kin.classHyperstatic').replace('{degree}', String(degree)).replace('{s}', degree > 1 ? t('kin.plural_s') : '');
   }
 
   // Build detailed unconstrained DOF explanations
+  const dofNames = getDofNames();
   const unconstrainedDofs: UnconstrainedDofDetail[] = [];
   for (const ud of kinResult.unconstrainedDofs) {
     unconstrainedDofs.push({
       nodeId: ud.nodeId,
       dof: ud.dof,
-      dofName: DOF_NAMES[ud.dof] ?? ud.dof,
+      dofName: dofNames[ud.dof] ?? ud.dof,
       explanation: explainUnconstrainedDof(ud.nodeId, ud.dof, input),
     });
   }
@@ -627,7 +634,7 @@ function buildDofBreakdown(
       for (const dof of effective) {
         end.acc[dof].push({
           fromNodeId: end.nId,
-          label: `${end.info.support.type} en Nodo ${end.nId}`,
+          label: `${end.info.support.type} ${t('kin.atNode')} ${end.nId}`,
           viaElems: [],
         });
       }
@@ -643,7 +650,7 @@ function buildDofBreakdown(
         for (const dof of res.effectiveDofs) {
           end.acc[dof].push({
             fromNodeId: end.nId,
-            label: `${res.support.type} en Nodo ${res.support.nodeId}`,
+            label: `${res.support.type} ${t('kin.atNode')} ${res.support.nodeId}`,
             viaElems: res.chain,
           });
         }
@@ -668,7 +675,7 @@ function buildDofBreakdown(
   // Format a source as text (label + chain path)
   const fmtSrc = (s: DofConstraintSource): string => {
     const via = s.viaElems.length > 0
-      ? ` (vía ${s.viaElems.map(id => `Barra ${id}`).join(' → ')})`
+      ? ` (${t('kin.via')} ${s.viaElems.map(id => `${t('kin.member')} ${id}`).join(' → ')})`
       : '';
     return s.label + via;
   };
@@ -678,7 +685,7 @@ function buildDofBreakdown(
   // All other supports (pin, rollers) only provide translational restraint;
   // their θz contribution comes from the moment arm (couple) effect.
   const isDirectThzLabel = (label: string): boolean =>
-    label.startsWith('Empotramiento') || label.startsWith('Resorte');
+    label.startsWith(t('kin.supFixed')) || label.startsWith(t('kin.supSpring'));
 
   // Build a "cupla" explanation: θz is constrained by the force couple formed
   // between translational reactions at both ends of the element (or chain).
@@ -698,12 +705,12 @@ function buildDofBreakdown(
     const descsI = dedup(allTransI);
     const descsJ = dedup(allTransJ);
     if (descsI.length > 0 && descsJ.length > 0) {
-      return `Cupla: ${descsI.join(', ')} ↔ ${descsJ.join(', ')}`;
+      return `${t('kin.couple')}: ${descsI.join(', ')} ↔ ${descsJ.join(', ')}`;
     }
     // Fallback: only one end has translational sources
     const available = descsI.length > 0 ? descsI : descsJ;
-    if (available.length > 0) return `${available.join(', ')} (brazo de palanca)`;
-    return 'Equilibrio de momento';
+    if (available.length > 0) return `${available.join(', ')} (${t('kin.leverArm')})`;
+    return t('kin.momentEquilibrium');
   };
 
   // θz implicit: if frame, no direct/virtual θz sources, but both nodes have translational restraint
@@ -729,7 +736,7 @@ function buildDofBreakdown(
     const sources = combined[dof];
     let displayText: string;
     if (sources.length === 0) {
-      displayText = '⚠ sin restricción';
+      displayText = '⚠ ' + t('kin.noConstraint');
     } else if (dof === 'θz') {
       // θz display: distinguish direct θz (from fixed/spring that directly restrains rotation)
       // from moment arm θz (from translational supports forming a couple).
@@ -751,7 +758,7 @@ function buildDofBreakdown(
         // Implicit already carries the couple text from buildCoupleText()
         parts.push(...implicitSources.map(s => s.label));
       }
-      displayText = parts.length > 0 ? parts.join(' · ') : '⚠ sin restricción';
+      displayText = parts.length > 0 ? parts.join(' · ') : '⚠ ' + t('kin.noConstraint');
     } else {
       displayText = sources.map(fmtSrc).join(' · ');
     }
@@ -770,19 +777,19 @@ function buildDofBreakdown(
   let summary: string;
   if (status === 'mechanism') {
     if (freeDofs.length > 0) {
-      summary = `mecanismo — falta restricción en ${freeDofs.join(', ')}.`;
+      summary = t('kin.summMechMissing').replace('{dofs}', freeDofs.join(', '));
     } else {
-      summary = 'mecanismo.';
+      summary = t('kin.summMech');
     }
   } else if (status === 'hyperstatic') {
     const overDofs = lines.filter(l => l.sources.length > 1 && !l.sources.every(s => s.implicit)).map(l => l.dof);
     if (overDofs.length > 0) {
-      summary = `hiperestática — restricción de más en ${overDofs.join(', ')}.`;
+      summary = t('kin.summHyperOver').replace('{dofs}', overDofs.join(', '));
     } else {
-      summary = 'hiperestática — restricciones de más.';
+      summary = t('kin.summHyper');
     }
   } else {
-    summary = 'isostática — vinculación justa.';
+    summary = t('kin.summIso');
   }
 
   return { lines, totalConstraints, needed, summary };
@@ -804,15 +811,16 @@ function generatePerElementAnalysis(
   // Pre-build support lookup by nodeId
   const supportByNode = new Map<number, SupportDetail>();
   const supportedNodes = new Set<number>();
+  const supLabels2 = getSupportLabels();
   for (const sup of input.supports.values()) {
-    const t = sup.type as string;
-    const preset = SUPPORT_LABELS[t];
+    const st = sup.type as string;
+    const preset = supLabels2[st];
     if (preset) {
       supportByNode.set(sup.nodeId, {
         nodeId: sup.nodeId, type: preset.label, dofs: preset.dofs, restrainedDofs: preset.restrained,
       });
       supportedNodes.add(sup.nodeId);
-    } else if (t === 'spring') {
+    } else if (st === 'spring') {
       const parts: string[] = [];
       let d = 0;
       if (sup.kx && sup.kx > 0) { parts.push('ux'); d++; }
@@ -820,7 +828,7 @@ function generatePerElementAnalysis(
       if (sup.kz && sup.kz > 0) { parts.push('\u03b8z'); d++; }
       if (d > 0) {
         supportByNode.set(sup.nodeId, {
-          nodeId: sup.nodeId, type: 'Resorte', dofs: d, restrainedDofs: parts.join(', '),
+          nodeId: sup.nodeId, type: t('kin.supSpring'), dofs: d, restrainedDofs: parts.join(', '),
         });
         supportedNodes.add(sup.nodeId);
       }
@@ -865,7 +873,7 @@ function generatePerElementAnalysis(
       if (nodeJMech) mechNodeIds.push(elem.nodeJ);
       const dofDetails = mechNodeIds.map(nid => {
         const dofs = unconstrainedByNode.get(nid);
-        return dofs ? `Nodo ${nid}: ${dofs.join(', ')} sin restringir` : `Nodo ${nid}: inestable`;
+        return dofs ? `${t('kin.node')} ${nid}: ${dofs.join(', ')} ${t('kin.unconstrained')}` : `${t('kin.node')} ${nid}: ${t('kin.unstable')}`;
       }).join('. ');
       explanation = `${dofDetails}.`;
     } else if (globalClassification === 'isostatic') {
@@ -979,38 +987,38 @@ function buildConstraintDescription(
     const upDescs = upstream.map(ce => {
       // Find which support this element chain reaches
       const reachedSup = findReachableSupport(ce.elemId, nodeId, thisElemId, nodeElems, supportByNode);
-      const typeLabel = ce.type === 'frame' ? 'rígida' : 'articulada';
-      const hingeNote = ce.hingedAtNode ? ', con articulación' : '';
-      const supNote = reachedSup ? ` \u2192 llega a ${reachedSup.type.toLowerCase()} en Nodo ${reachedSup.nodeId}` : '';
-      return `Barra ${ce.elemId} (${typeLabel}${hingeNote})${supNote}`;
+      const typeLabel = ce.type === 'frame' ? t('kin.connRigid') : t('kin.connHinged');
+      const hingeNote = ce.hingedAtNode ? ', ' + t('kin.withHinge') : '';
+      const supNote = reachedSup ? ` \u2192 ${t('kin.reachesSupport').replace('{type}', reachedSup.type.toLowerCase()).replace('{node}', String(reachedSup.nodeId))}` : '';
+      return `${t('kin.member')} ${ce.elemId} (${typeLabel}${hingeNote})${supNote}`;
     });
     if (support) {
-      parts.push(`+ vinculación de ${upDescs.join('; ')}`);
+      parts.push(`+ ${t('kin.constraintFrom')} ${upDescs.join('; ')}`);
     } else {
-      parts.push(`Vinculación virtual de ${upDescs.join('; ')}`);
+      parts.push(`${t('kin.virtualConstraint')} ${upDescs.join('; ')}`);
     }
   }
 
   // Describe downstream elements (they depend on this bar, not the other way around)
   if (downstream.length > 0) {
-    const downIds = downstream.map(ce => `Barra ${ce.elemId}`).join(', ');
+    const downIds = downstream.map(ce => `${t('kin.member')} ${ce.elemId}`).join(', ');
     if (support || upstream.length > 0) {
-      parts.push(`(${downIds} depende${downstream.length > 1 ? 'n' : ''} de esta cadena)`);
+      parts.push(`(${downIds} ${t('kin.dependsOnChain').replace('{s}', downstream.length > 1 ? t('kin.plural_n') : '')})`);
     }
     // If there's nothing else, these downstream elements don't help
   }
 
   // No support and no upstream connections
   if (!support && upstream.length === 0 && downstream.length === 0) {
-    parts.push('Extremo libre');
+    parts.push(t('kin.freeEnd'));
   } else if (!support && upstream.length === 0 && downstream.length > 0) {
-    const downIds = downstream.map(ce => `Barra ${ce.elemId}`).join(', ');
-    parts.push(`Sin apoyo propio. ${downIds} conectada${downstream.length > 1 ? 's' : ''} pero sin apoyo independiente`);
+    const downIds = downstream.map(ce => `${t('kin.member')} ${ce.elemId}`).join(', ');
+    parts.push(`${t('kin.noOwnSupport')} ${downIds} ${t('kin.connectedNoSupport').replace('{s}', downstream.length > 1 ? t('kin.plural_s') : '')}`);
   }
 
   // Hinge note
   if (isHingedEnd && elemType === 'frame') {
-    parts.push('\u2014 articulación (libera momento)');
+    parts.push('\u2014 ' + t('kin.hingeReleasesMoment'));
   }
 
   return parts.join(' ');
@@ -1081,16 +1089,16 @@ function buildElementExplanation(
   // Build per-node summary
   const descNode = (info: NodeConstraintInfo, c: number): string => {
     if (info.support && info.connectedElems.some(ce => ce.reachesSupport)) {
-      return `${info.support.type.toLowerCase()} + vinculación de barras conectadas`;
+      return `${info.support.type.toLowerCase()} + ${t('kin.constraintFromMembers')}`;
     }
     if (info.support) {
-      return `${info.support.type.toLowerCase()} (${info.support.dofs} reac.)`;
+      return `${info.support.type.toLowerCase()} (${info.support.dofs} ${t('kin.reactions')})`;
     }
     const upstreams = info.connectedElems.filter(ce => ce.reachesSupport);
     if (upstreams.length > 0) {
-      return `vinculación virtual (${c} restr. efectivas)`;
+      return `${t('kin.virtualConstraintShort')} (${c} ${t('kin.effectiveRestr')})`;
     }
-    return 'sin restricciones directas';
+    return t('kin.noDirectConstraints');
   };
 
   const nI = descNode(nodeIInfo, cI);
@@ -1098,11 +1106,11 @@ function buildElementExplanation(
 
   if (status === 'hyperstatic') {
     const excess = total - needed;
-    return `Nodo ${nodeIInfo.nodeId}: ${nI}. Nodo ${nodeJInfo.nodeId}: ${nJ}. Total: ${total} restricciones efectivas para ${needed} GDL \u2014 ${excess} de más.`;
+    return `${t('kin.node')} ${nodeIInfo.nodeId}: ${nI}. ${t('kin.node')} ${nodeJInfo.nodeId}: ${nJ}. ${t('kin.totalEffective').replace('{total}', String(total)).replace('{needed}', String(needed)).replace('{excess}', String(excess))}`;
   }
 
   // isostatic
-  return `Nodo ${nodeIInfo.nodeId}: ${nI}. Nodo ${nodeJInfo.nodeId}: ${nJ}. Vinculación justa para ${needed} GDL \u2014 no sobra ni falta.`;
+  return `${t('kin.node')} ${nodeIInfo.nodeId}: ${nI}. ${t('kin.node')} ${nodeJInfo.nodeId}: ${nJ}. ${t('kin.justRight').replace('{needed}', String(needed))}`;
 }
 
 // ─── Helpers ────────────────────────────────────────────────────
@@ -1160,7 +1168,7 @@ function explainUnconstrainedDof(nodeId: number, dof: string, input: SolverInput
   const supportedNodes = new Set(Array.from(input.supports.values()).map(s => s.nodeId));
 
   if (connectedElems.length === 0) {
-    return `El nodo ${nodeId} no está conectado a ningún elemento.`;
+    return t('kin.nodeNotConnected').replace('{node}', String(nodeId));
   }
 
   // Check if all elements at node are hinged
@@ -1171,20 +1179,20 @@ function explainUnconstrainedDof(nodeId: number, dof: string, input: SolverInput
   // Rotation DOF unconstrained
   if (dof === 'rz') {
     if (allHinged && !support) {
-      return `Todas las barras en el nodo ${nodeId} tienen articulación — no hay transferencia de momento. ` +
-        `Elementos: ${frameElems.map(e => `Elem. ${e.id}`).join(', ')}.`;
+      return t('kin.allHingedNoMoment').replace('{node}', String(nodeId)).replace('{elems}', frameElems.map(e => `Elem. ${e.id}`).join(', '));
     }
     if (allHinged && support && support.type !== 'fixed') {
-      return `Todas las barras en el nodo ${nodeId} están articuladas y el apoyo (${SUPPORT_LABELS[support.type as string]?.label ?? support.type}) no restringe rotación.`;
+      const supLabel = getSupportLabels()[support.type as string]?.label ?? support.type;
+      return t('kin.allHingedSupportNoRot').replace('{node}', String(nodeId)).replace('{support}', supLabel);
     }
-    return `El nodo ${nodeId} no tiene suficiente restricción rotacional.`;
+    return t('kin.insufficientRotConstraint').replace('{node}', String(nodeId));
   }
 
   // Translation DOF (ux or uy) unconstrained
-  const direction = dof === 'ux' ? 'horizontal' : 'vertical';
+  const direction = dof === 'ux' ? t('kin.dirHorizontal') : t('kin.dirVertical');
 
   if (!support && connectedElems.length === 1) {
-    return `El nodo ${nodeId} es un extremo libre — solo conectado al Elem. ${connectedElems[0].id}, sin apoyo.`;
+    return t('kin.nodeFreeEnd').replace('{node}', String(nodeId)).replace('{elem}', String(connectedElems[0].id));
   }
 
   // Check for bi-articulated elements (only transmit axial)
@@ -1207,10 +1215,10 @@ function explainUnconstrainedDof(nodeId: number, dof: string, input: SolverInput
     });
 
     if (dof === 'ux' && biArtVertical.length === biArticulated.length && biArticulated.length === connectedElems.length) {
-      return `Los elementos conectados al nodo ${nodeId} (${biArtIds}) son bi-articulados y verticales — solo transmiten fuerza axial vertical, sin rigidez ${direction}.`;
+      return t('kin.biArtVertical').replace('{node}', String(nodeId)).replace('{elems}', biArtIds).replace('{dir}', direction);
     }
     if (dof === 'uy' && biArtHorizontal.length === biArticulated.length && biArticulated.length === connectedElems.length) {
-      return `Los elementos conectados al nodo ${nodeId} (${biArtIds}) son bi-articulados y horizontales — solo transmiten fuerza axial horizontal, sin rigidez ${direction}.`;
+      return t('kin.biArtHorizontal').replace('{node}', String(nodeId)).replace('{elems}', biArtIds).replace('{dir}', direction);
     }
   }
 
@@ -1231,7 +1239,7 @@ function explainUnconstrainedDof(nodeId: number, dof: string, input: SolverInput
       }
     }
     if (allCollinear) {
-      return `Los elementos en el nodo ${nodeId} son colineales y todos están articulados — pueden deslizar perpendicularmente sin resistencia.`;
+      return t('kin.collinearHinged').replace('{node}', String(nodeId));
     }
   }
 
@@ -1245,15 +1253,15 @@ function explainUnconstrainedDof(nodeId: number, dof: string, input: SolverInput
     });
 
     if (!hasPathToSupport && allHinged) {
-      return `El nodo ${nodeId} no tiene apoyo y todas sus barras están articuladas — no recibe rigidez ${direction} de ningún elemento.`;
+      return t('kin.noSupportAllHinged').replace('{node}', String(nodeId)).replace('{dir}', direction);
     }
     if (!hasPathToSupport) {
-      return `El nodo ${nodeId} no tiene restricción ${direction} suficiente. Revisar apoyos y articulaciones de los elementos conectados.`;
+      return t('kin.insufficientDirConstraint').replace('{node}', String(nodeId)).replace('{dir}', direction);
     }
   }
 
   // Generic fallback
-  return `El nodo ${nodeId} tiene el GDL "${DOF_NAMES[dof] ?? dof}" sin restringir. La combinación de apoyos y articulaciones no alcanza para estabilizarlo en esa dirección.`;
+  return t('kin.genericUnconstrained').replace('{node}', String(nodeId)).replace('{dof}', getDofNames()[dof] ?? dof);
 }
 
 /**
@@ -1276,11 +1284,11 @@ function generateSuggestions(
       if (!seen.has(key)) {
         seen.add(key);
         if (ud.dof === 'rz') {
-          suggestions.push(`Agregar un empotramiento en el nodo ${ud.nodeId} para restringir la rotación.`);
+          suggestions.push(t('kin.sugAddFixed').replace('{node}', String(ud.nodeId)));
         } else if (ud.dof === 'ux') {
-          suggestions.push(`Agregar un apoyo que restrinja el desplazamiento horizontal en el nodo ${ud.nodeId} (articulación fija, empotramiento o roller vertical).`);
+          suggestions.push(t('kin.sugAddHorizSupport').replace('{node}', String(ud.nodeId)));
         } else {
-          suggestions.push(`Agregar un apoyo que restrinja el desplazamiento vertical en el nodo ${ud.nodeId} (articulación fija, empotramiento o roller horizontal).`);
+          suggestions.push(t('kin.sugAddVertSupport').replace('{node}', String(ud.nodeId)));
         }
       }
     }
@@ -1292,7 +1300,7 @@ function generateSuggestions(
         const key = `upgrade-${ud.nodeId}`;
         if (!seen.has(key)) {
           seen.add(key);
-          suggestions.push(`Cambiar el apoyo en nodo ${ud.nodeId} de ${SUPPORT_LABELS[sup.type as string]?.label ?? sup.type} a empotramiento para restringir rotación.`);
+          suggestions.push(t('kin.sugUpgradeSupport').replace('{node}', String(ud.nodeId)).replace('{type}', getSupportLabels()[sup.type as string]?.label ?? sup.type));
         }
       }
     }
@@ -1307,7 +1315,7 @@ function generateSuggestions(
       const key = `remove-hinge-${ud.nodeId}`;
       if (!seen.has(key)) {
         seen.add(key);
-        suggestions.push(`Quitar la articulación del Elem. ${hingesHere[0].elemId} (extremo ${hingesHere[0].end}) en el nodo ${ud.nodeId} para permitir transferencia de momento.`);
+        suggestions.push(t('kin.sugRemoveHinge').replace('{elem}', String(hingesHere[0].elemId)).replace('{end}', hingesHere[0].end).replace('{node}', String(ud.nodeId)));
       }
     }
   }
@@ -1325,14 +1333,14 @@ function generateSuggestions(
       const key = 'global-horizontal';
       if (!seen.has(key)) {
         seen.add(key);
-        suggestions.push('La estructura carece de restricción horizontal global. Verificar que al menos un apoyo restrinja desplazamiento horizontal (articulación fija, empotramiento, o roller vertical).');
+        suggestions.push(t('kin.sugGlobalHorizontal'));
       }
     }
   }
 
   // If no specific suggestions yet, add a generic one
   if (suggestions.length === 0) {
-    suggestions.push('Revisar la combinación de apoyos y articulaciones. La estructura necesita más restricciones para ser estable.');
+    suggestions.push(t('kin.sugGeneric'));
   }
 
   return suggestions;

--- a/web/src/lib/engine/live-calc.ts
+++ b/web/src/lib/engine/live-calc.ts
@@ -11,6 +11,7 @@
  */
 
 import { modelStore, resultsStore, uiStore } from '../store';
+import { t } from '../i18n';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
@@ -32,24 +33,24 @@ const VALID_3D_DIAGRAMS = ['deformed', 'momentY', 'momentZ', 'shearY', 'shearZ',
  * Called from the $effect in App.svelte when liveCalc is enabled.
  * Sets results/errors directly on the stores.
  *
- * @param analysisMode  Current analysis mode ('2d' | '3d')
+ * @param analysisMode  Current analysis mode ('2d' | '3d' | 'edu')
  * @param axisConvention3D  Current 3D axis convention string
- * @param prevDiagram  Diagram type before results were cleared (to restore user selection)
  */
-export function runLiveCalc(analysisMode: string, axisConvention3D: string, prevDiagram: string): void {
+export function runLiveCalc(analysisMode: string, axisConvention3D: string): void {
   try {
-    if (analysisMode === '3d') {
-      liveCalc3D(axisConvention3D, prevDiagram);
+    if (analysisMode === '3d' || analysisMode === 'pro') {
+      liveCalc3D(axisConvention3D);
     } else {
-      liveCalc2D(prevDiagram);
+      liveCalc2D();
     }
   } catch (err: any) {
-    uiStore.liveCalcError = err.message ?? 'Error desconocido';
+    uiStore.liveCalcError = err.message ?? t('error.unknown');
   }
 }
 
-function liveCalc3D(axisConvention: string, prevDiagram: string): void {
-  const r = modelStore.solve3D(uiStore.includeSelfWeight, axisConvention === 'leftHand');
+function liveCalc3D(axisConvention: string): void {
+  const isPro = uiStore.analysisMode === 'pro';
+  const r = modelStore.solve3D(uiStore.includeSelfWeight, axisConvention === 'leftHand', isPro);
   if (typeof r === 'string') {
     uiStore.liveCalcError = r;
     return;
@@ -57,17 +58,14 @@ function liveCalc3D(axisConvention: string, prevDiagram: string): void {
   if (!r) return;
 
   if (hasNaN3D(r.displacements as any)) {
-    uiStore.liveCalcError = 'Error numérico 3D: estructura inestable (mecanismo)';
+    uiStore.liveCalcError = t('results.numericError3d');
     return;
   }
 
-  resultsStore.setResults3D(r);
-  if ((VALID_3D_DIAGRAMS as readonly string[]).includes(prevDiagram)) {
-    resultsStore.diagramType = prevDiagram as any;
-  }
+  resultsStore.setResults3D(r, true);
 }
 
-function liveCalc2D(prevDiagram: string): void {
+function liveCalc2D(): void {
   const r = modelStore.solve(uiStore.includeSelfWeight);
   if (typeof r === 'string') {
     uiStore.liveCalcError = r;
@@ -76,11 +74,11 @@ function liveCalc2D(prevDiagram: string): void {
   if (!r) return;
 
   if (hasNaN2D(r.displacements as any)) {
-    uiStore.liveCalcError = 'Error numérico: estructura inestable (mecanismo)';
+    uiStore.liveCalcError = t('results.numericError');
     return;
   }
 
-  resultsStore.setResults(r);
+  resultsStore.setResults(r, true);
 
   // Auto-solve combinations if defined
   if (modelStore.model.combinations.length > 0) {
@@ -88,11 +86,6 @@ function liveCalc2D(prevDiagram: string): void {
     if (combo && typeof combo !== 'string') {
       resultsStore.setCombinationResults(combo.perCase, combo.perCombo, combo.envelope);
     }
-  }
-
-  // Restore diagram type if it was a valid results view
-  if ((VALID_2D_DIAGRAMS as readonly string[]).includes(prevDiagram)) {
-    resultsStore.diagramType = prevDiagram as any;
   }
 }
 
@@ -102,34 +95,93 @@ function liveCalc2D(prevDiagram: string): void {
  * Solve the structure manually (triggered by Enter key / Calcular button).
  * Handles 2D and 3D, combinations, toasts and mobile panel.
  */
-export function runGlobalSolve(): void {
-  if (uiStore.analysisMode === '3d') {
-    globalSolve3D();
+export async function runGlobalSolve(): Promise<void> {
+  if (uiStore.analysisMode === '3d' || uiStore.analysisMode === 'pro') {
+    await globalSolve3D();
+  } else if (uiStore.analysisMode === 'edu') {
+    // Edu mode handles its own solve via edu-solver.ts (registered listener).
+    // This branch is a no-op safety fallback — the edu module's listener
+    // fires first on the same 'dedaliano-solve' event.
+    return;
   } else {
     globalSolve2D();
+  }
+}
+
+/** Show solver diagnostic warnings/errors as toasts (max 2 to avoid spam) */
+function showSolverWarningToasts(diags?: import('./types').SolverDiagnostic[]): void {
+  if (!diags) return;
+  const important = diags.filter(d => d.severity === 'error' || d.severity === 'warning');
+  for (const d of important.slice(0, 2)) {
+    const msg = t(d.message) !== d.message ? t(d.message) : d.message;
+    uiStore.toast(msg, d.severity === 'error' ? 'error' : 'info');
   }
 }
 
 /** Detect if an error message is mechanism/hipostatic-related */
 function isMechanismError(msg: string): boolean {
   const lc = msg.toLowerCase();
-  return lc.includes('mecanismo') || lc.includes('hipostática') || lc.includes('singular') || lc.includes('inestable');
+  return lc.includes('mecanismo') || lc.includes('hipostática') || lc.includes('singular') || lc.includes('inestable')
+    || lc.includes('mechanism') || lc.includes('hypostatic') || lc.includes('unstable');
 }
 
-function globalSolve3D(): void {
-  const r = modelStore.solve3D(uiStore.includeSelfWeight, uiStore.axisConvention3D === 'leftHand');
+async function globalSolve3D(): Promise<void> {
+  const isPro = uiStore.analysisMode === 'pro';
+  const leftHand = uiStore.axisConvention3D === 'leftHand';
+  const hasCombos = modelStore.model.combinations.length > 0;
+  const t0 = performance.now();
+
+  // When combinations exist, use parallel Web Workers for maximum performance
+  if (hasCombos) {
+    try {
+      const comboResult = await modelStore.solveCombinations3DParallel(uiStore.includeSelfWeight, leftHand, isPro);
+      if (typeof comboResult === 'string') {
+        uiStore.toast(comboResult, 'error');
+        return;
+      }
+      if (!comboResult) {
+        uiStore.toast(t('results.emptyModelError'), 'error');
+        return;
+      }
+
+      // Use first per-case result as the "single" baseline view
+      const firstCaseResult = comboResult.perCase.values().next().value;
+      if (firstCaseResult) resultsStore.setResults3D(firstCaseResult);
+
+      resultsStore.setCombinationResults3D(comboResult.perCase, comboResult.perCombo, comboResult.envelope);
+
+      if (uiStore.isMobile) uiStore.mobileResultsPanelOpen = true;
+      const elapsed = performance.now() - t0;
+      const timeStr = elapsed >= 1000 ? (elapsed / 1000).toFixed(2) + ' s' : elapsed.toFixed(0) + ' ms';
+      const nBars = firstCaseResult?.elementForces.length ?? 0;
+      const nReac = firstCaseResult?.reactions.length ?? 0;
+      uiStore.toast(
+        `${t('results.analysis3dSuccess')} (${timeStr}) — ${nBars} ${t('results.bars')}, ${nReac} ${t('results.reactions')} + ${comboResult.perCombo.size} ${t('results.combinations')}`,
+        'success',
+      );
+      if (firstCaseResult) showSolverWarningToasts(firstCaseResult.solverDiagnostics);
+    } catch (e: any) {
+      console.error('[globalSolve3D] Combination solving failed:', e.message);
+      uiStore.toast(e.message, 'error');
+    }
+    return;
+  }
+
+  // No combinations — single solve only
+  const r = modelStore.solve3D(uiStore.includeSelfWeight, leftHand, isPro);
   if (typeof r === 'string') {
-    // No kinematic action in 3D — panel is 2D only
     uiStore.toast(r, 'error');
   } else if (r) {
     resultsStore.setResults3D(r);
     if (uiStore.isMobile) uiStore.mobileResultsPanelOpen = true;
+    const timeStr = r.timings ? ` (${r.timings.totalMs >= 1000 ? (r.timings.totalMs / 1000).toFixed(2) + ' s' : r.timings.totalMs.toFixed(1) + ' ms'})` : '';
     uiStore.toast(
-      `Análisis 3D exitoso — ${r.elementForces.length} barras, ${r.reactions.length} reacciones`,
+      `${t('results.analysis3dSuccess')}${timeStr} — ${r.elementForces.length} ${t('results.bars')}, ${r.reactions.length} ${t('results.reactions')}`,
       'success',
     );
+    showSolverWarningToasts(r.solverDiagnostics);
   } else {
-    uiStore.toast('Modelo vacío o error inesperado', 'error');
+    uiStore.toast(t('results.emptyModelError'), 'error');
   }
 }
 
@@ -140,12 +192,12 @@ function globalSolve2D(): void {
     return;
   }
   if (!r) {
-    uiStore.toast('Modelo vacío o error inesperado', 'error');
+    uiStore.toast(t('results.emptyModelError'), 'error');
     return;
   }
 
   if (hasNaN2D(r.displacements as any)) {
-    uiStore.toast('Error numérico: la estructura puede ser inestable (mecanismo)', 'error', 'kinematic');
+    uiStore.toast(t('results.numericError'), 'error', 'kinematic');
     return;
   }
 
@@ -154,8 +206,8 @@ function globalSolve2D(): void {
   const kin = modelStore.kinematicResult;
   let classText = '';
   if (kin) {
-    if (kin.classification === 'isostatic') classText = ' — Isostática';
-    else if (kin.classification === 'hyperstatic') classText = ` — Hiperestática (grado ${kin.degree})`;
+    if (kin.classification === 'isostatic') classText = ` — ${t('results.isostatic')}`;
+    else if (kin.classification === 'hyperstatic') classText = ` — ${t('results.hyperstatic')} (${t('results.degree')} ${kin.degree})`;
   }
 
   // Auto-solve combinations if defined
@@ -164,13 +216,17 @@ function globalSolve2D(): void {
     const comboResult = modelStore.solveCombinations(uiStore.includeSelfWeight);
     if (comboResult && typeof comboResult !== 'string') {
       resultsStore.setCombinationResults(comboResult.perCase, comboResult.perCombo, comboResult.envelope);
-      comboText = ` + ${comboResult.perCombo.size} combinaciones`;
+      comboText = ` + ${comboResult.perCombo.size} ${t('results.combinations')}`;
     }
   }
 
   if (uiStore.isMobile) uiStore.mobileResultsPanelOpen = true;
+  const timeStr = r.timings ? ` (${r.timings.totalMs >= 1000 ? (r.timings.totalMs / 1000).toFixed(2) + ' s' : r.timings.totalMs.toFixed(1) + ' ms'})` : '';
   uiStore.toast(
-    `Cálculo exitoso${classText} — ${r.elementForces.length} barras, ${r.reactions.length} reacciones${comboText}`,
+    `${t('results.calcSuccess')}${classText}${timeStr} — ${r.elementForces.length} ${t('results.bars')}, ${r.reactions.length} ${t('results.reactions')}${comboText}`,
     'success',
   );
+
+  // Show solver warnings/errors as separate toasts
+  showSolverWarningToasts(r.solverDiagnostics);
 }

--- a/web/src/lib/engine/mass-matrix-3d.ts
+++ b/web/src/lib/engine/mass-matrix-3d.ts
@@ -1,0 +1,357 @@
+// Consistent mass matrix assembly for 3D frame/truss modal analysis
+//
+// DOF order per element (local): [u1,v1,w1,θx1,θy1,θz1, u2,v2,w2,θx2,θy2,θz2]
+// Units: density in kg/m³ (converted internally to t/m³), areas in m², lengths in m
+// Output mass in consistent units: t = kN·s²/m
+
+import {
+  computeLocalAxes3D,
+  frameTransformationMatrix3D,
+  trussTransformationMatrix3D,
+  globalDof3D,
+} from './solver-3d';
+import type { DofNumbering3D } from './solver-3d';
+import type { SolverInput3D } from './types-3d';
+
+// ─── Local element mass matrices ─────────────────────────────────
+
+/**
+ * 12×12 consistent mass matrix for a 3D frame element in local coords.
+ *
+ * rhoA  = ρ * 0.001 * A  (mass per unit length, t/m)
+ * rhoIp = ρ * 0.001 * Ip (mass moment of inertia per unit length, t·m)
+ * L     = element length (m)
+ *
+ * Reference: Przemieniecki, "Theory of Matrix Structural Analysis" §5.7
+ */
+function frameConsistentMass3D(
+  rhoA: number, rhoIp: number, L: number,
+  hingeStart: boolean, hingeEnd: boolean,
+): Float64Array {
+  const n = 12;
+  const m = new Float64Array(n * n);
+  const L2 = L * L;
+
+  // ── Axial (u1=0, u2=6) — always the same ──
+  m[0 * n + 0] = rhoA * L / 3;
+  m[0 * n + 6] = rhoA * L / 6;
+  m[6 * n + 0] = rhoA * L / 6;
+  m[6 * n + 6] = rhoA * L / 3;
+
+  // ── Torsion (θx1=3, θx2=9) — always the same ──
+  m[3 * n + 3] = rhoIp * L / 3;
+  m[3 * n + 9] = rhoIp * L / 6;
+  m[9 * n + 3] = rhoIp * L / 6;
+  m[9 * n + 9] = rhoIp * L / 3;
+
+  if (!hingeStart && !hingeEnd) {
+    // ── Bending about Z-axis (v1=1, θz1=5, v2=7, θz2=11) ──
+    const c = rhoA * L / 420;
+    m[1 * n + 1]   = 156 * c;
+    m[1 * n + 5]   =  22 * L * c;
+    m[1 * n + 7]   =  54 * c;
+    m[1 * n + 11]  = -13 * L * c;
+
+    m[5 * n + 1]   =  22 * L * c;
+    m[5 * n + 5]   =   4 * L2 * c;
+    m[5 * n + 7]   =  13 * L * c;
+    m[5 * n + 11]  =  -3 * L2 * c;
+
+    m[7 * n + 1]   =  54 * c;
+    m[7 * n + 5]   =  13 * L * c;
+    m[7 * n + 7]   = 156 * c;
+    m[7 * n + 11]  = -22 * L * c;
+
+    m[11 * n + 1]  = -13 * L * c;
+    m[11 * n + 5]  =  -3 * L2 * c;
+    m[11 * n + 7]  = -22 * L * c;
+    m[11 * n + 11] =   4 * L2 * c;
+
+    // ── Bending about Y-axis (w1=2, θy1=4, w2=8, θy2=10) ──
+    // Note sign differences: θy = -dw/dx convention
+    m[2 * n + 2]   = 156 * c;
+    m[2 * n + 4]   = -22 * L * c;
+    m[2 * n + 8]   =  54 * c;
+    m[2 * n + 10]  =  13 * L * c;
+
+    m[4 * n + 2]   = -22 * L * c;
+    m[4 * n + 4]   =   4 * L2 * c;
+    m[4 * n + 8]   = -13 * L * c;
+    m[4 * n + 10]  =  -3 * L2 * c;
+
+    m[8 * n + 2]   =  54 * c;
+    m[8 * n + 4]   = -13 * L * c;
+    m[8 * n + 8]   = 156 * c;
+    m[8 * n + 10]  =  22 * L * c;
+
+    m[10 * n + 2]  =  13 * L * c;
+    m[10 * n + 4]  =  -3 * L2 * c;
+    m[10 * n + 8]  =  22 * L * c;
+    m[10 * n + 10] =   4 * L2 * c;
+  } else if (hingeStart && hingeEnd) {
+    // Both hinges: linear shape functions (no rotational coupling)
+    // v and w get the same treatment as truss transverse DOFs
+    const c = rhoA * L / 6;
+
+    // Bending Z-plane: v1=1, v2=7 (θz1, θz2 = 0)
+    m[1 * n + 1] = 2 * c;
+    m[1 * n + 7] = 1 * c;
+    m[7 * n + 1] = 1 * c;
+    m[7 * n + 7] = 2 * c;
+
+    // Bending Y-plane: w1=2, w2=8 (θy1, θy2 = 0)
+    m[2 * n + 2] = 2 * c;
+    m[2 * n + 8] = 1 * c;
+    m[8 * n + 2] = 1 * c;
+    m[8 * n + 8] = 2 * c;
+  } else {
+    // One hinge: static condensation of the full consistent mass matrix
+    // Same approach as 2D mass-matrix.ts
+    condenseBendingZ(m, n, rhoA, L, L2, hingeStart, hingeEnd);
+    condenseBendingY(m, n, rhoA, L, L2, hingeStart, hingeEnd);
+  }
+
+  return m;
+}
+
+/**
+ * Static condensation of bending-Z block (v1=1, θz1=5, v2=7, θz2=11).
+ * Condense out the rotation DOF at the hinge end.
+ */
+function condenseBendingZ(
+  m: Float64Array, n: number,
+  rhoA: number, L: number, L2: number,
+  hingeStart: boolean, _hingeEnd: boolean,
+): void {
+  const c = rhoA * L / 420;
+  // Full 4×4 bending-Z sub-matrix (local indices: v1, θz1, v2, θz2)
+  const full = [
+    [156 * c,  22 * L * c,  54 * c, -13 * L * c],
+    [ 22 * L * c,  4 * L2 * c,  13 * L * c,  -3 * L2 * c],
+    [ 54 * c,  13 * L * c, 156 * c, -22 * L * c],
+    [-13 * L * c,  -3 * L2 * c, -22 * L * c,   4 * L2 * c],
+  ];
+
+  // Global DOF indices for this block
+  const globalIdx = [1, 5, 7, 11];
+
+  if (hingeStart) {
+    // Condense out θz1 (local index 1 in full block)
+    const condenseOut = 1;
+    const keep = [0, 2, 3]; // v1, v2, θz2
+    const Mbb_inv = 1 / full[condenseOut][condenseOut];
+    for (let i = 0; i < keep.length; i++) {
+      for (let j = 0; j < keep.length; j++) {
+        const ci = keep[i], cj = keep[j];
+        const val = full[ci][cj] - full[ci][condenseOut] * Mbb_inv * full[condenseOut][cj];
+        m[globalIdx[ci] * n + globalIdx[cj]] = val;
+      }
+    }
+  } else {
+    // Condense out θz2 (local index 3 in full block)
+    const condenseOut = 3;
+    const keep = [0, 1, 2]; // v1, θz1, v2
+    const Mbb_inv = 1 / full[condenseOut][condenseOut];
+    for (let i = 0; i < keep.length; i++) {
+      for (let j = 0; j < keep.length; j++) {
+        const ci = keep[i], cj = keep[j];
+        const val = full[ci][cj] - full[ci][condenseOut] * Mbb_inv * full[condenseOut][cj];
+        m[globalIdx[ci] * n + globalIdx[cj]] = val;
+      }
+    }
+  }
+}
+
+/**
+ * Static condensation of bending-Y block (w1=2, θy1=4, w2=8, θy2=10).
+ * Sign differences due to θy = -dw/dx convention.
+ */
+function condenseBendingY(
+  m: Float64Array, n: number,
+  rhoA: number, L: number, L2: number,
+  hingeStart: boolean, _hingeEnd: boolean,
+): void {
+  const c = rhoA * L / 420;
+  // Full 4×4 bending-Y sub-matrix (local indices: w1, θy1, w2, θy2)
+  const full = [
+    [ 156 * c, -22 * L * c,  54 * c,  13 * L * c],
+    [-22 * L * c,   4 * L2 * c, -13 * L * c,  -3 * L2 * c],
+    [  54 * c, -13 * L * c, 156 * c,  22 * L * c],
+    [  13 * L * c,  -3 * L2 * c,  22 * L * c,   4 * L2 * c],
+  ];
+
+  // Global DOF indices for this block
+  const globalIdx = [2, 4, 8, 10];
+
+  if (hingeStart) {
+    // Condense out θy1 (local index 1 in full block)
+    const condenseOut = 1;
+    const keep = [0, 2, 3]; // w1, w2, θy2
+    const Mbb_inv = 1 / full[condenseOut][condenseOut];
+    for (let i = 0; i < keep.length; i++) {
+      for (let j = 0; j < keep.length; j++) {
+        const ci = keep[i], cj = keep[j];
+        const val = full[ci][cj] - full[ci][condenseOut] * Mbb_inv * full[condenseOut][cj];
+        m[globalIdx[ci] * n + globalIdx[cj]] = val;
+      }
+    }
+  } else {
+    // Condense out θy2 (local index 3 in full block)
+    const condenseOut = 3;
+    const keep = [0, 1, 2]; // w1, θy1, w2
+    const Mbb_inv = 1 / full[condenseOut][condenseOut];
+    for (let i = 0; i < keep.length; i++) {
+      for (let j = 0; j < keep.length; j++) {
+        const ci = keep[i], cj = keep[j];
+        const val = full[ci][cj] - full[ci][condenseOut] * Mbb_inv * full[condenseOut][cj];
+        m[globalIdx[ci] * n + globalIdx[cj]] = val;
+      }
+    }
+  }
+}
+
+/**
+ * 6×6 consistent mass matrix for a 3D truss element in local coords.
+ * DOFs: [u1, v1, w1, u2, v2, w2]
+ */
+function trussConsistentMass3D(rhoA: number, L: number): Float64Array {
+  const n = 6;
+  const m = new Float64Array(n * n);
+  const c = rhoA * L / 6;
+
+  // Diagonal: 2c
+  for (let i = 0; i < 6; i++) m[i * n + i] = 2 * c;
+
+  // Coupling between nodes: c for matching translational DOFs
+  m[0 * n + 3] = c;  m[3 * n + 0] = c;  // axial u1-u2
+  m[1 * n + 4] = c;  m[4 * n + 1] = c;  // transverse v1-v2
+  m[2 * n + 5] = c;  m[5 * n + 2] = c;  // transverse w1-w2
+
+  return m;
+}
+
+// ─── Transform and assemble ──────────────────────────────────────
+
+/** M_global = Tᵀ · M_local · T */
+function transformMassToGlobal(mLocal: Float64Array, T: Float64Array, ndof: number): Float64Array {
+  // temp = M_local · T
+  const temp = new Float64Array(ndof * ndof);
+  for (let i = 0; i < ndof; i++) {
+    for (let k = 0; k < ndof; k++) {
+      const mik = mLocal[i * ndof + k];
+      if (mik === 0) continue;
+      for (let j = 0; j < ndof; j++) {
+        temp[i * ndof + j] += mik * T[k * ndof + j];
+      }
+    }
+  }
+
+  // M_global = Tᵀ · temp
+  const mGlobal = new Float64Array(ndof * ndof);
+  for (let i = 0; i < ndof; i++) {
+    for (let k = 0; k < ndof; k++) {
+      const tki = T[k * ndof + i]; // Tᵀ[i][k] = T[k][i]
+      if (tki === 0) continue;
+      for (let j = 0; j < ndof; j++) {
+        mGlobal[i * ndof + j] += tki * temp[k * ndof + j];
+      }
+    }
+  }
+
+  return mGlobal;
+}
+
+// ─── Public API ──────────────────────────────────────────────────
+
+/**
+ * Assemble the global consistent mass matrix M (nFree × nFree) for 3D structures.
+ *
+ * @param input     Structure definition (nodes, elements, materials, sections, supports)
+ * @param dofNum    DOF numbering (from buildDofNumbering3D)
+ * @param densities Map of materialId → density in kg/m³
+ * @returns         Flat Float64Array of size nFree × nFree (row-major)
+ */
+export function buildMassMatrix3D(
+  input: SolverInput3D,
+  dofNum: DofNumbering3D,
+  densities: Map<number, number>,
+): Float64Array {
+  const nf = dofNum.nFree;
+  const M = new Float64Array(nf * nf);
+
+  for (const elem of input.elements.values()) {
+    const nodeI = input.nodes.get(elem.nodeI)!;
+    const nodeJ = input.nodes.get(elem.nodeJ)!;
+    const sec = input.sections.get(elem.sectionId)!;
+
+    const density = densities.get(elem.materialId) ?? 0;
+    if (density <= 0) continue;
+
+    const localY = (elem.localYx !== undefined && elem.localYy !== undefined && elem.localYz !== undefined)
+      ? { x: elem.localYx, y: elem.localYy, z: elem.localYz }
+      : undefined;
+    const axes = computeLocalAxes3D(nodeI, nodeJ, localY, elem.rollAngle);
+    const L = axes.L;
+    if (L < 1e-10) continue;
+
+    // Convert density: kg/m³ → t/m³ (= kN·s²/m⁴)
+    const rhoA = density * 0.001 * sec.a; // t/m = kN·s²/m²
+
+    if (elem.type === 'frame') {
+      // Polar moment of inertia approximation: Ip = Iy + Iz
+      const Ip = sec.iy + sec.iz;
+      const rhoIp = density * 0.001 * Ip;
+
+      const mLocal = frameConsistentMass3D(rhoA, rhoIp, L, elem.hingeStart, elem.hingeEnd);
+      const T = frameTransformationMatrix3D(axes.ex, axes.ey, axes.ez);
+      const mGlobal = transformMassToGlobal(mLocal, T, 12);
+
+      // Scatter into global M (free DOFs only)
+      const dofs: number[] = [];
+      for (let d = 0; d < dofNum.dofsPerNode; d++) {
+        const idx = globalDof3D(dofNum, elem.nodeI, d);
+        if (idx !== undefined) dofs.push(idx);
+      }
+      for (let d = 0; d < dofNum.dofsPerNode; d++) {
+        const idx = globalDof3D(dofNum, elem.nodeJ, d);
+        if (idx !== undefined) dofs.push(idx);
+      }
+
+      const ndof = dofs.length;
+      for (let i = 0; i < ndof; i++) {
+        const gi = dofs[i];
+        if (gi >= nf) continue;
+        for (let j = 0; j < ndof; j++) {
+          const gj = dofs[j];
+          if (gj >= nf) continue;
+          M[gi * nf + gj] += mGlobal[i * 12 + j];
+        }
+      }
+    } else {
+      // Truss: 6×6 (translations only)
+      const mLocal = trussConsistentMass3D(rhoA, L);
+      const T = trussTransformationMatrix3D(axes.ex, axes.ey, axes.ez);
+      const mGlobal = transformMassToGlobal(mLocal, T, 6);
+
+      const diI0 = globalDof3D(dofNum, elem.nodeI, 0)!;
+      const diI1 = globalDof3D(dofNum, elem.nodeI, 1)!;
+      const diI2 = globalDof3D(dofNum, elem.nodeI, 2)!;
+      const diJ0 = globalDof3D(dofNum, elem.nodeJ, 0)!;
+      const diJ1 = globalDof3D(dofNum, elem.nodeJ, 1)!;
+      const diJ2 = globalDof3D(dofNum, elem.nodeJ, 2)!;
+      const dofs = [diI0, diI1, diI2, diJ0, diJ1, diJ2];
+
+      for (let i = 0; i < 6; i++) {
+        const gi = dofs[i];
+        if (gi >= nf) continue;
+        for (let j = 0; j < 6; j++) {
+          const gj = dofs[j];
+          if (gj >= nf) continue;
+          M[gi * nf + gj] += mGlobal[i * 6 + j];
+        }
+      }
+    }
+  }
+
+  return M;
+}

--- a/web/src/lib/engine/modal-3d.ts
+++ b/web/src/lib/engine/modal-3d.ts
@@ -1,0 +1,272 @@
+// Modal analysis for 3D structures — natural frequencies and mode shapes
+//
+// Solves the generalized eigenvalue problem: K·φ = ω²·M·φ
+// Computes participation factors, effective modal masses, and cumulative
+// mass ratios in X, Y, Z directions.
+
+import { assemble3D, buildDofNumbering3D, globalDof3D } from './solver-3d';
+import type { DofNumbering3D } from './solver-3d';
+import type { SolverInput3D } from './types-3d';
+import type { SolverDiagnostic } from './types';
+import { solveGeneralizedEigen, matVec } from './matrix-utils';
+import { buildMassMatrix3D } from './mass-matrix-3d';
+import { t } from '../i18n';
+
+// ─── Types ───────────────────────────────────────────────────────
+
+export interface ModeShape3D {
+  /** Natural frequency (Hz) */
+  frequency: number;
+  /** Period (s) */
+  period: number;
+  /** Angular frequency ω (rad/s) */
+  omega: number;
+  /** Mode shape displacements per node (normalized, max component = 1) */
+  displacements: Array<{
+    nodeId: number;
+    ux: number; uy: number; uz: number;
+    rx: number; ry: number; rz: number;
+  }>;
+  /** Modal participation factor Γ in X direction */
+  participationX: number;
+  /** Modal participation factor Γ in Y direction */
+  participationY: number;
+  /** Modal participation factor Γ in Z direction */
+  participationZ: number;
+  /** Effective modal mass in X direction (t = kN·s²/m) */
+  effectiveMassX: number;
+  /** Effective modal mass in Y direction (t = kN·s²/m) */
+  effectiveMassY: number;
+  /** Effective modal mass in Z direction (t = kN·s²/m) */
+  effectiveMassZ: number;
+  /** Effective mass ratio in X: Meff_x / Mtotal */
+  massRatioX: number;
+  /** Effective mass ratio in Y: Meff_y / Mtotal */
+  massRatioY: number;
+  /** Effective mass ratio in Z: Meff_z / Mtotal */
+  massRatioZ: number;
+}
+
+export interface ModalResult3D {
+  modes: ModeShape3D[];
+  /** Number of free DOFs in the problem */
+  nDof: number;
+  /** Total mass of the structure (t = kN·s²/m) */
+  totalMass: number;
+  /** Cumulative effective mass ratio in X after all computed modes */
+  cumulativeMassRatioX: number;
+  /** Cumulative effective mass ratio in Y after all computed modes */
+  cumulativeMassRatioY: number;
+  /** Cumulative effective mass ratio in Z after all computed modes */
+  cumulativeMassRatioZ: number;
+  diagnostics?: SolverDiagnostic[];
+}
+
+// ─── Solver ──────────────────────────────────────────────────────
+
+/**
+ * Solve for natural frequencies and mode shapes of a 3D structure.
+ *
+ * @param input     Structure definition (nodes, elements, materials, sections, supports, loads)
+ * @param densities Map of materialId → density in kg/m³
+ * @param numModes  Number of modes to return (default: min(12, nFree))
+ * @returns         ModalResult3D on success, or error string on failure
+ */
+export function solveModal3D(
+  input: SolverInput3D,
+  densities: Map<number, number>,
+  numModes?: number,
+): ModalResult3D | string {
+  const dofNum = buildDofNumbering3D(input);
+  const nf = dofNum.nFree;
+
+  if (nf === 0) return t('modal.noFreeDofs');
+  if (nf > 500) return t('modal.modelTooLarge');
+
+  // Validate that at least one material has density assigned
+  const materialsUsed = new Set<number>();
+  for (const elem of input.elements.values()) materialsUsed.add(elem.materialId);
+  const missingDensity: number[] = [];
+  for (const matId of materialsUsed) {
+    const d = densities.get(matId);
+    if (d === undefined || d <= 0) missingDensity.push(matId);
+  }
+  if (missingDensity.length === materialsUsed.size) {
+    return t('modal.noDensity');
+  }
+
+  // ── Assemble stiffness Kff ──
+  const { K } = assemble3D(input, dofNum);
+  const nt = dofNum.nTotal;
+  const Kff = new Float64Array(nf * nf);
+  for (let i = 0; i < nf; i++) {
+    for (let j = 0; j < nf; j++) {
+      Kff[i * nf + j] = K[i * nt + j];
+    }
+  }
+
+  // ── Assemble mass Mff ──
+  const Mff = buildMassMatrix3D(input, dofNum, densities);
+
+  // Check that mass matrix is not zero
+  let massNorm = 0;
+  for (let i = 0; i < nf * nf; i++) massNorm += Mff[i] * Mff[i];
+  if (massNorm < 1e-20) return t('modal.zeroMassMatrix');
+
+  // ── Solve generalized eigenvalue problem: Kff·φ = λ·Mff·φ where λ = ω² ──
+  const eigenResult = solveGeneralizedEigen(Kff, Mff, nf);
+  if (!eigenResult) return t('modal.choleskyError');
+
+  const nModes = Math.min(numModes ?? 12, nf);
+
+  // ── Build influence vectors for participation factors ──
+  // r_x: 1 at every X-translational DOF, 0 elsewhere
+  // r_y: 1 at every Y-translational DOF, 0 elsewhere
+  // r_z: 1 at every Z-translational DOF, 0 elsewhere
+  const rX = new Float64Array(nf);
+  const rY = new Float64Array(nf);
+  const rZ = new Float64Array(nf);
+
+  for (const [nodeId] of input.nodes) {
+    const ixIdx = globalDof3D(dofNum, nodeId, 0); // ux
+    const iyIdx = globalDof3D(dofNum, nodeId, 1); // uy
+    const izIdx = globalDof3D(dofNum, nodeId, 2); // uz
+    if (ixIdx !== undefined && ixIdx < nf) rX[ixIdx] = 1;
+    if (iyIdx !== undefined && iyIdx < nf) rY[iyIdx] = 1;
+    if (izIdx !== undefined && izIdx < nf) rZ[izIdx] = 1;
+  }
+
+  // Pre-compute M·r for each direction
+  const MrX = matVec(Mff, rX, nf);
+  const MrY = matVec(Mff, rY, nf);
+  const MrZ = matVec(Mff, rZ, nf);
+
+  // Total mass: rᵀ·M·r for each translational direction
+  // Use the maximum to handle asymmetric restraints (per Chopra §13.2)
+  let totalMassX = 0;
+  for (let i = 0; i < nf; i++) totalMassX += rX[i] * MrX[i];
+  let totalMassY = 0;
+  for (let i = 0; i < nf; i++) totalMassY += rY[i] * MrY[i];
+  let totalMassZ = 0;
+  for (let i = 0; i < nf; i++) totalMassZ += rZ[i] * MrZ[i];
+  const totalMassMax = Math.max(totalMassX, totalMassY, totalMassZ);
+
+  // ── Extract modes ──
+  const modes: ModeShape3D[] = [];
+  let cumulativeMeffX = 0;
+  let cumulativeMeffY = 0;
+  let cumulativeMeffZ = 0;
+
+  for (let m = 0; m < nModes; m++) {
+    const lambda = eigenResult.values[m];
+    if (lambda <= 0) continue; // Skip zero/negative eigenvalues (rigid body modes)
+
+    const omega = Math.sqrt(lambda);
+    const frequency = omega / (2 * Math.PI);
+    const period = 1 / frequency;
+
+    // Extract raw mode shape vector (before normalization)
+    const phiRaw = new Float64Array(nf);
+    for (let i = 0; i < nf; i++) {
+      phiRaw[i] = eigenResult.vectors[i * nf + m];
+    }
+
+    // Compute participation factors BEFORE visual normalization
+    // Γ_dir = φᵀ·M·r_dir / (φᵀ·M·φ)
+    const Mphi = matVec(Mff, phiRaw, nf);
+    let phiMphi = 0;
+    for (let i = 0; i < nf; i++) phiMphi += phiRaw[i] * Mphi[i];
+
+    let phiMrX = 0;
+    for (let i = 0; i < nf; i++) phiMrX += phiRaw[i] * MrX[i];
+    let phiMrY = 0;
+    for (let i = 0; i < nf; i++) phiMrY += phiRaw[i] * MrY[i];
+    let phiMrZ = 0;
+    for (let i = 0; i < nf; i++) phiMrZ += phiRaw[i] * MrZ[i];
+
+    const gammaX = phiMphi > 1e-20 ? phiMrX / phiMphi : 0;
+    const gammaY = phiMphi > 1e-20 ? phiMrY / phiMphi : 0;
+    const gammaZ = phiMphi > 1e-20 ? phiMrZ / phiMphi : 0;
+
+    // Effective modal mass: Meff = Γ² × (φᵀ·M·φ)
+    const meffX = gammaX * gammaX * phiMphi;
+    const meffY = gammaY * gammaY * phiMphi;
+    const meffZ = gammaZ * gammaZ * phiMphi;
+
+    cumulativeMeffX += meffX;
+    cumulativeMeffY += meffY;
+    cumulativeMeffZ += meffZ;
+
+    // Normalize for display: max absolute component = 1
+    const phi = new Float64Array(phiRaw);
+    let maxAbs = 0;
+    for (let i = 0; i < nf; i++) {
+      if (Math.abs(phi[i]) > maxAbs) maxAbs = Math.abs(phi[i]);
+    }
+    if (maxAbs > 0) {
+      for (let i = 0; i < nf; i++) phi[i] /= maxAbs;
+    }
+
+    // Map to node displacements (6 DOF per node)
+    const displacements: ModeShape3D['displacements'] = [];
+    for (const [nodeId] of input.nodes) {
+      const ux = getPhiComponent3D(dofNum, phi, nodeId, 0, nf);
+      const uy = getPhiComponent3D(dofNum, phi, nodeId, 1, nf);
+      const uz = getPhiComponent3D(dofNum, phi, nodeId, 2, nf);
+      const rx = dofNum.dofsPerNode > 3 ? getPhiComponent3D(dofNum, phi, nodeId, 3, nf) : 0;
+      const ry = dofNum.dofsPerNode > 3 ? getPhiComponent3D(dofNum, phi, nodeId, 4, nf) : 0;
+      const rz = dofNum.dofsPerNode > 3 ? getPhiComponent3D(dofNum, phi, nodeId, 5, nf) : 0;
+      displacements.push({ nodeId, ux, uy, uz, rx, ry, rz });
+    }
+
+    modes.push({
+      frequency, period, omega, displacements,
+      participationX: gammaX,
+      participationY: gammaY,
+      participationZ: gammaZ,
+      effectiveMassX: meffX,
+      effectiveMassY: meffY,
+      effectiveMassZ: meffZ,
+      massRatioX: totalMassMax > 1e-20 ? meffX / totalMassMax : 0,
+      massRatioY: totalMassMax > 1e-20 ? meffY / totalMassMax : 0,
+      massRatioZ: totalMassMax > 1e-20 ? meffZ / totalMassMax : 0,
+    });
+  }
+
+  if (modes.length === 0) return t('modal.noModesFound');
+
+  const cumRatioX = totalMassMax > 1e-20 ? cumulativeMeffX / totalMassMax : 0;
+  const cumRatioY = totalMassMax > 1e-20 ? cumulativeMeffY / totalMassMax : 0;
+  const cumRatioZ = totalMassMax > 1e-20 ? cumulativeMeffZ / totalMassMax : 0;
+
+  const diags: SolverDiagnostic[] = [];
+  const minParticipation = 0.9;
+  if (cumRatioX < minParticipation && cumRatioY < minParticipation && cumRatioZ < minParticipation) {
+    diags.push({ severity: 'warning', code: 'MODAL_LOW_MASS_PARTICIPATION', message: 'diag.modalLowMassParticipation', source: 'solver', details: { x: cumRatioX, y: cumRatioY, z: cumRatioZ } });
+  }
+
+  return {
+    modes,
+    nDof: nf,
+    totalMass: totalMassMax,
+    cumulativeMassRatioX: cumRatioX,
+    cumulativeMassRatioY: cumRatioY,
+    cumulativeMassRatioZ: cumRatioZ,
+    diagnostics: diags.length > 0 ? diags : undefined,
+  };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+function getPhiComponent3D(
+  dofNum: DofNumbering3D,
+  phi: Float64Array,
+  nodeId: number,
+  localDof: number,
+  nFree: number,
+): number {
+  if (localDof >= dofNum.dofsPerNode) return 0;
+  const idx = globalDof3D(dofNum, nodeId, localDof);
+  if (idx === undefined || idx >= nFree) return 0;
+  return phi[idx];
+}

--- a/web/src/lib/engine/modal.ts
+++ b/web/src/lib/engine/modal.ts
@@ -5,6 +5,7 @@ import type { DofNumbering } from './solver-js';
 import { buildDofNumbering, assemble } from './solver-js';
 import { assembleMassMatrix } from './mass-matrix';
 import { solveGeneralizedEigen, matVec } from './matrix-utils';
+import { t } from '../i18n';
 
 export interface ModeShape {
   /** Natural frequency (Hz) */
@@ -73,8 +74,8 @@ export function solveModal(
   const dofNum = buildDofNumbering(input);
   const nf = dofNum.nFree;
 
-  if (nf === 0) return 'No hay grados de libertad libres';
-  if (nf > 500) return 'Modelo demasiado grande para análisis modal (máx ~500 DOFs libres)';
+  if (nf === 0) return t('modal.noFreeDofs');
+  if (nf > 500) return t('modal.modelTooLarge');
 
   // Validate that at least one material has density assigned
   const materialsUsed = new Set<number>();
@@ -85,7 +86,7 @@ export function solveModal(
     if (d === undefined || d <= 0) missingDensity.push(matId);
   }
   if (missingDensity.length === materialsUsed.size) {
-    return 'Ningún material tiene densidad asignada. Asigne densidad (kg/m³) a los materiales para el análisis modal.';
+    return t('modal.noDensity');
   }
 
   // Assemble stiffness (we only need Kff)
@@ -115,11 +116,11 @@ export function solveModal(
   // Check that mass matrix is not zero
   let massNorm = 0;
   for (let i = 0; i < nf * nf; i++) massNorm += Mff[i] * Mff[i];
-  if (massNorm < 1e-20) return 'Matriz de masa es cero — asigne densidad a los materiales';
+  if (massNorm < 1e-20) return t('modal.zeroMassMatrix');
 
   // Solve generalized eigenvalue problem: Kff·φ = λ·Mff·φ where λ = ω²
   const eigenResult = solveGeneralizedEigen(Kff, Mff, nf);
-  if (!eigenResult) return 'Fallo en descomposición de Cholesky de la matriz de masa';
+  if (!eigenResult) return t('modal.choleskyError');
 
   const nModes = Math.min(numModes ?? 6, nf);
   const modes: ModeShape[] = [];
@@ -220,7 +221,7 @@ export function solveModal(
     });
   }
 
-  if (modes.length === 0) return 'No se encontraron modos válidos';
+  if (modes.length === 0) return t('modal.noModesFound');
 
   // Compute Rayleigh damping coefficients (Chopra §11.4)
   // C = a₀·M + a₁·K, with ξ = a₀/(2ω) + a₁·ω/2

--- a/web/src/lib/engine/moving-loads.ts
+++ b/web/src/lib/engine/moving-loads.ts
@@ -3,6 +3,7 @@
 import type { SolverInput, AnalysisResults, ElementForces, FullEnvelope, ElementEnvelopeDiagram, EnvelopeDiagramData } from './types';
 import { solve } from './solver-js';
 import { computeDiagramValueAt } from './diagrams';
+import { t } from '../i18n';
 
 /** A single axle in a load train */
 export interface Axle {
@@ -18,7 +19,32 @@ export interface LoadTrain {
   axles: Axle[];
 }
 
-/** Predefined load trains */
+/** Predefined load trains (function to pick up current locale) */
+export function getPredefinedTrains(): LoadTrain[] {
+  return [
+    {
+      name: t('train.pointLoad100'),
+      axles: [{ offset: 0, weight: 100 }],
+    },
+    {
+      name: t('train.hl93Truck'),
+      axles: [
+        { offset: 0, weight: 35 },
+        { offset: 4.3, weight: 145 },
+        { offset: 8.6, weight: 145 },
+      ],
+    },
+    {
+      name: t('train.tandem'),
+      axles: [
+        { offset: 0, weight: 110 },
+        { offset: 1.2, weight: 110 },
+      ],
+    },
+  ];
+}
+
+/** @deprecated Use getPredefinedTrains() instead */
 export const PREDEFINED_TRAINS: LoadTrain[] = [
   {
     name: 'Carga puntual (100 kN)',
@@ -166,6 +192,141 @@ function buildPath(input: SolverInput, pathElementIds?: number[]): PathSegment[]
  * Run moving load analysis.
  * Returns envelope of max/min forces across all positions.
  */
+/**
+ * Check if a train is symmetric (single axle or mirror-symmetric weights).
+ */
+function isTrainSymmetric(train: LoadTrain): boolean {
+  if (train.axles.length <= 1) return true;
+  const maxOff = Math.max(...train.axles.map(a => a.offset));
+  for (const axle of train.axles) {
+    const mirror = maxOff - axle.offset;
+    const pair = train.axles.find(a => Math.abs(a.offset - mirror) < 1e-6);
+    if (!pair || Math.abs(pair.weight - axle.weight) > 1e-6) return false;
+  }
+  return true;
+}
+
+/**
+ * Create a reversed copy of a train (mirror axle order so it travels right-to-left).
+ */
+function reverseTrain(train: LoadTrain): LoadTrain {
+  const maxOff = Math.max(...train.axles.map(a => a.offset));
+  return {
+    name: train.name,
+    axles: train.axles.map(a => ({ offset: maxOff - a.offset, weight: a.weight })),
+  };
+}
+
+/**
+ * Build the load array for a single train position on the path.
+ */
+function buildTrainLoads(
+  baseLoads: SolverInput['loads'],
+  train: LoadTrain,
+  refPos: number,
+  totalLength: number,
+  path: PathSegment[],
+): SolverInput['loads'] {
+  const loads: SolverInput['loads'] = [...baseLoads];
+
+  for (const axle of train.axles) {
+    const pos = refPos + axle.offset;
+    if (pos < 0 || pos > totalLength) continue;
+
+    const seg = path.find(s => pos >= s.cumStart && pos <= s.cumStart + s.length);
+    if (!seg) continue;
+
+    const t = (pos - seg.cumStart) / seg.length;
+    const a = t * seg.length;
+
+    const cosTheta = seg.dx / seg.length;
+    const sinTheta = seg.dy / seg.length;
+    const pPerp = -axle.weight * cosTheta;
+
+    if (Math.abs(pPerp) > 1e-10) {
+      loads.push({
+        type: 'pointOnElement',
+        data: { elementId: seg.elementId, a, p: pPerp },
+      });
+    }
+
+    const pAxial = -axle.weight * sinTheta;
+    if (Math.abs(pAxial) > 1e-10) {
+      const fI = pAxial * (1 - t);
+      const fJ = pAxial * t;
+      loads.push(
+        { type: 'nodal', data: { nodeId: seg.nodeI, fx: fI * cosTheta, fy: fI * sinTheta, mz: 0 } },
+        { type: 'nodal', data: { nodeId: seg.nodeJ, fx: fJ * cosTheta, fy: fJ * sinTheta, mz: 0 } },
+      );
+    }
+  }
+
+  return loads;
+}
+
+/**
+ * Solve a single position and update envelope.
+ */
+function solvePosition(
+  baseInput: SolverInput,
+  train: LoadTrain,
+  refPos: number,
+  path: PathSegment[],
+  totalLength: number,
+  envelope: Map<number, { mMaxPos: number; mMaxNeg: number; vMaxPos: number; vMaxNeg: number; nMaxPos: number; nMaxNeg: number }>,
+  positions: MovingLoadEnvelope['positions'],
+): void {
+  const loads = buildTrainLoads(baseInput.loads, train, refPos, totalLength, path);
+  const input: SolverInput = { ...baseInput, loads };
+
+  try {
+    const results = solve(input);
+    positions.push({ refPosition: refPos, results });
+
+    for (const ef of results.elementForces) {
+      const env = envelope.get(ef.elementId);
+      if (!env) continue;
+      const mMax = Math.max(ef.mStart, ef.mEnd);
+      const mMin = Math.min(ef.mStart, ef.mEnd);
+      const vMax = Math.max(ef.vStart, ef.vEnd);
+      const vMin = Math.min(ef.vStart, ef.vEnd);
+      const nMax = Math.max(ef.nStart, ef.nEnd);
+      const nMin = Math.min(ef.nStart, ef.nEnd);
+
+      if (mMax > env.mMaxPos) env.mMaxPos = mMax;
+      if (mMin < env.mMaxNeg) env.mMaxNeg = mMin;
+      if (vMax > env.vMaxPos) env.vMaxPos = vMax;
+      if (vMin < env.vMaxNeg) env.vMaxNeg = vMin;
+      if (nMax > env.nMaxPos) env.nMaxPos = nMax;
+      if (nMin < env.nMaxNeg) env.nMaxNeg = nMin;
+    }
+  } catch (e) {
+    console.warn(`Moving load position ${refPos.toFixed(2)} failed: ${e instanceof Error ? e.message : e}`);
+  }
+}
+
+/**
+ * Compute forward reference positions for a train on a path.
+ */
+function computeRefPositions(train: LoadTrain, totalLength: number, step: number): number[] {
+  const maxAxleOffset = Math.max(...train.axles.map(a => a.offset));
+  const positions: number[] = [];
+  for (let refPos = -maxAxleOffset; refPos <= totalLength; refPos += step) {
+    positions.push(refPos);
+  }
+  return positions;
+}
+
+/**
+ * For each forward refPos, compute the mirror reverse refPos so that
+ * the reversed train produces the exact mirror loading on the structure.
+ * Forward train at r places axles at [r+o₁, r+o₂, ...].
+ * Mirror: reversed train at (L - r - maxOffset) places axles at [L-r-o₁, L-r-o₂, ...].
+ */
+function mirrorRefPositions(forwardPositions: number[], totalLength: number, maxAxleOffset: number): number[] {
+  return forwardPositions.map(r => totalLength - r - maxAxleOffset);
+}
+
 export function solveMovingLoads(
   baseInput: SolverInput,
   config: MovingLoadConfig,
@@ -173,12 +334,10 @@ export function solveMovingLoads(
   const step = config.step ?? 0.25;
   const path = buildPath(baseInput, config.pathElementIds);
 
-  if (path.length === 0) return 'No se encontró un camino continuo de elementos';
+  if (path.length === 0) return t('train.noPathFound');
 
   const totalLength = path[path.length - 1].cumStart + path[path.length - 1].length;
-  const maxAxleOffset = Math.max(...config.train.axles.map(a => a.offset));
 
-  // Initialize envelope
   const envelope = new Map<number, {
     mMaxPos: number; mMaxNeg: number;
     vMaxPos: number; vMaxNeg: number;
@@ -193,81 +352,26 @@ export function solveMovingLoads(
   }
 
   const positions: MovingLoadEnvelope['positions'] = [];
+  const forwardTrain = config.train;
+  const maxAxleOffset = Math.max(...forwardTrain.axles.map(a => a.offset));
+  const forwardRefPositions = computeRefPositions(forwardTrain, totalLength, step);
 
-  // Move reference axle from -maxAxleOffset to totalLength
-  for (let refPos = -maxAxleOffset; refPos <= totalLength; refPos += step) {
-    // Build loads for this position
-    const loads: SolverInput['loads'] = [...baseInput.loads];
+  // Forward pass
+  for (const refPos of forwardRefPositions) {
+    solvePosition(baseInput, forwardTrain, refPos, path, totalLength, envelope, positions);
+  }
 
-    for (const axle of config.train.axles) {
-      const pos = refPos + axle.offset;
-      if (pos < 0 || pos > totalLength) continue;
-
-      // Find which segment this axle falls on
-      const seg = path.find(s => pos >= s.cumStart && pos <= s.cumStart + s.length);
-      if (!seg) continue;
-
-      const t = (pos - seg.cumStart) / seg.length;
-      const a = t * seg.length; // distance from nodeI of this segment
-
-      // Decompose downward force into local coords
-      const cosTheta = seg.dx / seg.length;
-      const sinTheta = seg.dy / seg.length;
-      const pPerp = -axle.weight * cosTheta; // perpendicular component (local)
-
-      if (Math.abs(pPerp) > 1e-10) {
-        loads.push({
-          type: 'pointOnElement',
-          data: { elementId: seg.elementId, a, p: pPerp },
-        });
-      }
-
-      // Axial component as nodal loads
-      const pAxial = -axle.weight * sinTheta;
-      if (Math.abs(pAxial) > 1e-10) {
-        const fI = pAxial * (1 - t);
-        const fJ = pAxial * t;
-        loads.push(
-          { type: 'nodal', data: { nodeId: seg.nodeI, fx: fI * cosTheta, fy: fI * sinTheta, mz: 0 } },
-          { type: 'nodal', data: { nodeId: seg.nodeJ, fx: fJ * cosTheta, fy: fJ * sinTheta, mz: 0 } },
-        );
-      }
-    }
-
-    const input: SolverInput = { ...baseInput, loads };
-
-    try {
-      const results = solve(input);
-      positions.push({ refPosition: refPos, results });
-
-      // Update envelope
-      for (const ef of results.elementForces) {
-        const env = envelope.get(ef.elementId);
-        if (!env) continue;
-        const mMax = Math.max(ef.mStart, ef.mEnd);
-        const mMin = Math.min(ef.mStart, ef.mEnd);
-        const vMax = Math.max(ef.vStart, ef.vEnd);
-        const vMin = Math.min(ef.vStart, ef.vEnd);
-        const nMax = Math.max(ef.nStart, ef.nEnd);
-        const nMin = Math.min(ef.nStart, ef.nEnd);
-
-        if (mMax > env.mMaxPos) env.mMaxPos = mMax;
-        if (mMin < env.mMaxNeg) env.mMaxNeg = mMin;
-        if (vMax > env.vMaxPos) env.vMaxPos = vMax;
-        if (vMin < env.vMaxNeg) env.vMaxNeg = vMin;
-        if (nMax > env.nMaxPos) env.nMaxPos = nMax;
-        if (nMin < env.nMaxNeg) env.nMaxNeg = nMin;
-      }
-    } catch (e) {
-      // Skip positions where the solver fails (e.g. singular matrix at certain load configs).
-      // Log for debugging but don't abort — other positions may still be valid.
-      console.warn(`Moving load position ${refPos.toFixed(2)} failed: ${e instanceof Error ? e.message : e}`);
+  // Reverse pass for asymmetric trains — use mirror positions for exact symmetry
+  if (!isTrainSymmetric(forwardTrain)) {
+    const revTrain = reverseTrain(forwardTrain);
+    const reverseRefPositions = mirrorRefPositions(forwardRefPositions, totalLength, maxAxleOffset);
+    for (const refPos of reverseRefPositions) {
+      solvePosition(baseInput, revTrain, refPos, path, totalLength, envelope, positions);
     }
   }
 
-  if (positions.length === 0) return 'No se pudo resolver ninguna posición de carga';
+  if (positions.length === 0) return t('train.noPositionSolved');
 
-  // Compute pointwise envelope for dual-curve rendering
   const allResults = positions.map(p => p.results);
   const fullEnvelope = computePointwiseEnvelope(allResults);
 
@@ -295,12 +399,10 @@ export async function solveMovingLoadsAsync(
   const step = config.step ?? 0.25;
   const path = buildPath(baseInput, config.pathElementIds);
 
-  if (path.length === 0) return 'No se encontró un camino continuo de elementos';
+  if (path.length === 0) return t('train.noPathFound');
 
   const totalLength = path[path.length - 1].cumStart + path[path.length - 1].length;
-  const maxAxleOffset = Math.max(...config.train.axles.map(a => a.offset));
 
-  // Initialize envelope
   const envelope = new Map<number, {
     mMaxPos: number; mMaxNeg: number;
     vMaxPos: number; vMaxNeg: number;
@@ -314,63 +416,37 @@ export async function solveMovingLoadsAsync(
     });
   }
 
-  // Pre-compute all positions
-  const refPositions: number[] = [];
-  for (let refPos = -maxAxleOffset; refPos <= totalLength; refPos += step) {
-    refPositions.push(refPos);
+  // Pre-compute all positions: forward + mirrored reverse for asymmetric trains
+  const forwardTrain = config.train;
+  const maxAxleOffset = Math.max(...forwardTrain.axles.map(a => a.offset));
+  const forwardRefPositions = computeRefPositions(forwardTrain, totalLength, step);
+
+  const allRefPositions: Array<{ train: LoadTrain; refPos: number }> = [];
+  for (const refPos of forwardRefPositions) {
+    allRefPositions.push({ train: forwardTrain, refPos });
   }
-  const total = refPositions.length;
+  if (!isTrainSymmetric(forwardTrain)) {
+    const revTrain = reverseTrain(forwardTrain);
+    const reverseRefPositions = mirrorRefPositions(forwardRefPositions, totalLength, maxAxleOffset);
+    for (const refPos of reverseRefPositions) {
+      allRefPositions.push({ train: revTrain, refPos });
+    }
+  }
+  const total = allRefPositions.length;
 
   const positions: MovingLoadEnvelope['positions'] = [];
 
   for (let idx = 0; idx < total; idx++) {
-    // Check cancellation
-    if (signal?.aborted) return 'Análisis cancelado';
+    if (signal?.aborted) return t('train.analysisCancelled');
 
-    const refPos = refPositions[idx];
-
-    // Build loads for this position
-    const loads: SolverInput['loads'] = [...baseInput.loads];
-
-    for (const axle of config.train.axles) {
-      const pos = refPos + axle.offset;
-      if (pos < 0 || pos > totalLength) continue;
-
-      const seg = path.find(s => pos >= s.cumStart && pos <= s.cumStart + s.length);
-      if (!seg) continue;
-
-      const t = (pos - seg.cumStart) / seg.length;
-      const a = t * seg.length;
-
-      const cosTheta = seg.dx / seg.length;
-      const sinTheta = seg.dy / seg.length;
-      const pPerp = -axle.weight * cosTheta;
-
-      if (Math.abs(pPerp) > 1e-10) {
-        loads.push({
-          type: 'pointOnElement',
-          data: { elementId: seg.elementId, a, p: pPerp },
-        });
-      }
-
-      const pAxial = -axle.weight * sinTheta;
-      if (Math.abs(pAxial) > 1e-10) {
-        const fI = pAxial * (1 - t);
-        const fJ = pAxial * t;
-        loads.push(
-          { type: 'nodal', data: { nodeId: seg.nodeI, fx: fI * cosTheta, fy: fI * sinTheta, mz: 0 } },
-          { type: 'nodal', data: { nodeId: seg.nodeJ, fx: fJ * cosTheta, fy: fJ * sinTheta, mz: 0 } },
-        );
-      }
-    }
-
+    const { train, refPos } = allRefPositions[idx];
+    const loads = buildTrainLoads(baseInput.loads, train, refPos, totalLength, path);
     const input: SolverInput = { ...baseInput, loads };
 
     try {
       const results = solve(input);
       positions.push({ refPosition: refPos, results });
 
-      // Update envelope
       for (const ef of results.elementForces) {
         const env = envelope.get(ef.elementId);
         if (!env) continue;
@@ -392,15 +468,13 @@ export async function solveMovingLoadsAsync(
       console.warn(`Moving load position ${refPos.toFixed(2)} failed: ${e instanceof Error ? e.message : e}`);
     }
 
-    // Report progress & yield to event loop
     onProgress?.({ current: idx + 1, total, refPosition: refPos });
     await new Promise(r => setTimeout(r, 0));
   }
 
-  if (signal?.aborted) return 'Análisis cancelado';
-  if (positions.length === 0) return 'No se pudo resolver ninguna posición de carga';
+  if (signal?.aborted) return t('train.analysisCancelled');
+  if (positions.length === 0) return t('train.noPositionSolved');
 
-  // Compute pointwise envelope for dual-curve rendering
   const allResults = positions.map(p => p.results);
   const fullEnvelope = computePointwiseEnvelope(allResults);
 

--- a/web/src/lib/engine/pdelta-3d.ts
+++ b/web/src/lib/engine/pdelta-3d.ts
@@ -1,0 +1,577 @@
+// P-Delta (second-order) iterative analysis for 3D structures
+//
+// Uses the existing 3D solver as a building block — does NOT modify solver-3d.ts.
+// Algorithm:
+//   1. Assemble K and F via assemble3D
+//   2. Linear solve → baseline displacements and element forces
+//   3. Extract axial forces N from each element
+//   4. Build 12×12 (frame) or 6×6 (truss) geometric stiffness Kg per element
+//   5. Assemble global Kg, extract Kg_ff
+//   6. Solve (Kff + Kg_ff) · u = Ff iteratively until convergence
+//   7. Return amplified results with B2 factor
+
+import type {
+  SolverInput3D,
+  AnalysisResults3D,
+  Displacement3D,
+  Reaction3D,
+  ElementForces3D,
+} from './types-3d';
+import type { SolverDiagnostic } from './types';
+import {
+  assemble3D,
+  buildDofNumbering3D,
+  computeInternalForces3D,
+  computeLocalAxes3D,
+  frameTransformationMatrix3D,
+  trussTransformationMatrix3D,
+  globalDof3D,
+  isDofRestrained3D,
+} from './solver-3d';
+import type { DofNumbering3D } from './solver-3d';
+import { choleskySolve } from './matrix-utils';
+import { t } from '../i18n';
+
+// ─── Public interface ────────────────────────────────────────────
+
+export interface PDeltaResult3D {
+  results: AnalysisResults3D;
+  iterations: number;
+  converged: boolean;
+  isStable: boolean;
+  /** Global amplification factor B₂ = max(|u_pdelta|/|u_linear|) across all nodes.
+   *  B₂ > 1 means P-Delta amplifies displacements. Typical range: 1.0–1.5.
+   *  B₂ > 2.5 suggests the structure is close to instability. */
+  b2Factor: number;
+  /** Per-node amplification: ratio of P-Delta displacement to linear displacement */
+  amplification: Array<{ nodeId: number; ratio: number }>;
+  /** Linear analysis results for comparison */
+  linearResults: AnalysisResults3D;
+  diagnostics?: SolverDiagnostic[];
+}
+
+export interface PDeltaConfig3D {
+  /** Maximum iterations (default 20) */
+  maxIterations?: number;
+  /** Convergence tolerance: ‖Δu‖/‖u‖ (default 1e-4) */
+  tolerance?: number;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+/** Get displacement value for a given node/DOF from the full displacement vector */
+function getDisp3D(dofNum: DofNumbering3D, u: Float64Array, nodeId: number, localDof: number): number {
+  if (localDof >= dofNum.dofsPerNode) return 0;
+  const idx = globalDof3D(dofNum, nodeId, localDof);
+  return idx !== undefined ? (u[idx] ?? 0) : 0;
+}
+
+/** Get the global DOF indices for a frame element (12 DOFs: 6 per node) */
+function elementDofs(dofNum: DofNumbering3D, nodeI: number, nodeJ: number): number[] {
+  const dofs: number[] = [];
+  for (let d = 0; d < dofNum.dofsPerNode; d++) {
+    const idx = globalDof3D(dofNum, nodeI, d);
+    if (idx !== undefined) dofs.push(idx);
+  }
+  for (let d = 0; d < dofNum.dofsPerNode; d++) {
+    const idx = globalDof3D(dofNum, nodeJ, d);
+    if (idx !== undefined) dofs.push(idx);
+  }
+  return dofs;
+}
+
+/** Get the translational global DOF indices for a truss element (6 DOFs: 3 per node) */
+function trussDofs(dofNum: DofNumbering3D, nodeI: number, nodeJ: number): number[] {
+  const dofs: number[] = [];
+  for (let d = 0; d < 3; d++) {
+    const idx = globalDof3D(dofNum, nodeI, d);
+    if (idx !== undefined) dofs.push(idx);
+  }
+  for (let d = 0; d < 3; d++) {
+    const idx = globalDof3D(dofNum, nodeJ, d);
+    if (idx !== undefined) dofs.push(idx);
+  }
+  return dofs;
+}
+
+/**
+ * Build the 12×12 local geometric stiffness matrix for a 3D frame element.
+ *
+ * Local DOF order: [u1, v1, w1, θx1, θy1, θz1, u2, v2, w2, θx2, θy2, θz2]
+ *
+ * The matrix is (N/L) × coefficients, where N is the axial force (positive = tension).
+ * Reference: McGuire, Gallagher & Ziemian, "Matrix Structural Analysis", 2nd ed.
+ */
+function frameGeometricStiffness3D(N: number, L: number): Float64Array {
+  const kg = new Float64Array(12 * 12);
+  const c = N / L;
+  const L2 = L * L;
+
+  // Helper to set symmetric entry
+  function set(i: number, j: number, val: number): void {
+    kg[i * 12 + j] = val;
+    kg[j * 12 + i] = val;
+  }
+
+  // Row/col indices: u=0, v=1, w=2, θx=3, θy=4, θz=5 (node I)
+  //                  u=6, v=7, w=8, θx=9, θy=10, θz=11 (node J)
+
+  // v1-v1 block
+  set(1, 1, c * 6 / 5);
+  // w1-w1 block
+  set(2, 2, c * 6 / 5);
+
+  // θy1-w1
+  set(4, 2, c * (-L / 10));
+  // θz1-v1
+  set(5, 1, c * (L / 10));
+
+  // θy1-θy1
+  set(4, 4, c * 2 * L2 / 15);
+  // θz1-θz1
+  set(5, 5, c * 2 * L2 / 15);
+
+  // v2-v1
+  set(7, 1, c * (-6 / 5));
+  // w2-w1
+  set(8, 2, c * (-6 / 5));
+
+  // v2-θz1
+  set(7, 5, c * (-L / 10));
+  // w2-θy1
+  set(8, 4, c * (L / 10));
+
+  // v2-v2
+  set(7, 7, c * 6 / 5);
+  // w2-w2
+  set(8, 8, c * 6 / 5);
+
+  // θy2-w1
+  set(10, 2, c * (-L / 10));
+  // θz2-v1
+  set(11, 1, c * (L / 10));
+
+  // θy2-θy1
+  set(10, 4, c * (-L2 / 30));
+  // θz2-θz1
+  set(11, 5, c * (-L2 / 30));
+
+  // θy2-w2
+  set(10, 8, c * (L / 10));
+  // θz2-v2
+  set(11, 7, c * (-L / 10));
+
+  // θy2-θy2
+  set(10, 10, c * 2 * L2 / 15);
+  // θz2-θz2
+  set(11, 11, c * 2 * L2 / 15);
+
+  return kg;
+}
+
+/**
+ * Build the 6×6 local geometric stiffness matrix for a 3D truss element.
+ *
+ * Local DOF order: [u1, v1, w1, u2, v2, w2]
+ *
+ * For a truss, only the transverse DOFs get geometric stiffness.
+ * Same structure as frame but only translational DOFs.
+ */
+function trussGeometricStiffness3D(N: number, L: number): Float64Array {
+  const kg = new Float64Array(6 * 6);
+  const c = N / L;
+
+  // v1-v1, w1-w1
+  kg[1 * 6 + 1] = c;
+  kg[2 * 6 + 2] = c;
+
+  // v2-v1, w2-w1 (off-diagonal)
+  kg[4 * 6 + 1] = -c;
+  kg[1 * 6 + 4] = -c;
+  kg[5 * 6 + 2] = -c;
+  kg[2 * 6 + 5] = -c;
+
+  // v2-v2, w2-w2
+  kg[4 * 6 + 4] = c;
+  kg[5 * 6 + 5] = c;
+
+  return kg;
+}
+
+/**
+ * Transform a local matrix to global coordinates: Kg_global = T^T · Kg_local · T
+ */
+function transformToGlobal(kLocal: Float64Array, T: Float64Array, n: number): Float64Array {
+  // temp = Kg_local · T
+  const temp = new Float64Array(n * n);
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      let sum = 0;
+      for (let k = 0; k < n; k++) {
+        sum += kLocal[i * n + k] * T[k * n + j];
+      }
+      temp[i * n + j] = sum;
+    }
+  }
+  // Kg_global = T^T · temp
+  const kGlobal = new Float64Array(n * n);
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      let sum = 0;
+      for (let k = 0; k < n; k++) {
+        sum += T[k * n + i] * temp[k * n + j];
+      }
+      kGlobal[i * n + j] = sum;
+    }
+  }
+  return kGlobal;
+}
+
+/**
+ * Assemble the global geometric stiffness matrix (free-free partition only)
+ * from element axial forces.
+ */
+function assembleKg3D(
+  input: SolverInput3D,
+  dofNum: DofNumbering3D,
+  forces: ElementForces3D[],
+): Float64Array {
+  const nf = dofNum.nFree;
+  const Kg = new Float64Array(nf * nf);
+
+  // Build a lookup from elementId → ElementForces3D
+  const forceMap = new Map<number, ElementForces3D>();
+  for (const ef of forces) {
+    forceMap.set(ef.elementId, ef);
+  }
+
+  for (const elem of input.elements.values()) {
+    const ef = forceMap.get(elem.id);
+    if (!ef) continue;
+
+    // Average axial force (negative = compression for P-Delta)
+    const N = (ef.nStart + ef.nEnd) / 2;
+
+    const nodeI = input.nodes.get(elem.nodeI)!;
+    const nodeJ = input.nodes.get(elem.nodeJ)!;
+
+    const localY = (elem.localYx !== undefined && elem.localYy !== undefined && elem.localYz !== undefined)
+      ? { x: elem.localYx, y: elem.localYy, z: elem.localYz }
+      : undefined;
+    const axes = computeLocalAxes3D(nodeI, nodeJ, localY, elem.rollAngle);
+    const L = axes.L;
+
+    if (elem.type === 'frame') {
+      const kgLocal = frameGeometricStiffness3D(N, L);
+      const T = frameTransformationMatrix3D(axes.ex, axes.ey, axes.ez);
+      const kgGlobal = transformToGlobal(kgLocal, T, 12);
+
+      const dofs = elementDofs(dofNum, elem.nodeI, elem.nodeJ);
+      for (let i = 0; i < dofs.length; i++) {
+        if (dofs[i] >= nf) continue; // skip restrained DOFs
+        for (let j = 0; j < dofs.length; j++) {
+          if (dofs[j] >= nf) continue;
+          Kg[dofs[i] * nf + dofs[j]] += kgGlobal[i * 12 + j];
+        }
+      }
+    } else {
+      // Truss
+      const kgLocal = trussGeometricStiffness3D(N, L);
+      const T = trussTransformationMatrix3D(axes.ex, axes.ey, axes.ez);
+      const kgGlobal = transformToGlobal(kgLocal, T, 6);
+
+      const dofs = trussDofs(dofNum, elem.nodeI, elem.nodeJ);
+      for (let i = 0; i < dofs.length; i++) {
+        if (dofs[i] >= nf) continue;
+        for (let j = 0; j < dofs.length; j++) {
+          if (dofs[j] >= nf) continue;
+          Kg[dofs[i] * nf + dofs[j]] += kgGlobal[i * 6 + j];
+        }
+      }
+    }
+  }
+
+  return Kg;
+}
+
+// ─── Build results ───────────────────────────────────────────────
+
+/** Build AnalysisResults3D from a full displacement vector (same logic as solve3D) */
+function buildResults3D(
+  input: SolverInput3D,
+  dofNum: DofNumbering3D,
+  K: Float64Array,
+  F: Float64Array,
+  uAll: Float64Array,
+): AnalysisResults3D {
+  const nf = dofNum.nFree;
+  const nt = dofNum.nTotal;
+
+  // Displacements
+  const displacements: Displacement3D[] = [];
+  for (const nodeId of dofNum.nodeOrder) {
+    displacements.push({
+      nodeId,
+      ux: getDisp3D(dofNum, uAll, nodeId, 0),
+      uy: getDisp3D(dofNum, uAll, nodeId, 1),
+      uz: getDisp3D(dofNum, uAll, nodeId, 2),
+      rx: getDisp3D(dofNum, uAll, nodeId, 3),
+      ry: getDisp3D(dofNum, uAll, nodeId, 4),
+      rz: getDisp3D(dofNum, uAll, nodeId, 5),
+    });
+  }
+
+  // Reactions: R = K_row · uAll - F_row for restrained DOFs
+  const reactions: Reaction3D[] = [];
+  for (const sup of input.supports.values()) {
+    let fx = 0, fy = 0, fz = 0, mx = 0, my = 0, mz = 0;
+    const dofVals = [0, 0, 0, 0, 0, 0]; // fx, fy, fz, mx, my, mz
+
+    for (let d = 0; d < dofNum.dofsPerNode; d++) {
+      const gIdx = globalDof3D(dofNum, sup.nodeId, d);
+      if (gIdx === undefined || gIdx < nf) continue; // only restrained DOFs
+
+      let reaction = -F[gIdx];
+      for (let j = 0; j < nt; j++) {
+        reaction += K[gIdx * nt + j] * uAll[j];
+      }
+      dofVals[d] = reaction;
+    }
+
+    // Also compute spring reactions for spring DOFs (which are free DOFs)
+    const springs = [sup.kx, sup.ky, sup.kz, sup.krx, sup.kry, sup.krz];
+    for (let d = 0; d < dofNum.dofsPerNode; d++) {
+      const kVal = springs[d];
+      if (kVal !== undefined && kVal > 0) {
+        const gIdx = globalDof3D(dofNum, sup.nodeId, d);
+        if (gIdx !== undefined && gIdx < nf) {
+          dofVals[d] = kVal * uAll[gIdx];
+        }
+      }
+    }
+
+    fx = dofVals[0]; fy = dofVals[1]; fz = dofVals[2];
+    mx = dofVals[3]; my = dofVals[4]; mz = dofVals[5];
+
+    reactions.push({ nodeId: sup.nodeId, fx, fy, fz, mx, my, mz });
+  }
+
+  // Element forces
+  const elementForces = computeInternalForces3D(input, dofNum, uAll);
+
+  return { displacements, reactions, elementForces };
+}
+
+// ─── Main entry point ────────────────────────────────────────────
+
+/**
+ * P-Delta iterative analysis for 3D structures.
+ *
+ * 1. Assemble global K and F
+ * 2. Linear solve → baseline displacements and element forces
+ * 3. Build Kg from axial forces, assemble into free-free partition
+ * 4. Solve (Kff + Kg_ff) · u = Ff iteratively until convergence
+ * 5. Return amplified results with B2 factor
+ *
+ * Returns a string error message on failure.
+ */
+export function solvePDelta3D(
+  input: SolverInput3D,
+  config?: PDeltaConfig3D,
+): PDeltaResult3D | string {
+  try {
+    return solvePDelta3DInternal(input, config);
+  } catch (e: unknown) {
+    return e instanceof Error ? e.message : String(e);
+  }
+}
+
+function solvePDelta3DInternal(
+  input: SolverInput3D,
+  config?: PDeltaConfig3D,
+): PDeltaResult3D {
+  const maxIter = config?.maxIterations ?? 20;
+  const tol = config?.tolerance ?? 1e-4;
+
+  // Build DOF numbering
+  const dofNum = buildDofNumbering3D(input);
+  const nf = dofNum.nFree;
+  const nt = dofNum.nTotal;
+
+  if (nf === 0) {
+    throw new Error(t('pdelta.noFreeDofs'));
+  }
+
+  // Assemble base stiffness and force vector
+  const { K, F } = assemble3D(input, dofNum);
+
+  // Extract Kff (free-free partition)
+  const Kff = new Float64Array(nf * nf);
+  for (let i = 0; i < nf; i++) {
+    for (let j = 0; j < nf; j++) {
+      Kff[i * nf + j] = K[i * nt + j];
+    }
+  }
+
+  // Extract Ff, adjusted for prescribed displacements: Ff = F_f - K_fr · u_r
+  const nRestr = nt - nf;
+  const uR = new Float64Array(nRestr);
+  for (const sup of input.supports.values()) {
+    const prescribedVals = [sup.dx, sup.dy, sup.dz, sup.drx, sup.dry, sup.drz];
+    for (let d = 0; d < dofNum.dofsPerNode; d++) {
+      if (!isDofRestrained3D(sup, d)) continue;
+      const val = prescribedVals[d];
+      if (val !== undefined && val !== 0) {
+        const gIdx = globalDof3D(dofNum, sup.nodeId, d);
+        if (gIdx !== undefined && gIdx >= nf) {
+          uR[gIdx - nf] = val;
+        }
+      }
+    }
+  }
+
+  const Ff = new Float64Array(nf);
+  for (let i = 0; i < nf; i++) {
+    Ff[i] = F[i];
+    for (let j = 0; j < nRestr; j++) {
+      Ff[i] -= K[i * nt + (nf + j)] * uR[j];
+    }
+  }
+
+  // Initial linear solve
+  let uFree = choleskySolve(new Float64Array(Kff), new Float64Array(Ff), nf);
+  if (!uFree) {
+    throw new Error(t('pdelta.linearSolveError'));
+  }
+
+  // Save linear solution for B₂ computation
+  const uLinearFree = new Float64Array(uFree);
+
+  // Build full displacement vector helper
+  function buildFullU(uf: Float64Array): Float64Array {
+    const uAll = new Float64Array(nt);
+    for (let i = 0; i < nf; i++) uAll[i] = uf[i];
+    for (let i = 0; i < nRestr; i++) uAll[nf + i] = uR[i];
+    return uAll;
+  }
+
+  let converged = false;
+  let iterations = 0;
+  let isStable = true;
+  let elementForces: ElementForces3D[] = [];
+
+  for (let iter = 0; iter < maxIter; iter++) {
+    iterations = iter + 1;
+
+    // Compute internal forces from current displacements
+    const uAll = buildFullU(uFree);
+    elementForces = computeInternalForces3D(input, dofNum, uAll);
+
+    // Assemble geometric stiffness (free-free partition)
+    const Kg = assembleKg3D(input, dofNum, elementForces);
+
+    // Modified stiffness: Kmod = Kff + Kg
+    const Kmod = new Float64Array(nf * nf);
+    for (let i = 0; i < nf * nf; i++) {
+      Kmod[i] = Kff[i] + Kg[i];
+    }
+
+    // Solve modified system
+    const uNew = choleskySolve(new Float64Array(Kmod), new Float64Array(Ff), nf);
+    if (!uNew) {
+      // Cholesky failed — system is no longer positive definite (instability)
+      isStable = false;
+      converged = false;
+      break;
+    }
+
+    // Check for divergence
+    let uNorm = 0;
+    for (let i = 0; i < nf; i++) uNorm += uNew[i] * uNew[i];
+    uNorm = Math.sqrt(uNorm);
+
+    let uPrevNorm = 0;
+    for (let i = 0; i < nf; i++) uPrevNorm += uFree[i] * uFree[i];
+    uPrevNorm = Math.sqrt(uPrevNorm);
+
+    if (uNorm > 10 * uPrevNorm && uPrevNorm > 1e-10) {
+      isStable = false;
+      converged = false;
+      break;
+    }
+
+    // Check convergence: ‖Δu‖/‖u‖
+    let duNorm = 0;
+    for (let i = 0; i < nf; i++) {
+      const du = uNew[i] - uFree[i];
+      duNorm += du * du;
+    }
+    duNorm = Math.sqrt(duNorm);
+
+    uFree = uNew;
+
+    if (uNorm > 1e-15 && duNorm / uNorm < tol) {
+      converged = true;
+      // Final internal forces update
+      const uAllFinal = buildFullU(uFree);
+      elementForces = computeInternalForces3D(input, dofNum, uAllFinal);
+      break;
+    }
+  }
+
+  if (!converged && isStable) {
+    // Didn't converge but didn't diverge — use last result
+    const uAll = buildFullU(uFree);
+    elementForces = computeInternalForces3D(input, dofNum, uAll);
+  }
+
+  // Build final P-Delta results
+  const uAllFinal = buildFullU(uFree);
+  const results = buildResults3D(input, dofNum, K, F, uAllFinal);
+
+  // Build linear results for comparison
+  const uAllLinear = buildFullU(uLinearFree);
+  const linearResults = buildResults3D(input, dofNum, K, F, uAllLinear);
+
+  // Compute per-node amplification and global B₂
+  const amplification: Array<{ nodeId: number; ratio: number }> = [];
+  let b2Factor = 1.0;
+
+  for (const nodeId of dofNum.nodeOrder) {
+    const pdDisp = results.displacements.find(d => d.nodeId === nodeId)!;
+    const linDisp = linearResults.displacements.find(d => d.nodeId === nodeId)!;
+
+    const pdMag = Math.sqrt(
+      pdDisp.ux * pdDisp.ux + pdDisp.uy * pdDisp.uy + pdDisp.uz * pdDisp.uz,
+    );
+    const linMag = Math.sqrt(
+      linDisp.ux * linDisp.ux + linDisp.uy * linDisp.uy + linDisp.uz * linDisp.uz,
+    );
+
+    const ratio = linMag > 1e-15 ? pdMag / linMag : 1.0;
+    amplification.push({ nodeId, ratio });
+    if (ratio > b2Factor) b2Factor = ratio;
+  }
+
+  const diags: SolverDiagnostic[] = [];
+  if (!converged) {
+    diags.push({ severity: 'error', code: 'PDELTA_NOT_CONVERGED', message: 'diag.pdeltaNotConverged', source: 'solver', details: { iterations, tolerance: config?.tolerance ?? 1e-4 } });
+  }
+  if (!isStable) {
+    diags.push({ severity: 'error', code: 'PDELTA_UNSTABLE', message: 'diag.pdeltaUnstable', source: 'solver', details: { b2Factor } });
+  }
+  if (isStable && b2Factor > 1.5) {
+    diags.push({ severity: 'warning', code: 'PDELTA_HIGH_B2', message: 'diag.pdeltaHighB2', source: 'solver', details: { b2Factor } });
+  }
+
+  return {
+    results,
+    iterations,
+    converged,
+    isStable,
+    b2Factor,
+    amplification,
+    linearResults,
+    diagnostics: diags.length > 0 ? diags : undefined,
+  };
+}

--- a/web/src/lib/engine/pdelta.ts
+++ b/web/src/lib/engine/pdelta.ts
@@ -7,6 +7,7 @@ import {
 } from './solver-js';
 import { assembleKg } from './geometric-stiffness';
 import { choleskySolve } from './matrix-utils';
+import { t } from '../i18n';
 
 export interface PDeltaConfig {
   /** Maximum iterations (default 20) */
@@ -47,7 +48,7 @@ export function solvePDelta(
   const nf = dofNum.nFree;
   const nt = dofNum.nTotal;
 
-  if (nf === 0) return 'No hay grados de libertad libres';
+  if (nf === 0) return t('pdelta.noFreeDofs');
 
   // Assemble base stiffness and force
   const { K, F } = assemble(input, dofNum);
@@ -70,7 +71,7 @@ export function solvePDelta(
     uFree = choleskySolve(new Float64Array(Kff), new Float64Array(Ff), nf)
           ?? solveLU(new Float64Array(Kff), new Float64Array(Ff), nf);
   } catch {
-    return 'Error en resolución lineal inicial';
+    return t('pdelta.linearSolveError');
   }
 
   // Save linear solution for B₂ computation

--- a/web/src/lib/engine/plastic.ts
+++ b/web/src/lib/engine/plastic.ts
@@ -2,6 +2,7 @@
 
 import type { SolverInput, SolverElement, AnalysisResults, ElementForces } from './types';
 import { solve, computeStaticDegree } from './solver-js';
+import { t } from '../i18n';
 
 export interface PlasticHinge {
   elementId: number;
@@ -98,7 +99,7 @@ export function solvePlastic(
   // Plastic analysis requires frame elements (moment-carrying)
   const hasFrames = Array.from(input.elements.values()).some(e => e.type === 'frame');
   if (!hasFrames) {
-    return 'El análisis plástico requiere elementos tipo pórtico (frame). Los reticulados (truss) solo transmiten fuerza axial y no forman articulaciones plásticas por flexión.';
+    return t('plastic.requiresFrames');
   }
 
   // Compute Mp for each section
@@ -276,7 +277,7 @@ export function solvePlastic(
   }
 
   if (allHinges.length === 0) {
-    return 'No se formaron articulaciones plásticas. Los momentos en la estructura no alcanzan la capacidad plástica Mp. Posibles causas: las cargas son muy bajas relativas a la resistencia de la sección, o la sección tiene capacidad muy alta.';
+    return t('plastic.noHingesFormed');
   }
 
   return {

--- a/web/src/lib/engine/section-stress-3d.ts
+++ b/web/src/lib/engine/section-stress-3d.ts
@@ -8,6 +8,7 @@
 
 import type { ElementForces3D } from './types-3d';
 import type { Section } from '../store/model.svelte';
+import { t } from '../i18n';
 import {
   resolveSectionGeometry,
   computeMohrCircle,
@@ -743,17 +744,17 @@ export function suggestCriticalSections3D(ef: ElementForces3D): Array<{ t: numbe
   const sections: Array<{ t: number; reason: string }> = [];
 
   // Start and end
-  sections.push({ t: 0, reason: 'Nodo I' });
-  sections.push({ t: 1, reason: 'Nodo J' });
+  sections.push({ t: 0, reason: t('stress.endI') });
+  sections.push({ t: 1, reason: t('stress.endJ') });
 
   // Midspan
-  sections.push({ t: 0.5, reason: 'Centro' });
+  sections.push({ t: 0.5, reason: t('stress.midspan') });
 
   // Where Vy = 0 (max Mz)
   if (Math.abs(ef.vyStart) > 1e-6 && Math.abs(ef.vyEnd) > 1e-6 && ef.vyStart * ef.vyEnd < 0) {
     const tVy0 = ef.vyStart / (ef.vyStart - ef.vyEnd);
     if (tVy0 > 0.01 && tVy0 < 0.99) {
-      sections.push({ t: tVy0, reason: 'Vy=0 (Mz máx)' });
+      sections.push({ t: tVy0, reason: 'Vy=0 (Mz max)' });
     }
   }
 
@@ -761,7 +762,7 @@ export function suggestCriticalSections3D(ef: ElementForces3D): Array<{ t: numbe
   if (Math.abs(ef.vzStart) > 1e-6 && Math.abs(ef.vzEnd) > 1e-6 && ef.vzStart * ef.vzEnd < 0) {
     const tVz0 = ef.vzStart / (ef.vzStart - ef.vzEnd);
     if (tVz0 > 0.01 && tVz0 < 0.99) {
-      sections.push({ t: tVz0, reason: 'Vz=0 (My máx)' });
+      sections.push({ t: tVz0, reason: 'Vz=0 (My max)' });
     }
   }
 
@@ -769,13 +770,13 @@ export function suggestCriticalSections3D(ef: ElementForces3D): Array<{ t: numbe
   for (const pl of ef.pointLoadsY) {
     const tp = pl.a / ef.length;
     if (tp > 0.01 && tp < 0.99) {
-      sections.push({ t: tp, reason: 'Carga puntual Y' });
+      sections.push({ t: tp, reason: t('stress.pointLoadY') });
     }
   }
   for (const pl of ef.pointLoadsZ) {
     const tp = pl.a / ef.length;
     if (tp > 0.01 && tp < 0.99) {
-      sections.push({ t: tp, reason: 'Carga puntual Z' });
+      sections.push({ t: tp, reason: t('stress.pointLoadZ') });
     }
   }
 

--- a/web/src/lib/engine/section-stress.ts
+++ b/web/src/lib/engine/section-stress.ts
@@ -7,6 +7,7 @@ import type { Section } from '../store/model.svelte';
 import { ALL_PROFILES, familyToShape, type SteelProfile, type SectionShape } from '../data/steel-profiles';
 import type { ElementForces } from './types';
 import { computeDiagramValueAt } from './diagrams';
+import { t } from '../i18n';
 
 // ─── Types ────────────────────────────────────────────────────────────
 
@@ -909,8 +910,8 @@ export function suggestCriticalSections(ef: ElementForces): CriticalSection[] {
   const L = ef.length;
 
   // Always include ends
-  sections.push({ t: 0, reason: 'Extremo I' });
-  sections.push({ t: 1, reason: 'Extremo J' });
+  sections.push({ t: 0, reason: t('stress.endI') });
+  sections.push({ t: 1, reason: t('stress.endJ') });
 
   // Find where V = 0 (M is maximum)
   // V(x) = Vs + q_i·x + (q_j - q_i)·x²/(2L) + Σ(point loads before x)
@@ -926,7 +927,7 @@ export function suggestCriticalSections(ef: ElementForces): CriticalSection[] {
       const x0 = -Vs / qi;
       const t0 = x0 / L;
       if (t0 > 0.01 && t0 < 0.99) {
-        sections.push({ t: t0, reason: 'M máx (V=0)' });
+        sections.push({ t: t0, reason: 'M max (V=0)' });
       }
     } else if (Math.abs(qj - qi) > 1e-10) {
       // Trapezoidal: V(x) = Vs + qi·x + (qj-qi)·x²/(2L) = 0
@@ -940,7 +941,7 @@ export function suggestCriticalSections(ef: ElementForces): CriticalSection[] {
         for (const x0 of [(-b + sqrtDisc) / (2 * a), (-b - sqrtDisc) / (2 * a)]) {
           const t0 = x0 / L;
           if (t0 > 0.01 && t0 < 0.99) {
-            sections.push({ t: t0, reason: 'M máx (V=0)' });
+            sections.push({ t: t0, reason: 'M max (V=0)' });
           }
         }
       }
@@ -952,14 +953,14 @@ export function suggestCriticalSections(ef: ElementForces): CriticalSection[] {
     for (const pl of ef.pointLoads) {
       const tPl = pl.a / L;
       if (tPl > 0.01 && tPl < 0.99) {
-        sections.push({ t: tPl, reason: `Carga puntual` });
+        sections.push({ t: tPl, reason: t('stress.pointLoadReason') });
       }
     }
   }
 
   // Midpoint (useful for uniform loads)
   if (sections.every(s => Math.abs(s.t - 0.5) > 0.05)) {
-    sections.push({ t: 0.5, reason: 'Mitad' });
+    sections.push({ t: 0.5, reason: t('stress.midspan') });
   }
 
   // Sort by t and deduplicate (merge close ones)

--- a/web/src/lib/engine/shell-stress-recovery.ts
+++ b/web/src/lib/engine/shell-stress-recovery.ts
@@ -1,0 +1,352 @@
+// Post-processing: recover plate/quad membrane stresses from nodal displacements.
+// Used when the WASM solver doesn't return plateStresses/quadStresses.
+//
+// For quads (MITC4): bilinear membrane stress at 2×2 Gauss points,
+// extrapolated to corner nodes for smooth heatmap visualization.
+
+import type { AnalysisResults3D, QuadStress, PlateStress } from './types-3d';
+
+interface NodePos { x: number; y: number; z?: number }
+interface QuadDef { id: number; nodes: number[]; materialId: number; thickness: number }
+interface PlateDef { id: number; nodes: number[]; materialId: number; thickness: number }
+interface MatDef { e: number; nu: number }
+
+/**
+ * Enrich AnalysisResults3D with quad/plate stresses computed from displacements.
+ * Only runs if the results don't already contain stress data.
+ */
+export function enrichWithShellStresses(
+  results: AnalysisResults3D,
+  nodes: Map<number, NodePos>,
+  quads: Map<number, QuadDef>,
+  plates: Map<number, PlateDef>,
+  materials: Map<number, MatDef>,
+): void {
+  // Build displacement lookup: nodeId → [ux, uy, uz, rx, ry, rz]
+  const dispMap = new Map<number, number[]>();
+  for (const d of results.displacements) {
+    dispMap.set(d.nodeId, [d.ux, d.uy, d.uz, d.rx, d.ry, d.rz]);
+  }
+
+  // Compute quad stresses if missing
+  if ((!results.quadStresses || results.quadStresses.length === 0) && quads.size > 0) {
+    results.quadStresses = [];
+    for (const quad of quads.values()) {
+      const mat = materials.get(quad.materialId);
+      if (!mat) continue;
+      const qs = computeQuadStress(quad, nodes, dispMap, mat.e, mat.nu);
+      if (qs) results.quadStresses.push(qs);
+    }
+  }
+
+  // Compute plate stresses if missing
+  if ((!results.plateStresses || results.plateStresses.length === 0) && plates.size > 0) {
+    results.plateStresses = [];
+    for (const plate of plates.values()) {
+      const mat = materials.get(plate.materialId);
+      if (!mat) continue;
+      const ps = computePlateStress(plate, nodes, dispMap, mat.e, mat.nu);
+      if (ps) results.plateStresses.push(ps);
+    }
+  }
+}
+
+// ─── Quad (bilinear membrane) stress recovery ────────────────
+
+function computeQuadStress(
+  quad: QuadDef,
+  nodes: Map<number, NodePos>,
+  dispMap: Map<number, number[]>,
+  E: number, // MPa
+  nu: number,
+): QuadStress | null {
+  const [n0, n1, n2, n3] = quad.nodes.map(id => nodes.get(id));
+  if (!n0 || !n1 || !n2 || !n3) return null;
+
+  const coords: [number, number, number][] = [
+    [n0.x, n0.y, n0.z ?? 0],
+    [n1.x, n1.y, n1.z ?? 0],
+    [n2.x, n2.y, n2.z ?? 0],
+    [n3.x, n3.y, n3.z ?? 0],
+  ];
+
+  // Build local coordinate system
+  const { ex, ey } = quadLocalAxes(coords);
+
+  // Project to 2D local coords
+  const pts2d = projectTo2D(coords, ex, ey);
+
+  // Extract local displacements (project global ux,uy,uz to local ex,ey)
+  const uLocal: number[] = [];
+  for (const nid of quad.nodes) {
+    const d = dispMap.get(nid) ?? [0, 0, 0, 0, 0, 0];
+    // Project displacement onto local axes
+    const ulx = d[0] * ex[0] + d[1] * ex[1] + d[2] * ex[2];
+    const uly = d[0] * ey[0] + d[1] * ey[1] + d[2] * ey[2];
+    uLocal.push(ulx, uly);
+  }
+
+  // E in solver is kN/m² (kPa), model E is in MPa → convert: 1 MPa = 1000 kN/m²
+  const Ekpa = E * 1000;
+
+  // Constitutive matrix (plane stress)
+  const c = Ekpa / (1 - nu * nu);
+  const D = [
+    c, c * nu, 0,
+    c * nu, c, 0,
+    0, 0, c * (1 - nu) / 2,
+  ];
+
+  // Evaluate at 2×2 Gauss points
+  const s3 = 1 / Math.sqrt(3);
+  const gaussPts: [number, number][] = [[-s3, -s3], [s3, -s3], [s3, s3], [-s3, s3]];
+
+  const gpStress: { sxx: number; syy: number; txy: number; vm: number }[] = [];
+
+  for (const [xi, eta] of gaussPts) {
+    // Shape function derivatives w.r.t. xi, eta
+    const dNdxi = [
+      -(1 - eta) / 4, (1 - eta) / 4, (1 + eta) / 4, -(1 + eta) / 4,
+    ];
+    const dNdeta = [
+      -(1 - xi) / 4, -(1 + xi) / 4, (1 + xi) / 4, (1 - xi) / 4,
+    ];
+
+    // Jacobian
+    let j11 = 0, j12 = 0, j21 = 0, j22 = 0;
+    for (let i = 0; i < 4; i++) {
+      j11 += dNdxi[i] * pts2d[i][0];
+      j12 += dNdxi[i] * pts2d[i][1];
+      j21 += dNdeta[i] * pts2d[i][0];
+      j22 += dNdeta[i] * pts2d[i][1];
+    }
+    const detJ = j11 * j22 - j12 * j21;
+    if (Math.abs(detJ) < 1e-20) continue;
+    const invJ = [j22 / detJ, -j12 / detJ, -j21 / detJ, j11 / detJ];
+
+    // dN/dx, dN/dy
+    const dNdx: number[] = [];
+    const dNdy: number[] = [];
+    for (let i = 0; i < 4; i++) {
+      dNdx.push(invJ[0] * dNdxi[i] + invJ[1] * dNdeta[i]);
+      dNdy.push(invJ[2] * dNdxi[i] + invJ[3] * dNdeta[i]);
+    }
+
+    // Strain: eps = B * u
+    let epsXx = 0, epsYy = 0, gammaXy = 0;
+    for (let i = 0; i < 4; i++) {
+      epsXx += dNdx[i] * uLocal[i * 2];
+      epsYy += dNdy[i] * uLocal[i * 2 + 1];
+      gammaXy += dNdy[i] * uLocal[i * 2] + dNdx[i] * uLocal[i * 2 + 1];
+    }
+
+    // Stress: sigma = D * eps
+    const sxx = D[0] * epsXx + D[1] * epsYy + D[2] * gammaXy;
+    const syy = D[3] * epsXx + D[4] * epsYy + D[5] * gammaXy;
+    const txy = D[6] * epsXx + D[7] * epsYy + D[8] * gammaXy;
+    const vm = Math.sqrt(sxx * sxx - sxx * syy + syy * syy + 3 * txy * txy);
+
+    gpStress.push({ sxx, syy, txy, vm });
+  }
+
+  if (gpStress.length < 4) return null;
+
+  // Centroidal average
+  const avg = {
+    sxx: gpStress.reduce((s, g) => s + g.sxx, 0) / 4,
+    syy: gpStress.reduce((s, g) => s + g.syy, 0) / 4,
+    txy: gpStress.reduce((s, g) => s + g.txy, 0) / 4,
+    vm: gpStress.reduce((s, g) => s + g.vm, 0) / 4,
+  };
+
+  // Extrapolate Von Mises from Gauss points to corner nodes
+  const nodalVonMises = extrapolateToNodes(gpStress.map(g => g.vm));
+
+  return {
+    elementId: quad.id,
+    sigmaXx: avg.sxx,
+    sigmaYy: avg.syy,
+    tauXy: avg.txy,
+    mx: 0, my: 0, mxy: 0, // Bending moments need plate DOFs — omitted in membrane-only recovery
+    vonMises: avg.vm,
+    nodalVonMises,
+  };
+}
+
+// ─── Plate (CST membrane) stress recovery ────────────────────
+
+function computePlateStress(
+  plate: PlateDef,
+  nodes: Map<number, NodePos>,
+  dispMap: Map<number, number[]>,
+  E: number,
+  nu: number,
+): PlateStress | null {
+  const [n0, n1, n2] = plate.nodes.map(id => nodes.get(id));
+  if (!n0 || !n1 || !n2) return null;
+
+  const coords: [number, number, number][] = [
+    [n0.x, n0.y, n0.z ?? 0],
+    [n1.x, n1.y, n1.z ?? 0],
+    [n2.x, n2.y, n2.z ?? 0],
+  ];
+
+  const { ex, ey } = triLocalAxes(coords);
+
+  // Project to 2D
+  const o = coords[0];
+  const pts2d: [number, number][] = coords.map(c => {
+    const dx = c[0] - o[0], dy = c[1] - o[1], dz = c[2] - o[2];
+    return [dx * ex[0] + dy * ex[1] + dz * ex[2], dx * ey[0] + dy * ey[1] + dz * ey[2]];
+  });
+
+  // Local displacements
+  const uLocal: number[] = [];
+  for (const nid of plate.nodes) {
+    const d = dispMap.get(nid) ?? [0, 0, 0, 0, 0, 0];
+    uLocal.push(
+      d[0] * ex[0] + d[1] * ex[1] + d[2] * ex[2],
+      d[0] * ey[0] + d[1] * ey[1] + d[2] * ey[2],
+    );
+  }
+
+  const Ekpa = E * 1000;
+  const c = Ekpa / (1 - nu * nu);
+
+  // CST B-matrix (constant strain triangle)
+  const x0 = pts2d[0][0], y0 = pts2d[0][1];
+  const x1 = pts2d[1][0], y1 = pts2d[1][1];
+  const x2 = pts2d[2][0], y2 = pts2d[2][1];
+  const area2 = (x1 - x0) * (y2 - y0) - (x2 - x0) * (y1 - y0);
+  if (Math.abs(area2) < 1e-20) return null;
+
+  // dN/dx, dN/dy for CST
+  const dNdx = [(y1 - y2) / area2, (y2 - y0) / area2, (y0 - y1) / area2];
+  const dNdy = [(x2 - x1) / area2, (x0 - x2) / area2, (x1 - x0) / area2];
+
+  let epsXx = 0, epsYy = 0, gammaXy = 0;
+  for (let i = 0; i < 3; i++) {
+    epsXx += dNdx[i] * uLocal[i * 2];
+    epsYy += dNdy[i] * uLocal[i * 2 + 1];
+    gammaXy += dNdy[i] * uLocal[i * 2] + dNdx[i] * uLocal[i * 2 + 1];
+  }
+
+  const sxx = c * (epsXx + nu * epsYy);
+  const syy = c * (nu * epsXx + epsYy);
+  const txy = c * (1 - nu) / 2 * gammaXy;
+  const vm = Math.sqrt(sxx * sxx - sxx * syy + syy * syy + 3 * txy * txy);
+
+  // Principal stresses
+  const savg = (sxx + syy) / 2;
+  const sdiff = Math.sqrt(((sxx - syy) / 2) ** 2 + txy * txy);
+  const s1 = savg + sdiff;
+  const s2 = savg - sdiff;
+
+  return {
+    elementId: plate.id,
+    sigmaXx: sxx,
+    sigmaYy: syy,
+    tauXy: txy,
+    mx: 0, my: 0, mxy: 0,
+    sigma1: s1,
+    sigma2: s2,
+    vonMises: vm,
+    nodalVonMises: [vm, vm, vm], // CST = constant stress → same at all nodes
+  };
+}
+
+// ─── Geometry helpers ────────────────────────────────────────
+
+function quadLocalAxes(coords: [number, number, number][]) {
+  // ex = (n1 - n0) normalized, ey = ez × ex, ez = ex × (n3 - n0)
+  const dx = coords[1][0] - coords[0][0];
+  const dy = coords[1][1] - coords[0][1];
+  const dz = coords[1][2] - coords[0][2];
+  const len = Math.sqrt(dx * dx + dy * dy + dz * dz);
+  const ex = [dx / len, dy / len, dz / len];
+
+  const v2x = coords[3][0] - coords[0][0];
+  const v2y = coords[3][1] - coords[0][1];
+  const v2z = coords[3][2] - coords[0][2];
+
+  // ez = ex × v2
+  const ezx = ex[1] * v2z - ex[2] * v2y;
+  const ezy = ex[2] * v2x - ex[0] * v2z;
+  const ezz = ex[0] * v2y - ex[1] * v2x;
+  const ezLen = Math.sqrt(ezx * ezx + ezy * ezy + ezz * ezz);
+  const ez = ezLen > 1e-12 ? [ezx / ezLen, ezy / ezLen, ezz / ezLen] : [0, 0, 1];
+
+  // ey = ez × ex
+  const ey = [
+    ez[1] * ex[2] - ez[2] * ex[1],
+    ez[2] * ex[0] - ez[0] * ex[2],
+    ez[0] * ex[1] - ez[1] * ex[0],
+  ];
+
+  return { ex, ey, ez };
+}
+
+function triLocalAxes(coords: [number, number, number][]) {
+  const dx = coords[1][0] - coords[0][0];
+  const dy = coords[1][1] - coords[0][1];
+  const dz = coords[1][2] - coords[0][2];
+  const len = Math.sqrt(dx * dx + dy * dy + dz * dz);
+  const ex = [dx / len, dy / len, dz / len];
+
+  const v2x = coords[2][0] - coords[0][0];
+  const v2y = coords[2][1] - coords[0][1];
+  const v2z = coords[2][2] - coords[0][2];
+
+  const ezx = ex[1] * v2z - ex[2] * v2y;
+  const ezy = ex[2] * v2x - ex[0] * v2z;
+  const ezz = ex[0] * v2y - ex[1] * v2x;
+  const ezLen = Math.sqrt(ezx * ezx + ezy * ezy + ezz * ezz);
+  const ez = ezLen > 1e-12 ? [ezx / ezLen, ezy / ezLen, ezz / ezLen] : [0, 0, 1];
+
+  const ey = [
+    ez[1] * ex[2] - ez[2] * ex[1],
+    ez[2] * ex[0] - ez[0] * ex[2],
+    ez[0] * ex[1] - ez[1] * ex[0],
+  ];
+
+  return { ex, ey, ez };
+}
+
+function projectTo2D(
+  coords: [number, number, number][],
+  ex: number[],
+  ey: number[],
+): [number, number][] {
+  const o = coords[0];
+  return coords.map(c => {
+    const dx = c[0] - o[0], dy = c[1] - o[1], dz = c[2] - o[2];
+    return [dx * ex[0] + dy * ex[1] + dz * ex[2], dx * ey[0] + dy * ey[1] + dz * ey[2]] as [number, number];
+  });
+}
+
+/**
+ * Bilinear extrapolation from 2×2 Gauss points to 4 corner nodes.
+ * Gauss points at ±1/√3, corners at ±1.
+ */
+function extrapolateToNodes(gpValues: number[]): number[] {
+  if (gpValues.length !== 4) return gpValues;
+  const s = Math.sqrt(3);
+  // Corner nodes in order: (-1,-1), (1,-1), (1,1), (-1,1)
+  // Gauss points in order: (-1/√3,-1/√3), (1/√3,-1/√3), (1/√3,1/√3), (-1/√3,1/√3)
+  const cornerXi: [number, number][] = [[-1, -1], [1, -1], [1, 1], [-1, 1]];
+  const nodal: number[] = [];
+
+  for (const [xiN, etaN] of cornerXi) {
+    const xiS = xiN * s;
+    const etaS = etaN * s;
+    // Bilinear shape functions evaluated at scaled point
+    const N0 = (1 - xiS) * (1 - etaS) / 4;
+    const N1 = (1 + xiS) * (1 - etaS) / 4;
+    const N2 = (1 + xiS) * (1 + etaS) / 4;
+    const N3 = (1 - xiS) * (1 + etaS) / 4;
+    const val = N0 * gpValues[0] + N1 * gpValues[1] + N2 * gpValues[2] + N3 * gpValues[3];
+    nodal.push(Math.max(0, val)); // Clamp non-negative
+  }
+
+  return nodal;
+}

--- a/web/src/lib/engine/solver-3d.ts
+++ b/web/src/lib/engine/solver-3d.ts
@@ -19,6 +19,7 @@ import type {
 } from './types-3d';
 import { choleskySolve } from './matrix-utils';
 import { computeStaticDegree3D, analyzeKinematics3D } from './kinematic-3d';
+import { t } from '../i18n';
 
 // ─── DOF Numbering ───────────────────────────────────────────────
 
@@ -166,7 +167,7 @@ export function computeLocalAxes3D(
   const L = Math.sqrt(dx * dx + dy * dy + dz * dz);
 
   if (L < 1e-10) {
-    throw new Error(`Elemento con longitud cero entre nodos (${nodeI.x},${nodeI.y},${nodeI.z}) y (${nodeJ.x},${nodeJ.y},${nodeJ.z})`);
+    throw new Error(t('solver.elemZeroLength3D').replace('{coordI}', `(${nodeI.x},${nodeI.y},${nodeI.z})`).replace('{coordJ}', `(${nodeJ.x},${nodeJ.y},${nodeJ.z})`));
   }
 
   const ex: [number, number, number] = [dx / L, dy / L, dz / L];
@@ -183,7 +184,7 @@ export function computeLocalAxes3D(
     let ezz = ex[0] * ref[1] - ex[1] * ref[0];
     const ezLen = Math.sqrt(ezx * ezx + ezy * ezy + ezz * ezz);
     if (ezLen < 1e-10) {
-      throw new Error(`Vector de orientación local Y paralelo al eje del elemento`);
+      throw new Error(t('solver.localYParallel'));
     }
     ezx /= ezLen; ezy /= ezLen; ezz /= ezLen;
     ez = [ezx, ezy, ezz];
@@ -212,7 +213,7 @@ export function computeLocalAxes3D(
     let eyz = refEz[0] * ex[1] - refEz[1] * ex[0];
     const eyLen = Math.sqrt(eyx * eyx + eyy * eyy + eyz * eyz);
     if (eyLen < 1e-10) {
-      throw new Error(`Error al calcular ejes locales: refEz paralelo a ex`);
+      throw new Error(t('solver.localAxesError'));
     }
     eyx /= eyLen; eyy /= eyLen; eyz /= eyLen;
     ey = [eyx, eyy, eyz];
@@ -954,7 +955,7 @@ function solveLU3D(A: Float64Array, b: Float64Array, n: number): Float64Array {
     }
 
     if (maxVal < singularityTol) {
-      throw new Error(`Matriz singular 3D (mecanismo). La estructura no tiene suficientes restricciones.`);
+      throw new Error(t('solver.singularMatrix3D'));
     }
 
     if (maxRow !== k) {
@@ -974,7 +975,7 @@ function solveLU3D(A: Float64Array, b: Float64Array, n: number): Float64Array {
   }
 
   if (Math.abs(a[(n - 1) * n + (n - 1)]) < singularityTol) {
-    throw new Error('Matriz singular 3D (mecanismo). La estructura es hipostática.');
+    throw new Error(t('solver.singularHypostatic3D'));
   }
 
   const x = new Float64Array(n);
@@ -988,7 +989,7 @@ function solveLU3D(A: Float64Array, b: Float64Array, n: number): Float64Array {
 
   for (let i = 0; i < n; i++) {
     if (!isFinite(x[i])) {
-      throw new Error(`Resultado inválido 3D (mecanismo).`);
+      throw new Error(t('solver.invalidResult3D'));
     }
   }
 
@@ -1253,40 +1254,40 @@ export function solve3D(input: SolverInput3D): AnalysisResults3D | string {
 
 function solve3DInternal(input: SolverInput3D): AnalysisResults3D {
   // Validate
-  if (input.nodes.size < 2) throw new Error('Se necesitan al menos 2 nodos');
-  if (input.elements.size < 1) throw new Error('Se necesita al menos 1 elemento');
-  if (input.supports.size < 1) throw new Error('Se necesita al menos 1 apoyo');
+  if (input.nodes.size < 2) throw new Error(t('solver.minNodes'));
+  if (input.elements.size < 1) throw new Error(t('solver.minElements'));
+  if (input.supports.size < 1) throw new Error(t('solver.minSupports'));
 
   // Validate element references
   for (const elem of input.elements.values()) {
     if (!input.nodes.has(elem.nodeI) || !input.nodes.has(elem.nodeJ)) {
-      throw new Error(`Elemento ${elem.id}: nodos no encontrados`);
+      throw new Error(t('solver.elemNodesNotFound').replace('{id}', String(elem.id)));
     }
     if (!input.materials.has(elem.materialId)) {
-      throw new Error(`Elemento ${elem.id}: material ${elem.materialId} no encontrado`);
+      throw new Error(t('solver.elemMaterialNotFound').replace('{id}', String(elem.id)).replace('{matId}', String(elem.materialId)));
     }
     if (!input.sections.has(elem.sectionId)) {
-      throw new Error(`Elemento ${elem.id}: sección ${elem.sectionId} no encontrada`);
+      throw new Error(t('solver.elemSectionNotFound').replace('{id}', String(elem.id)).replace('{secId}', String(elem.sectionId)));
     }
     const ni = input.nodes.get(elem.nodeI)!;
     const nj = input.nodes.get(elem.nodeJ)!;
     const dx = nj.x - ni.x, dy = nj.y - ni.y, dz = nj.z - ni.z;
     if (Math.sqrt(dx * dx + dy * dy + dz * dz) < 1e-10) {
-      throw new Error(`Elemento ${elem.id}: longitud cero`);
+      throw new Error(t('solver.elemZeroLengthById').replace('{id}', String(elem.id)));
     }
   }
 
   // Validate material properties
   for (const mat of input.materials.values()) {
-    if (mat.e <= 0) throw new Error(`Material ${mat.id}: módulo de elasticidad E debe ser > 0`);
+    if (mat.e <= 0) throw new Error(t('solver.matInvalidE').replace('{id}', String(mat.id)));
   }
 
   // Validate sections
   for (const sec of input.sections.values()) {
-    if (sec.a <= 0) throw new Error(`Sección ${sec.id}: área A debe ser > 0`);
-    if (sec.iz <= 0) throw new Error(`Sección ${sec.id}: Iz debe ser > 0`);
-    if (sec.iy <= 0) throw new Error(`Sección ${sec.id}: Iy debe ser > 0`);
-    if (sec.j <= 0) throw new Error(`Sección ${sec.id}: J debe ser > 0`);
+    if (sec.a <= 0) throw new Error(t('solver.secInvalidA3D').replace('{id}', String(sec.id)));
+    if (sec.iz <= 0) throw new Error(t('solver.secInvalidIz3D').replace('{id}', String(sec.id)));
+    if (sec.iy <= 0) throw new Error(t('solver.secInvalidIy3D').replace('{id}', String(sec.id)));
+    if (sec.j <= 0) throw new Error(t('solver.secInvalidJ3D').replace('{id}', String(sec.id)));
   }
 
   // Kinematic analysis — check for mechanisms before solving
@@ -1319,7 +1320,7 @@ function solve3DInternal(input: SolverInput3D): AnalysisResults3D {
   }
 
   if (dofNum.nFree === 0 && !hasPrescribed && input.loads.length === 0) {
-    throw new Error('No hay grados de libertad libres — la estructura está completamente restringida');
+    throw new Error(t('solver.noFreeDofs'));
   }
 
   // Assemble
@@ -1396,9 +1397,7 @@ function solve3DInternal(input: SolverInput3D): AnalysisResults3D {
   if (artificialDofs.size > 0) {
     for (const idx of artificialDofs) {
       if (idx < nf && Math.abs(uf[idx]) > 100) {
-        throw new Error(
-          'Mecanismo local 3D detectado: rotación excesiva en un nodo con barras articuladas.'
-        );
+        throw new Error(t('solver.localMechanismRotation3D'));
       }
     }
   }

--- a/web/src/lib/engine/solver-detailed-3d.ts
+++ b/web/src/lib/engine/solver-detailed-3d.ts
@@ -10,6 +10,7 @@ import type {
   SolverInput3D, SolverSupport3D,
   SolverDistributedLoad3D, SolverPointLoad3D,
 } from './types-3d';
+import { t } from '../i18n';
 
 // Re-export the same DSMStepData interface so the StepWizard can display both 2D and 3D
 export type {
@@ -168,7 +169,7 @@ function solveLU(A: Float64Array, b: Float64Array, n: number): Float64Array {
       const val = Math.abs(a[i * n + k]);
       if (val > maxVal) { maxVal = val; maxRow = i; }
     }
-    if (maxVal < singularityTol) throw new Error('Matriz singular 3D (mecanismo o estructura hipostatica). Verifica los apoyos.');
+    if (maxVal < singularityTol) throw new Error(t('detailed3d.singularMatrix'));
     if (maxRow !== k) {
       for (let j = 0; j < n; j++) {
         const tmp = a[k * n + j]; a[k * n + j] = a[maxRow * n + j]; a[maxRow * n + j] = tmp;
@@ -181,7 +182,7 @@ function solveLU(A: Float64Array, b: Float64Array, n: number): Float64Array {
       bw[i] -= factor * bw[k];
     }
   }
-  if (Math.abs(a[(n - 1) * n + (n - 1)]) < singularityTol) throw new Error('Matriz singular 3D (mecanismo). Estructura hipostatica.');
+  if (Math.abs(a[(n - 1) * n + (n - 1)]) < singularityTol) throw new Error(t('detailed3d.singularHypostatic'));
   const x = new Float64Array(n);
   for (let i = n - 1; i >= 0; i--) {
     let sum = bw[i];

--- a/web/src/lib/engine/solver-detailed.ts
+++ b/web/src/lib/engine/solver-detailed.ts
@@ -7,6 +7,7 @@ import type {
   SolverInput, SolverNode, SolverSupport,
   SolverDistributedLoad, SolverPointLoadOnElement, SolverThermalLoad,
 } from './types';
+import { t } from '../i18n';
 
 // ─── Types ──────────────────────────────────────────────────────
 
@@ -235,7 +236,7 @@ function solveLU(A: Float64Array, b: Float64Array, n: number): Float64Array {
       const val = Math.abs(a[i * n + k]);
       if (val > maxVal) { maxVal = val; maxRow = i; }
     }
-    if (maxVal < singularityTol) throw new Error(`Matriz singular (mecanismo o estructura hipostática). Verificá los apoyos.`);
+    if (maxVal < singularityTol) throw new Error(t('detailed.singularMatrix'));
     if (maxRow !== k) {
       for (let j = 0; j < n; j++) {
         const tmp = a[k * n + j]; a[k * n + j] = a[maxRow * n + j]; a[maxRow * n + j] = tmp;
@@ -248,7 +249,7 @@ function solveLU(A: Float64Array, b: Float64Array, n: number): Float64Array {
       bw[i] -= factor * bw[k];
     }
   }
-  if (Math.abs(a[(n - 1) * n + (n - 1)]) < singularityTol) throw new Error('Matriz singular (mecanismo). Estructura hipostática.');
+  if (Math.abs(a[(n - 1) * n + (n - 1)]) < singularityTol) throw new Error(t('detailed.singularHypostatic'));
   const x = new Float64Array(n);
   for (let i = n - 1; i >= 0; i--) {
     let sum = bw[i];
@@ -528,7 +529,7 @@ export function solveDetailed(input: SolverInput): DSMStepData {
       const c = Math.cos(ang), s = Math.sin(ang);
       const eKn = mat.e * 1000;
       const alpha = 1.2e-5;
-      const desc = `Carga térmica elem ${elem.id}`;
+      const desc = t('detailed.thermalLoadDesc').replace('{id}', String(elem.id));
       const addLC = (nodeId: number, ld: number, val: number, d: string) => {
         if (Math.abs(val) < 1e-15) return;
         const idx = globalDof(nodeId, ld);

--- a/web/src/lib/engine/solver-js.ts
+++ b/web/src/lib/engine/solver-js.ts
@@ -8,6 +8,7 @@ import type {
 } from './types';
 import { choleskySolve } from './matrix-utils';
 import { computeStaticDegree as _computeStaticDegree, analyzeKinematics as _analyzeKinematics } from './kinematic-2d';
+import { t } from '../i18n';
 
 // ─── DOF Numbering ───────────────────────────────────────────────
 
@@ -696,7 +697,7 @@ export function solveLU(A: Float64Array, b: Float64Array, n: number): Float64Arr
     }
 
     if (maxVal < singularityTol) {
-      throw new Error(`Matriz singular (mecanismo o estructura hipostática). La estructura no tiene suficientes restricciones para ser estable. Verificá los apoyos y la geometría.`);
+      throw new Error(t('solver.singularMatrix'));
     }
 
     // Swap rows
@@ -723,7 +724,7 @@ export function solveLU(A: Float64Array, b: Float64Array, n: number): Float64Arr
 
   // Check last diagonal
   if (Math.abs(a[(n - 1) * n + (n - 1)]) < singularityTol) {
-    throw new Error('Matriz singular (mecanismo). La estructura es hipostática — no tiene suficientes vínculos para equilibrio estático.');
+    throw new Error(t('solver.singularHypostatic'));
   }
 
   // Back substitution
@@ -739,7 +740,7 @@ export function solveLU(A: Float64Array, b: Float64Array, n: number): Float64Arr
   // Check for NaN/Inf
   for (let i = 0; i < n; i++) {
     if (!isFinite(x[i])) {
-      throw new Error(`Resultado inválido (mecanismo). La estructura es hipostática o tiene un grado de libertad sin restringir.`);
+      throw new Error(t('solver.invalidResult'));
     }
   }
 
@@ -949,44 +950,44 @@ export function computeInternalForces(
 
 export function solve(input: SolverInput): AnalysisResults {
   // Validate
-  if (input.nodes.size < 2) throw new Error('Se necesitan al menos 2 nodos');
-  if (input.elements.size < 1) throw new Error('Se necesita al menos 1 elemento');
-  if (input.supports.size < 1) throw new Error('Se necesita al menos 1 apoyo');
+  if (input.nodes.size < 2) throw new Error(t('solver.minNodes'));
+  if (input.elements.size < 1) throw new Error(t('solver.minElements'));
+  if (input.supports.size < 1) throw new Error(t('solver.minSupports'));
 
   // Validate all element nodes exist and geometry is valid
   for (const elem of input.elements.values()) {
     if (!input.nodes.has(elem.nodeI) || !input.nodes.has(elem.nodeJ)) {
-      throw new Error(`Elemento ${elem.id}: nodos no encontrados`);
+      throw new Error(t('solver.elemNodesNotFound').replace('{id}', String(elem.id)));
     }
     if (!input.materials.has(elem.materialId)) {
-      throw new Error(`Elemento ${elem.id}: material ${elem.materialId} no encontrado`);
+      throw new Error(t('solver.elemMaterialNotFound').replace('{id}', String(elem.id)).replace('{matId}', String(elem.materialId)));
     }
     if (!input.sections.has(elem.sectionId)) {
-      throw new Error(`Elemento ${elem.id}: sección ${elem.sectionId} no encontrada`);
+      throw new Error(t('solver.elemSectionNotFound').replace('{id}', String(elem.id)).replace('{secId}', String(elem.sectionId)));
     }
     // Check for zero-length elements
     const ni = input.nodes.get(elem.nodeI)!;
     const nj = input.nodes.get(elem.nodeJ)!;
     const L = nodeDistance(ni, nj);
     if (L < 1e-10) {
-      throw new Error(`Elemento ${elem.id}: longitud cero (nodos ${elem.nodeI} y ${elem.nodeJ} coinciden)`);
+      throw new Error(t('solver.elemZeroLength').replace('{id}', String(elem.id)).replace('{nodeI}', String(elem.nodeI)).replace('{nodeJ}', String(elem.nodeJ)));
     }
   }
 
   // Validate material properties
   for (const mat of input.materials.values()) {
     if (mat.e <= 0) {
-      throw new Error(`Material ${mat.id}: módulo de elasticidad E debe ser > 0`);
+      throw new Error(t('solver.matInvalidE').replace('{id}', String(mat.id)));
     }
   }
 
   // Validate section properties
   for (const sec of input.sections.values()) {
     if (sec.a <= 0) {
-      throw new Error(`Sección ${sec.id} "${sec.name}": área A debe ser > 0`);
+      throw new Error(t('solver.secInvalidA').replace('{id}', String(sec.id)).replace('{name}', sec.name));
     }
     if (sec.iz <= 0) {
-      throw new Error(`Sección ${sec.id} "${sec.name}": inercia Iz debe ser > 0`);
+      throw new Error(t('solver.secInvalidIz').replace('{id}', String(sec.id)).replace('{name}', sec.name));
     }
   }
 
@@ -1000,7 +1001,7 @@ export function solve(input: SolverInput): AnalysisResults {
         const nj = input.nodes.get(elem.nodeJ)!;
         const L = nodeDistance(ni, nj);
         if (pl.a < 0 || pl.a > L) {
-          throw new Error(`Carga puntual en elemento ${pl.elementId}: posición a=${pl.a.toFixed(3)}m fuera del rango [0, ${L.toFixed(3)}m]`);
+          throw new Error(t('solver.pointLoadOutOfRange').replace('{elemId}', String(pl.elementId)).replace('{a}', pl.a.toFixed(3)).replace('{L}', L.toFixed(3)));
         }
       }
     }
@@ -1044,8 +1045,7 @@ export function solve(input: SolverInput): AnalysisResults {
       // → node has zero transverse stiffness → mechanism
       if (doubleHinged >= frames && frames >= 2 && !supType) {
         throw new Error(
-          `Mecanismo en nodo ${nodeId}: todos los ${frames} elementos tienen articulación en ambos extremos ` +
-          `(solo transmiten axil). El nudo no tiene rigidez lateral ni a flexión.`
+          t('solver.mechanismAllDoubleHinged').replace('{nodeId}', String(nodeId)).replace('{frames}', String(frames))
         );
       }
       // Case 2: ALL elements hinged at this node AND at least one is double-hinged.
@@ -1057,9 +1057,7 @@ export function solve(input: SolverInput): AnalysisResults {
       const hasRotSupport = supType === 'fixed' || supType === 'spring';
       if (hinges >= frames && frames >= 2 && doubleHinged > 0 && !hasRotSupport) {
         throw new Error(
-          `Mecanismo en nodo ${nodeId}: todos los ${frames} elementos tienen articulación en ese nodo ` +
-          `y ${doubleHinged} de ellos son biarticulados (solo axil). ` +
-          `El nudo no tiene rigidez a flexión ni suficiente rigidez transversal.`
+          t('solver.mechanismHingedNode').replace('{nodeId}', String(nodeId)).replace('{frames}', String(frames)).replace('{doubleHinged}', String(doubleHinged))
         );
       }
     }
@@ -1107,7 +1105,7 @@ export function solve(input: SolverInput): AnalysisResults {
   }
 
   if (dofNum.nFree === 0 && !hasPrescribed && input.loads.length === 0) {
-    throw new Error('No hay grados de libertad libres — la estructura está completamente restringida');
+    throw new Error(t('solver.noFreeDofs'));
   }
 
   // Assemble
@@ -1194,11 +1192,7 @@ export function solve(input: SolverInput): AnalysisResults {
   if (artificialDofs.size > 0) {
     for (const idx of artificialDofs) {
       if (idx < nf && Math.abs(uf[idx]) > 100) {
-        throw new Error(
-          'Mecanismo local detectado: un nodo con todas las barras articuladas tiene ' +
-          'rotación excesiva, lo que indica una inestabilidad local. ' +
-          'Revisá las articulaciones de la estructura.'
-        );
+        throw new Error(t('solver.localMechanismRotation'));
       }
     }
   }
@@ -1226,11 +1220,7 @@ export function solve(input: SolverInput): AnalysisResults {
 
     // If max displacement exceeds 10× the structure span, it's a near-mechanism
     if (maxDisp > 10 * maxSpan) {
-      throw new Error(
-        'Mecanismo local detectado: los desplazamientos son excesivos, lo que indica una ' +
-        'inestabilidad local (por ejemplo, un panel rectangular con todas las barras articuladas ' +
-        'en ambos extremos). Revisá las articulaciones y la geometría de la estructura.'
-      );
+      throw new Error(t('solver.localMechanismDisplacement'));
     }
   }
 

--- a/web/src/lib/engine/solver-pool.ts
+++ b/web/src/lib/engine/solver-pool.ts
@@ -1,0 +1,150 @@
+/**
+ * solver-pool.ts — Worker pool for parallel 3D solving.
+ *
+ * Pre-initializes a pool of Web Workers, each with its own WASM instance.
+ * Distributes solve_3d calls across workers for parallel execution.
+ */
+
+interface PendingSolve {
+  resolve: (json: string) => void;
+  reject: (err: Error) => void;
+}
+
+interface PoolWorker {
+  worker: Worker;
+  ready: boolean;
+  pending: Map<number, PendingSolve>;
+}
+
+let pool: PoolWorker[] = [];
+let wasmBytes: ArrayBuffer | null = null;
+let initPromise: Promise<void> | null = null;
+let nextId = 0;
+
+/** Maximum number of workers to create */
+const MAX_WORKERS = Math.min(navigator.hardwareConcurrency ?? 4, 8);
+
+/** Fetch the WASM binary once for sharing with workers. */
+async function fetchWasmBytes(): Promise<ArrayBuffer> {
+  if (wasmBytes) return wasmBytes;
+  // The WASM binary is served alongside the JS glue code
+  // Use the same resolution path as the glue code
+  const wasmUrl = new URL('../wasm/dedaliano_engine_bg.wasm', import.meta.url);
+  const resp = await fetch(wasmUrl);
+  wasmBytes = await resp.arrayBuffer();
+  return wasmBytes;
+}
+
+/** Create a single worker and wait for it to become ready. */
+function createWorker(bytes: ArrayBuffer): Promise<PoolWorker> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(
+      new URL('./solver-worker.ts', import.meta.url),
+      { type: 'module' },
+    );
+
+    const pw: PoolWorker = { worker, ready: false, pending: new Map() };
+
+    worker.onmessage = (e: MessageEvent) => {
+      const msg = e.data;
+      if (msg.type === 'ready') {
+        pw.ready = true;
+        resolve(pw);
+        return;
+      }
+      if (msg.type === 'error') {
+        reject(new Error(msg.message));
+        return;
+      }
+      if (msg.type === 'result') {
+        const p = pw.pending.get(msg.id);
+        if (p) {
+          pw.pending.delete(msg.id);
+          if (msg.error) p.reject(new Error(msg.error));
+          else p.resolve(msg.resultJson);
+        }
+      }
+    };
+
+    worker.onerror = (err) => {
+      reject(new Error(`Worker error: ${err.message}`));
+    };
+
+    // Send WASM bytes (copy, not transfer, since multiple workers need it)
+    worker.postMessage({ type: 'init', wasmBytes: bytes.slice(0) });
+  });
+}
+
+/** Initialize the worker pool. Idempotent — safe to call multiple times. */
+export async function initPool(numWorkers?: number): Promise<void> {
+  if (pool.length > 0) return;
+  if (initPromise) return initPromise;
+
+  const count = numWorkers ?? MAX_WORKERS;
+
+  initPromise = (async () => {
+    const bytes = await fetchWasmBytes();
+    const workers = await Promise.all(
+      Array.from({ length: count }, () => createWorker(bytes)),
+    );
+    pool = workers;
+  })();
+
+  return initPromise;
+}
+
+/** Check if the pool is initialized and ready. */
+export function isPoolReady(): boolean {
+  return pool.length > 0 && pool.every(w => w.ready);
+}
+
+/**
+ * Solve multiple 3D cases in parallel across the worker pool.
+ *
+ * @param cases Array of { id, json } where json is the serialized SolverInput3D
+ * @returns Map from id to parsed result JSON string
+ */
+export async function solveParallel(
+  cases: Array<{ id: number; json: string }>,
+): Promise<Map<number, string>> {
+  if (pool.length === 0) {
+    throw new Error('Worker pool not initialized. Call initPool() first.');
+  }
+
+  const results = new Map<number, string>();
+
+  // Distribute cases round-robin across workers
+  const promises: Promise<void>[] = [];
+
+  for (let i = 0; i < cases.length; i++) {
+    const workerIdx = i % pool.length;
+    const pw = pool[workerIdx];
+    const { id, json } = cases[i];
+    const msgId = nextId++;
+
+    const promise = new Promise<void>((resolve, reject) => {
+      pw.pending.set(msgId, {
+        resolve: (resultJson: string) => {
+          results.set(id, resultJson);
+          resolve();
+        },
+        reject: (err: Error) => reject(err),
+      });
+      pw.worker.postMessage({ type: 'solve3d', id: msgId, json });
+    });
+
+    promises.push(promise);
+  }
+
+  await Promise.all(promises);
+  return results;
+}
+
+/** Terminate all workers and clean up the pool. */
+export function destroyPool(): void {
+  for (const pw of pool) {
+    pw.worker.terminate();
+  }
+  pool = [];
+  initPromise = null;
+}

--- a/web/src/lib/engine/solver-service.ts
+++ b/web/src/lib/engine/solver-service.ts
@@ -1,17 +1,25 @@
 // Solver service — pure functions extracted from model.svelte.ts
 // Each function takes a ModelData parameter instead of accessing reactive store state.
 
-import { solve as solveStructure, solve3D as solve3DEngine, analyzeKinematics, combineResults, combineResults3D, computeEnvelope, computeEnvelope3D } from './wasm-solver';
+import { solve as solveStructure, solve3D as solve3DEngine, analyzeKinematics, combineResults, combineResults3D, computeEnvelope, computeEnvelope3D, solveMultiCase3D, serializeInput3D } from './wasm-solver';
 import type { SolverInput, FullEnvelope, AnalysisResults } from './types';
 import { computeLocalAxes3D } from './solver-3d';
-import type { SolverInput3D, SolverLoad3D, AnalysisResults3D, FullEnvelope3D } from './types-3d';
+import type { SolverInput3D, SolverLoad3D, AnalysisResults3D, FullEnvelope3D, Constraint3D } from './types-3d';
 import type { KinematicResult } from './kinematic-2d';
+import {
+  convertSurfaceLoad, convertThermalQuadLoad,
+  plateSelfWeightLoads, quadSelfWeightLoads,
+  addShellConnectivity, addShellAdjacency,
+  postProcessShellStresses,
+} from './solver-shells';
+import { initPool, isPoolReady, solveParallel } from './solver-pool';
+import { t } from '../i18n';
 
 import type {
   Node, Element, Support, Load, Material, Section,
   LoadCase, LoadCombination,
   DistributedLoad, PointLoadOnElement, ThermalLoad,
-  NodalLoad3D, DistributedLoad3D, PointLoadOnElement3D,
+  NodalLoad3D, DistributedLoad3D, PointLoadOnElement3D, SurfaceLoad3D, ThermalLoadQuad3D,
 } from '../store/model.svelte';
 
 // ─── ModelData interface ──────────────────────────────────────────
@@ -23,6 +31,9 @@ export interface ModelData {
   loads: Load[];
   materials: Map<number, Material>;
   sections: Map<number, Section>;
+  plates?: Map<number, { id: number; nodes: [number, number, number]; materialId: number; thickness: number }>;
+  quads?: Map<number, { id: number; nodes: [number, number, number, number]; materialId: number; thickness: number }>;
+  constraints?: Constraint3D[];
 }
 
 // ─── Internal helpers ─────────────────────────────────────────────
@@ -119,10 +130,10 @@ export function validateAndSolve2D(
   onKinematic?: (k: KinematicResult | null) => void,
 ): AnalysisResults | string | null {
   if (model.nodes.size < 2 || model.elements.size < 1) {
-    return 'Necesita al menos 2 nodos y 1 elemento';
+    return t('svc.needNodesAndElements');
   }
   if (model.supports.size < 1) {
-    return 'Necesita al menos 1 apoyo';
+    return t('svc.needSupport');
   }
 
   // Check for disconnected nodes (nodes not connected to any element)
@@ -133,7 +144,7 @@ export function validateAndSolve2D(
   }
   for (const nodeId of model.nodes.keys()) {
     if (!connectedNodes.has(nodeId)) {
-      return `Nodo ${nodeId} no está conectado a ningún elemento. Elimínelo o conéctelo.`;
+      return t('svc.disconnectedNode').replace('{n}', String(nodeId));
     }
   }
 
@@ -146,9 +157,9 @@ export function validateAndSolve2D(
       if (L2d < 1e-6) {
         const dz = Math.abs((nj.z ?? 0) - (ni.z ?? 0));
         if (dz > 1e-6) {
-          return `Elemento ${elem.id} tiene longitud cero en 2D pero sus nodos difieren en Z (${dz.toFixed(3)} m). Este modelo es 3D — cambie a Dedaliano 3D para analizarlo.`;
+          return t('svc.zeroLength2dButZ').replace('{n}', String(elem.id)).replace('{dz}', dz.toFixed(3));
         }
-        return `Elemento ${elem.id} tiene longitud cero (nodos ${elem.nodeI} y ${elem.nodeJ} coinciden).`;
+        return t('svc.zeroLengthElement').replace('{n}', String(elem.id)).replace('{ni}', String(elem.nodeI)).replace('{nj}', String(elem.nodeJ));
       }
     }
   }
@@ -158,11 +169,11 @@ export function validateAndSolve2D(
     const types3D = new Set(['fixed3d', 'pinned3d', 'spring3d', 'rollerXZ', 'rollerXY', 'rollerYZ']);
     const sup3D = [...model.supports.values()].find(s => types3D.has(s.type));
     if (sup3D) {
-      return `Este modelo usa apoyos 3D (${sup3D.type}) que no son compatibles con el análisis 2D. Cambie a Dedaliano 3D para analizarlo.`;
+      return t('svc.model3dSupport').replace('{n}', sup3D.type);
     }
     const hasZCoords = [...model.nodes.values()].some(n => n.z !== undefined && Math.abs(n.z) > 1e-10);
     if (hasZCoords) {
-      return `Este modelo tiene nodos con coordenada Z (geometría 3D). Cambie a Dedaliano 3D para analizarlo.`;
+      return t('svc.model3dZCoords');
     }
   }
 
@@ -179,7 +190,7 @@ export function validateAndSolve2D(
     } else constrainedDOFs += 1; // roller
   }
   if (constrainedDOFs < 3) {
-    return `Estructura hipostática: solo ${constrainedDOFs} grados de libertad restringidos (mínimo 3 para equilibrio en 2D). Es un mecanismo.`;
+    return t('svc.hypostaticDofs').replace('{n}', String(constrainedDOFs));
   }
 
   // ── External stability: reaction equilibrium matrix rank check ──
@@ -240,10 +251,10 @@ export function validateAndSolve2D(
         const hasRy = cols.some(c => Math.abs(c[1]) > 1e-12);
         const hasMoment = cols.some(c => Math.abs(c[2]) > 1e-12);
 
-        if (!hasRx) return 'Estructura hipostática (mecanismo): no hay restricción horizontal en ningún apoyo.';
-        if (!hasRy) return 'Estructura hipostática (mecanismo): no hay restricción vertical en ningún apoyo.';
-        if (!hasMoment) return 'Estructura hipostática (mecanismo): las reacciones de apoyo no pueden resistir momentos — son paralelas, colineales o concurrentes. Revisá la disposición de apoyos.';
-        return 'Estructura hipostática (mecanismo): las reacciones de apoyo no forman un sistema estáticamente estable. Sus líneas de acción son concurrentes o paralelas.';
+        if (!hasRx) return t('svc.hypostaticNoHoriz');
+        if (!hasRy) return t('svc.hypostaticNoVert');
+        if (!hasMoment) return t('svc.hypostaticNoMoment');
+        return t('svc.hypostaticUnstable');
       }
     }
   }
@@ -273,7 +284,7 @@ export function validateAndSolve2D(
     }
     if (visited.size < connectedNodes.size) {
       const disconnected = [...connectedNodes].filter(n => !visited.has(n));
-      return `Estructura no conexa: los nodos ${disconnected.join(', ')} están desconectados del resto. Una todos los tramos.`;
+      return t('svc.disconnectedGraph').replace('{ids}', disconnected.join(', '));
     }
   }
 
@@ -301,17 +312,17 @@ export function validateAndSolve2D(
       const onlyRollersY = [...model.supports.values()].every(s => s.type === 'rollerY');
 
       if (onlyRollersX) {
-        return 'Estructura inestable: todos los apoyos son rodillos horizontales (sin restricción en X).';
+        return t('svc.unstableAllRollersX');
       }
       if (onlyRollersY) {
-        return 'Estructura inestable: todos los apoyos son rodillos verticales (sin restricción en Y).';
+        return t('svc.unstableAllRollersY');
       }
 
       if (allCollinear) {
         const types = [...model.supports.values()].map(s => s.type);
         const allRollers = types.every(t => isRollerType(t));
         if (allRollers) {
-          return 'Estructura inestable: todos los apoyos son colineales y tipo rodillo — no hay restricción suficiente.';
+          return t('svc.unstableCollinearRollers');
         }
       }
     }
@@ -364,7 +375,7 @@ export function validateAndSolve2D(
           }
         }
         if (allCollinearHere) {
-          return `Mecanismo en nodo ${nodeId}: todos los elementos (${elems}) son colineales y tienen articulación en ese nodo — no hay transferencia de momento ni estabilidad lateral.`;
+          return t('svc.mechCollinearHinge').replace('{n}', String(nodeId)).replace('{elems}', String(elems));
         }
       }
     }
@@ -393,10 +404,10 @@ export function validateAndSolve2D(
       const supType = supportMap2.get(nodeId);
       const hasRotSupport = supType === 'fixed' || supType === 'spring';
       if (dblCount >= frames && frames >= 2 && !supType) {
-        return `Mecanismo en nodo ${nodeId}: todos los elementos (${frames}) tienen articulación en ambos extremos — solo transmiten axil, sin rigidez lateral ni a flexión.`;
+        return t('svc.mechDoubleHinged').replace('{n}', String(nodeId)).replace('{elems}', String(frames));
       }
       if (hinges >= frames && frames >= 2 && dblCount > 0 && !hasRotSupport) {
-        return `Mecanismo en nodo ${nodeId}: todos los ${frames} elementos tienen articulación en ese nodo y ${dblCount} son biarticulados — rigidez insuficiente.`;
+        return t('svc.mechInsufficientStiffness').replace('{n}', String(nodeId)).replace('{elems}', String(frames)).replace('{dbl}', String(dblCount));
       }
     }
   }
@@ -405,19 +416,19 @@ export function validateAndSolve2D(
   for (const l of model.loads) {
     if (l.type === 'nodal') {
       if (!model.nodes.has(l.data.nodeId)) {
-        return `Carga nodal referencia al nodo ${l.data.nodeId} que no existe.`;
+        return t('svc.loadRefNodeMissing').replace('{n}', String(l.data.nodeId));
       }
     } else if (l.type === 'distributed') {
       if (!model.elements.has((l.data as DistributedLoad).elementId)) {
-        return `Carga distribuida referencia al elemento ${(l.data as DistributedLoad).elementId} que no existe.`;
+        return t('svc.loadRefDistMissing').replace('{n}', String((l.data as DistributedLoad).elementId));
       }
     } else if (l.type === 'pointOnElement') {
       if (!model.elements.has((l.data as PointLoadOnElement).elementId)) {
-        return `Carga puntual referencia al elemento ${(l.data as PointLoadOnElement).elementId} que no existe.`;
+        return t('svc.loadRefPointMissing').replace('{n}', String((l.data as PointLoadOnElement).elementId));
       }
     } else if (l.type === 'thermal') {
       if (!model.elements.has((l.data as ThermalLoad).elementId)) {
-        return `Carga térmica referencia al elemento ${(l.data as ThermalLoad).elementId} que no existe.`;
+        return t('svc.loadRefThermalMissing').replace('{n}', String((l.data as ThermalLoad).elementId));
       }
     }
   }
@@ -517,7 +528,7 @@ export function validateAndSolve2D(
     return results;
   } catch (err: any) {
     console.error('Solver error:', err);
-    return `Error al resolver: ${err.message}`;
+    return t('svc.solverError').replace('{n}', err.message);
   }
 }
 
@@ -693,9 +704,9 @@ export function solveCombinations2D(
   combinations: LoadCombination[],
   includeSelfWeight = false,
 ): { perCase: Map<number, AnalysisResults>; perCombo: Map<number, AnalysisResults>; envelope: FullEnvelope } | string | null {
-  if (model.nodes.size < 2 || model.elements.size < 1) return 'Necesita al menos 2 nodos y 1 elemento';
-  if (model.supports.size < 1) return 'Necesita al menos 1 apoyo';
-  if (combinations.length === 0) return 'Defina al menos una combinación de carga';
+  if (model.nodes.size < 2 || model.elements.size < 1) return t('svc.needNodesAndElements');
+  if (model.supports.size < 1) return t('svc.needSupport');
+  if (combinations.length === 0) return t('svc.needCombination');
 
   const perCase = new Map<number, AnalysisResults>();
 
@@ -704,12 +715,12 @@ export function solveCombinations2D(
     const caseModel: ModelData = { ...model, loads: model.loads.filter(l => (l.data.caseId ?? 1) === lc.id) };
     const result = validateAndSolve2D(caseModel, includeSelfWeight && lc.type === 'D');
     if (typeof result === 'string') {
-      return `Error en caso "${lc.name}": ${result}`;
+      return t('svc.errorInCase').replace('{n}', lc.name).replace('{err}', result);
     }
     if (result) perCase.set(lc.id, result);
   }
 
-  if (perCase.size === 0) return 'Ningún caso de carga tiene cargas aplicadas';
+  if (perCase.size === 0) return t('svc.noLoadsApplied');
 
   const perCombo = new Map<number, AnalysisResults>();
 
@@ -721,19 +732,18 @@ export function solveCombinations2D(
   const allComboResults = Array.from(perCombo.values());
   const envelope = computeEnvelope(allComboResults);
 
-  if (!envelope) return 'No se pudieron calcular envolventes';
+  if (!envelope) return t('svc.envelopeError');
   return { perCase, perCombo, envelope };
 }
 
 // ─── 3D: buildSolverInput3D ──────────────────────────────────────
 
 /** Build a SolverInput3D from model data. Returns null if model is empty. */
-export function buildSolverInput3D(model: ModelData, includeSelfWeight = false, leftHand = false): SolverInput3D | null {
-  if (model.nodes.size < 2 || model.elements.size < 1 || model.supports.size < 1) return null;
-
+/** Build only the loads array for a 3D solver input (avoids rebuilding all structural Maps per case). */
+function buildSolverLoads3D(model: ModelData, loads: Load[], includeSelfWeight: boolean, leftHand: boolean): SolverLoad3D[] {
   const solverLoads: SolverLoad3D[] = [];
 
-  for (const l of model.loads) {
+  for (const l of loads) {
     if (l.type === 'nodal') {
       solverLoads.push({
         type: 'nodal',
@@ -873,9 +883,9 @@ export function buildSolverInput3D(model: ModelData, includeSelfWeight = false, 
       if (Math.abs(projAxial) > 1e-10) {
         const dz3d = (nj.z ?? 0) - (ni.z ?? 0);
         const L3d = Math.sqrt(edx * edx + edy * edy + dz3d * dz3d);
-        const t = d.a / L3d;
-        const fI = projAxial * (1 - t);
-        const fJ = projAxial * t;
+        const tFrac = d.a / L3d;
+        const fI = projAxial * (1 - tFrac);
+        const fJ = projAxial * tFrac;
         solverLoads.push(
           { type: 'nodal', data: { nodeId: elem.nodeI, fx: fI * axes.ex[0], fy: fI * axes.ex[1], fz: fI * axes.ex[2], mx: 0, my: 0, mz: 0 } },
           { type: 'nodal', data: { nodeId: elem.nodeJ, fx: fJ * axes.ex[0], fy: fJ * axes.ex[1], fz: fJ * axes.ex[2], mx: 0, my: 0, mz: 0 } },
@@ -887,6 +897,10 @@ export function buildSolverInput3D(model: ModelData, includeSelfWeight = false, 
         type: 'pointOnElement',
         data: { elementId: d.elementId, a: d.a, py: d.py, pz: d.pz },
       });
+    } else if (l.type === 'surface3d') {
+      if (model.quads) {
+        solverLoads.push(...convertSurfaceLoad(l.data as SurfaceLoad3D, model.quads, model.nodes));
+      }
     } else if (l.type === 'thermal') {
       const d = l.data as ThermalLoad;
       solverLoads.push({
@@ -898,6 +912,8 @@ export function buildSolverInput3D(model: ModelData, includeSelfWeight = false, 
           dtGradientZ: d.dtGradient,
         },
       });
+    } else if (l.type === 'thermalQuad3d') {
+      solverLoads.push(...convertThermalQuadLoad(l.data as ThermalLoadQuad3D));
     }
   }
 
@@ -910,23 +926,32 @@ export function buildSolverInput3D(model: ModelData, includeSelfWeight = false, 
       const nj = model.nodes.get(elem.nodeJ);
       if (!mat || !sec || !ni || !nj) continue;
       const dx = nj.x - ni.x;
-      const dy = nj.y - (ni.y);
+      const dy = nj.y - ni.y;
       const dz = (nj.z ?? 0) - (ni.z ?? 0);
       const L = Math.sqrt(dx * dx + dy * dy + dz * dz);
       if (L < 1e-10) continue;
-
       const w = mat.rho * sec.a;
       const totalWeight = w * L;
-      solverLoads.push({
-        type: 'nodal',
-        data: { nodeId: elem.nodeI, fx: 0, fy: -totalWeight / 2, fz: 0, mx: 0, my: 0, mz: 0 },
-      });
-      solverLoads.push({
-        type: 'nodal',
-        data: { nodeId: elem.nodeJ, fx: 0, fy: -totalWeight / 2, fz: 0, mx: 0, my: 0, mz: 0 },
-      });
+      solverLoads.push(
+        { type: 'nodal', data: { nodeId: elem.nodeI, fx: 0, fy: -totalWeight / 2, fz: 0, mx: 0, my: 0, mz: 0 } },
+        { type: 'nodal', data: { nodeId: elem.nodeJ, fx: 0, fy: -totalWeight / 2, fz: 0, mx: 0, my: 0, mz: 0 } },
+      );
+    }
+    if (model.plates?.size) {
+      solverLoads.push(...plateSelfWeightLoads(model.plates, model.nodes, model.materials));
+    }
+    if (model.quads?.size) {
+      solverLoads.push(...quadSelfWeightLoads(model.quads, model.nodes, model.materials));
     }
   }
+
+  return solverLoads;
+}
+
+export function buildSolverInput3D(model: ModelData, includeSelfWeight = false, leftHand = false): SolverInput3D | null {
+  if (model.nodes.size < 2 || model.elements.size < 1 || model.supports.size < 1) return null;
+
+  const solverLoads = buildSolverLoads3D(model, model.loads, includeSelfWeight, leftHand);
 
   // Convert support types to SolverSupport3D booleans
   const supportTo3D = (s: Support): { rx: boolean; ry: boolean; rz: boolean; rrx: boolean; rry: boolean; rrz: boolean } => {
@@ -1008,6 +1033,9 @@ export function buildSolverInput3D(model: ModelData, includeSelfWeight = false, 
       }];
     })),
     loads: solverLoads,
+    plates: model.plates ? new Map(Array.from(model.plates.entries()).map(([id, p]) => [id, { id: p.id, nodes: p.nodes, materialId: p.materialId, thickness: p.thickness }])) : new Map(),
+    quads: model.quads ? new Map(Array.from(model.quads.entries()).map(([id, q]) => [id, { id: q.id, nodes: q.nodes, materialId: q.materialId, thickness: q.thickness }])) : new Map(),
+    constraints: model.constraints ?? [],
     leftHand,
   };
 }
@@ -1017,21 +1045,22 @@ export function buildSolverInput3D(model: ModelData, includeSelfWeight = false, 
 /** Solve the current model using the 3D solver. Returns results or error string. */
 export function validateAndSolve3D(model: ModelData, includeSelfWeight = false, leftHand = false): AnalysisResults3D | string | null {
   if (model.nodes.size < 2 || model.elements.size < 1) {
-    return 'Necesita al menos 2 nodos y 1 elemento';
+    return t('svc.needNodesAndElements');
   }
   if (model.supports.size < 1) {
-    return 'Necesita al menos 1 apoyo';
+    return t('svc.needSupport');
   }
 
-  // Check for disconnected nodes
+  // Check for disconnected nodes (consider elements + PRO shell elements)
   const connectedNodes = new Set<number>();
   for (const elem of model.elements.values()) {
     connectedNodes.add(elem.nodeI);
     connectedNodes.add(elem.nodeJ);
   }
+  addShellConnectivity(connectedNodes, model.plates, model.quads);
   for (const nodeId of model.nodes.keys()) {
     if (!connectedNodes.has(nodeId)) {
-      return `Nodo ${nodeId} no está conectado a ningún elemento. Elimínelo o conéctelo.`;
+      return t('svc.disconnectedNode').replace('{n}', String(nodeId));
     }
   }
 
@@ -1043,18 +1072,19 @@ export function validateAndSolve3D(model: ModelData, includeSelfWeight = false, 
       const dx = nj.x - ni.x, dy = nj.y - ni.y, dz = (nj.z ?? 0) - (ni.z ?? 0);
       const L = Math.sqrt(dx * dx + dy * dy + dz * dz);
       if (L < 1e-6) {
-        return `Elemento ${elem.id} tiene longitud cero (nodos ${elem.nodeI} y ${elem.nodeJ} coinciden).`;
+        return t('svc.zeroLengthElement').replace('{n}', String(elem.id)).replace('{ni}', String(elem.nodeI)).replace('{nj}', String(elem.nodeJ));
       }
     }
   }
 
-  // Check graph connectivity
+  // Check graph connectivity (include plate/quad adjacency)
   const adj = new Map<number, Set<number>>();
   for (const nid of connectedNodes) adj.set(nid, new Set());
   for (const elem of model.elements.values()) {
     adj.get(elem.nodeI)!.add(elem.nodeJ);
     adj.get(elem.nodeJ)!.add(elem.nodeI);
   }
+  addShellAdjacency(adj, model.plates, model.quads);
   const visited = new Set<number>();
   const startNode = connectedNodes.values().next().value!;
   const queue = [startNode];
@@ -1067,11 +1097,11 @@ export function validateAndSolve3D(model: ModelData, includeSelfWeight = false, 
   }
   if (visited.size < connectedNodes.size) {
     const disconnected = [...connectedNodes].filter(n => !visited.has(n));
-    return `Estructura no conexa: los nodos ${disconnected.join(', ')} están desconectados del resto.`;
+    return t('svc.disconnectedGraph').replace('{ids}', disconnected.join(', '));
   }
 
   const input = buildSolverInput3D(model, includeSelfWeight, leftHand);
-  if (!input) return 'Modelo vacío';
+  if (!input) return t('svc.emptyModel');
 
   try {
     const t0 = performance.now();
@@ -1081,11 +1111,15 @@ export function validateAndSolve3D(model: ModelData, includeSelfWeight = false, 
       console.warn(`Solver 3D (${dt.toFixed(1)} ms): ${results}`);
     } else {
       console.log(`Estructura 3D resuelta en ${dt.toFixed(1)} ms — ${model.nodes.size} nodos, ${model.elements.size} elementos`);
+      // PRO-only: post-process shell stresses
+      if (model.quads?.size || model.plates?.size) {
+        postProcessShellStresses(results, model.nodes, model.quads ?? new Map(), model.plates ?? new Map(), model.materials);
+      }
     }
     return results;
   } catch (err: any) {
     console.error('Solver 3D error:', err);
-    return `Error al resolver 3D: ${err.message}`;
+    return t('svc.solver3dError').replace('{n}', err.message);
   }
 }
 
@@ -1098,33 +1132,237 @@ export function solveCombinations3D(
   includeSelfWeight = false,
   leftHand = false,
 ): { perCase: Map<number, AnalysisResults3D>; perCombo: Map<number, AnalysisResults3D>; envelope: FullEnvelope3D } | string | null {
-  if (model.nodes.size < 2 || model.elements.size < 1) return 'Necesita al menos 2 nodos y 1 elemento';
-  if (model.supports.size < 1) return 'Necesita al menos 1 apoyo';
-  if (combinations.length === 0) return 'Defina al menos una combinación de carga';
+  if (model.nodes.size < 2 || model.elements.size < 1) return t('svc.needNodesAndElements');
+  if (model.supports.size < 1) return t('svc.needSupport');
+  if (combinations.length === 0) return t('svc.needCombination');
 
+  const hasShells = (model.quads?.size ?? 0) > 0 || (model.plates?.size ?? 0) > 0;
+
+  // Build base solver input once (structural data without loads)
+  const baseInput = buildSolverInput3D({ ...model, loads: [] }, false, leftHand);
+  if (!baseInput) return t('svc.emptyModel');
+
+  // Build per-case load arrays — reuse baseInput structure, only build loads per case
+  const mcLoadCases: Array<{ name: string; loads: SolverLoad3D[] }> = [];
+  const caseNameToId = new Map<string, number>();
+
+  for (const lc of loadCases) {
+    const caseLoads = model.loads.filter(l => (l.data.caseId ?? 1) === lc.id);
+    const loads = buildSolverLoads3D(model, caseLoads, includeSelfWeight && lc.type === 'D', leftHand);
+    mcLoadCases.push({ name: lc.name, loads });
+    caseNameToId.set(lc.name, lc.id);
+  }
+
+  if (mcLoadCases.length === 0) return t('svc.noLoadsApplied');
+
+  // Build combination definitions (name-based factors for WASM multi-case)
+  const mcCombinations: Array<{ name: string; factors: Record<string, number> }> = [];
+  const comboNameToId = new Map<string, number>();
+
+  for (const combo of combinations) {
+    const factors: Record<string, number> = {};
+    for (const f of combo.factors) {
+      const lc = loadCases.find(c => c.id === f.caseId);
+      if (lc) factors[lc.name] = f.factor;
+    }
+    mcCombinations.push({ name: combo.name, factors });
+    comboNameToId.set(combo.name, combo.id);
+  }
+
+  // Single WASM call: solves all cases, combines, computes envelope
+  try {
+    const t0 = performance.now();
+    const mcResult = solveMultiCase3D({
+      solver: baseInput,
+      loadCases: mcLoadCases,
+      combinations: mcCombinations,
+    });
+    const tWasm = performance.now() - t0;
+
+    if (!mcResult || !mcResult.caseResults || !mcResult.combinationResults || !mcResult.envelope) {
+      return t('svc.envelopeError3d');
+    }
+
+    // Map results back to id-keyed Maps
+    const perCase = new Map<number, AnalysisResults3D>();
+    for (const cr of mcResult.caseResults) {
+      const id = caseNameToId.get(cr.name);
+      if (id != null) perCase.set(id, cr.results);
+    }
+
+    const perCombo = new Map<number, AnalysisResults3D>();
+    for (const cr of mcResult.combinationResults) {
+      const id = comboNameToId.get(cr.name);
+      if (id != null) perCombo.set(id, cr.results);
+    }
+
+    // Shell stress enrichment — only for per-case results (combos are derived on-demand)
+    const t1 = performance.now();
+    if (hasShells) {
+      const quads = model.quads ?? new Map();
+      const plates = model.plates ?? new Map();
+      for (const r of perCase.values()) {
+        postProcessShellStresses(r, model.nodes, quads, plates, model.materials);
+      }
+      for (const r of perCombo.values()) {
+        postProcessShellStresses(r, model.nodes, quads, plates, model.materials);
+      }
+    }
+    const tShell = performance.now() - t1;
+
+    console.log(`[solveCombinations3D] WASM: ${tWasm.toFixed(0)} ms | Shell enrichment: ${tShell.toFixed(0)} ms | Cases: ${perCase.size} | Combos: ${perCombo.size}`);
+
+    return { perCase, perCombo, envelope: mcResult.envelope };
+  } catch (err: any) {
+    // Fallback: if multi-case fails, try the old per-case approach
+    console.warn('Multi-case 3D failed, falling back to per-case solve:', err.message);
+    return solveCombinations3DFallback(model, loadCases, combinations, includeSelfWeight, leftHand);
+  }
+}
+
+/** Fallback: solve cases individually (used if multi-case WASM is unavailable) */
+function solveCombinations3DFallback(
+  model: ModelData,
+  loadCases: LoadCase[],
+  combinations: LoadCombination[],
+  includeSelfWeight: boolean,
+  leftHand: boolean,
+): { perCase: Map<number, AnalysisResults3D>; perCombo: Map<number, AnalysisResults3D>; envelope: FullEnvelope3D } | string | null {
+  const hasShells = (model.quads?.size ?? 0) > 0 || (model.plates?.size ?? 0) > 0;
   const perCase = new Map<number, AnalysisResults3D>();
 
   for (const lc of loadCases) {
-    // Filter loads for this case instead of mutating model.loads
     const caseModel: ModelData = { ...model, loads: model.loads.filter(l => (l.data.caseId ?? 1) === lc.id) };
-    const result = validateAndSolve3D(caseModel, includeSelfWeight && lc.type === 'D', leftHand);
-    if (typeof result === 'string') {
-      return `Error en caso 3D "${lc.name}": ${result}`;
+    const input = buildSolverInput3D(caseModel, includeSelfWeight && lc.type === 'D', leftHand);
+    if (!input) continue;
+    try {
+      const result = solve3DEngine(input);
+      if (typeof result === 'string') {
+        return t('svc.errorInCase3d').replace('{n}', lc.name).replace('{err}', result);
+      }
+      if (result) {
+        if (hasShells) postProcessShellStresses(result, model.nodes, model.quads ?? new Map(), model.plates ?? new Map(), model.materials);
+        perCase.set(lc.id, result);
+      }
+    } catch (err: any) {
+      return t('svc.errorInCase3d').replace('{n}', lc.name).replace('{err}', err.message);
     }
-    if (result) perCase.set(lc.id, result);
   }
 
-  if (perCase.size === 0) return 'Ningún caso de carga tiene cargas aplicadas';
+  if (perCase.size === 0) return t('svc.noLoadsApplied');
 
   const perCombo = new Map<number, AnalysisResults3D>();
   for (const combo of combinations) {
     const combined = combineResults3D(combo.factors, perCase);
-    if (combined) perCombo.set(combo.id, combined);
+    if (combined) {
+      if (hasShells) postProcessShellStresses(combined, model.nodes, model.quads ?? new Map(), model.plates ?? new Map(), model.materials);
+      perCombo.set(combo.id, combined);
+    }
   }
 
   const allComboResults = Array.from(perCombo.values());
   const envelope = computeEnvelope3D(allComboResults);
-
-  if (!envelope) return 'No se pudieron calcular envolventes 3D';
+  if (!envelope) return t('svc.envelopeError3d');
   return { perCase, perCombo, envelope };
+}
+
+// ─── 3D: Parallel solveCombinations3D (Web Workers) ──────────────
+
+/**
+ * Solve 3D load combinations in PARALLEL using Web Workers.
+ * Each load case is solved on a separate thread, then results are combined on the main thread.
+ * Falls back to sequential solving if workers fail to initialize.
+ */
+export async function solveCombinations3DParallel(
+  model: ModelData,
+  loadCases: LoadCase[],
+  combinations: LoadCombination[],
+  includeSelfWeight = false,
+  leftHand = false,
+): Promise<{ perCase: Map<number, AnalysisResults3D>; perCombo: Map<number, AnalysisResults3D>; envelope: FullEnvelope3D } | string | null> {
+  if (model.nodes.size < 2 || model.elements.size < 1) return t('svc.needNodesAndElements');
+  if (model.supports.size < 1) return t('svc.needSupport');
+  if (combinations.length === 0) return t('svc.needCombination');
+
+  const hasShells = (model.quads?.size ?? 0) > 0 || (model.plates?.size ?? 0) > 0;
+
+  // Build base solver input once (structural data without loads)
+  const baseInput = buildSolverInput3D({ ...model, loads: [] }, false, leftHand);
+  if (!baseInput) return t('svc.emptyModel');
+
+  // Serialize the base structure (shared across all cases)
+  const baseJson = JSON.parse(serializeInput3D(baseInput));
+
+  // Build per-case inputs
+  const caseInputs: Array<{ caseId: number; caseName: string; json: string }> = [];
+
+  for (const lc of loadCases) {
+    const caseLoads = model.loads.filter(l => (l.data.caseId ?? 1) === lc.id);
+    const loads = buildSolverLoads3D(model, caseLoads, includeSelfWeight && lc.type === 'D', leftHand);
+    // Create full solver input JSON with this case's loads
+    const fullInput = { ...baseJson, loads };
+    caseInputs.push({ caseId: lc.id, caseName: lc.name, json: JSON.stringify(fullInput) });
+  }
+
+  if (caseInputs.length === 0) return t('svc.noLoadsApplied');
+
+  // Try parallel solving via Web Workers
+  try {
+    // Initialize pool lazily (only on first use, workers persist for reuse)
+    if (!isPoolReady()) {
+      const numWorkers = Math.min(caseInputs.length, navigator.hardwareConcurrency ?? 4);
+      await initPool(numWorkers);
+    }
+
+    const t0 = performance.now();
+    const resultJsons = await solveParallel(
+      caseInputs.map(c => ({ id: c.caseId, json: c.json })),
+    );
+    const tSolve = performance.now() - t0;
+
+    // Parse results and build per-case map
+    const perCase = new Map<number, AnalysisResults3D>();
+    for (const ci of caseInputs) {
+      const rJson = resultJsons.get(ci.caseId);
+      if (!rJson) continue;
+      const result: AnalysisResults3D = JSON.parse(rJson);
+      if (hasShells) {
+        postProcessShellStresses(result, model.nodes, model.quads ?? new Map(), model.plates ?? new Map(), model.materials);
+      }
+      perCase.set(ci.caseId, result);
+    }
+
+    if (perCase.size === 0) return t('svc.noLoadsApplied');
+
+    // Combine results for each combination (fast, on main thread)
+    const t1 = performance.now();
+    const perCombo = new Map<number, AnalysisResults3D>();
+    for (const combo of combinations) {
+      const factors = combo.factors.map(f => ({
+        caseId: f.caseId,
+        factor: f.factor,
+      }));
+      const combined = combineResults3D(factors, perCase);
+      if (combined) {
+        if (hasShells) {
+          postProcessShellStresses(combined, model.nodes, model.quads ?? new Map(), model.plates ?? new Map(), model.materials);
+        }
+        perCombo.set(combo.id, combined);
+      }
+    }
+
+    // Compute envelope from all combo results
+    const allComboResults = Array.from(perCombo.values());
+    const envelope = computeEnvelope3D(allComboResults);
+    if (!envelope) return t('svc.envelopeError3d');
+
+    const tPost = performance.now() - t1;
+    console.log(`[solveCombinations3D parallel] Solve: ${tSolve.toFixed(0)} ms | Combine+envelope: ${tPost.toFixed(0)} ms | Cases: ${perCase.size} | Combos: ${perCombo.size} | Workers: ${Math.min(caseInputs.length, navigator.hardwareConcurrency ?? 4)}`);
+
+    return { perCase, perCombo, envelope };
+  } catch (err: any) {
+    // Fallback to synchronous solving if workers fail
+    console.warn('Parallel solve failed, falling back to sequential:', err.message);
+    return solveCombinations3D(model, loadCases, combinations, includeSelfWeight, leftHand);
+  }
 }

--- a/web/src/lib/engine/solver-shells.ts
+++ b/web/src/lib/engine/solver-shells.ts
@@ -1,0 +1,189 @@
+/**
+ * solver-shells.ts — PRO-only shell element solver helpers.
+ *
+ * Extracts all plate/quad (DKT, MITC4) logic from the main solver-service
+ * so that Basic 3D mode never touches shell code paths.
+ *
+ * Used exclusively when analysisMode === 'pro'.
+ */
+
+import type { SolverLoad3D, AnalysisResults3D } from './types-3d';
+import type { Node, Material, SurfaceLoad3D, ThermalLoadQuad3D } from '../store/model.svelte';
+import { enrichWithShellStresses } from './shell-stress-recovery';
+
+// ─── Types ───────────────────────────────────────────────────────
+
+interface PlateData {
+  id: number;
+  nodes: [number, number, number];
+  materialId: number;
+  thickness: number;
+}
+
+interface QuadData {
+  id: number;
+  nodes: [number, number, number, number];
+  materialId: number;
+  thickness: number;
+}
+
+// ─── Geometry helpers ────────────────────────────────────────────
+
+function triArea3D(a: Node, b: Node, c: Node): number {
+  const ex = b.x - a.x, ey = b.y - a.y, ez = (b.z ?? 0) - (a.z ?? 0);
+  const fx = c.x - a.x, fy = c.y - a.y, fz = (c.z ?? 0) - (a.z ?? 0);
+  return 0.5 * Math.sqrt(
+    (ey * fz - ez * fy) ** 2 + (ez * fx - ex * fz) ** 2 + (ex * fy - ey * fx) ** 2,
+  );
+}
+
+// ─── Surface loads (PRO-only load type) ──────────────────────────
+
+/** Convert a surface3d pressure load on a quad to equivalent nodal loads. */
+export function convertSurfaceLoad(
+  load: SurfaceLoad3D,
+  quads: Map<number, QuadData>,
+  nodes: Map<number, Node>,
+): SolverLoad3D[] {
+  const out: SolverLoad3D[] = [];
+  const quad = quads.get(load.quadId);
+  if (!quad) return out;
+
+  const ns = quad.nodes.map(nid => nodes.get(nid));
+  if (ns.some(n => !n)) return out;
+  const [p0, p1, p2, p3] = ns as [Node, Node, Node, Node];
+
+  const area = triArea3D(p0, p1, p2) + triArea3D(p0, p2, p3);
+  const F = -load.q * area / 4; // negative Y = downward
+
+  for (const nid of quad.nodes) {
+    out.push({
+      type: 'nodal',
+      data: { nodeId: nid, fx: 0, fy: F, fz: 0, mx: 0, my: 0, mz: 0 },
+    });
+  }
+  return out;
+}
+
+/** Placeholder for thermal quad loads (not yet implemented in solver). */
+export function convertThermalQuadLoad(_load: ThermalLoadQuad3D): SolverLoad3D[] {
+  // TODO: Convert quad thermal loads when solver exposes SolverThermalLoadQuad.
+  return [];
+}
+
+// ─── Self-weight for shell elements ──────────────────────────────
+
+/** Compute self-weight nodal loads for DKT plate elements. */
+export function plateSelfWeightLoads(
+  plates: Map<number, PlateData>,
+  nodes: Map<number, Node>,
+  materials: Map<number, Material>,
+): SolverLoad3D[] {
+  const out: SolverLoad3D[] = [];
+  for (const plate of plates.values()) {
+    const mat = materials.get(plate.materialId);
+    if (!mat) continue;
+    const ns = plate.nodes.map(nid => nodes.get(nid));
+    if (ns.some(n => !n)) continue;
+    const [p0, p1, p2] = ns as [Node, Node, Node];
+    const area = triArea3D(p0, p1, p2);
+    const totalWeight = mat.rho * plate.thickness * area;
+    const wPerNode = -totalWeight / 3;
+    for (const nid of plate.nodes) {
+      out.push({
+        type: 'nodal',
+        data: { nodeId: nid, fx: 0, fy: wPerNode, fz: 0, mx: 0, my: 0, mz: 0 },
+      });
+    }
+  }
+  return out;
+}
+
+/** Compute self-weight nodal loads for MITC4 quad elements. */
+export function quadSelfWeightLoads(
+  quads: Map<number, QuadData>,
+  nodes: Map<number, Node>,
+  materials: Map<number, Material>,
+): SolverLoad3D[] {
+  const out: SolverLoad3D[] = [];
+  for (const quad of quads.values()) {
+    const mat = materials.get(quad.materialId);
+    if (!mat) continue;
+    const ns = quad.nodes.map(nid => nodes.get(nid));
+    if (ns.some(n => !n)) continue;
+    const [p0, p1, p2, p3] = ns as [Node, Node, Node, Node];
+    const area = triArea3D(p0, p1, p2) + triArea3D(p0, p2, p3);
+    const totalWeight = mat.rho * quad.thickness * area;
+    const wPerNode = -totalWeight / 4;
+    for (const nid of quad.nodes) {
+      out.push({
+        type: 'nodal',
+        data: { nodeId: nid, fx: 0, fy: wPerNode, fz: 0, mx: 0, my: 0, mz: 0 },
+      });
+    }
+  }
+  return out;
+}
+
+// ─── Shell connectivity for validation ───────────────────────────
+
+/** Add plate/quad node IDs to a connected-nodes set. */
+export function addShellConnectivity(
+  connectedNodes: Set<number>,
+  plates?: Map<number, PlateData>,
+  quads?: Map<number, QuadData>,
+): void {
+  if (plates) {
+    for (const plate of plates.values()) {
+      for (const nid of plate.nodes) connectedNodes.add(nid);
+    }
+  }
+  if (quads) {
+    for (const quad of quads.values()) {
+      for (const nid of quad.nodes) connectedNodes.add(nid);
+    }
+  }
+}
+
+/** Add plate/quad edge adjacency to a graph adjacency map. */
+export function addShellAdjacency(
+  adj: Map<number, Set<number>>,
+  plates?: Map<number, PlateData>,
+  quads?: Map<number, QuadData>,
+): void {
+  if (plates) {
+    for (const plate of plates.values()) {
+      for (let i = 0; i < plate.nodes.length; i++) {
+        for (let j = i + 1; j < plate.nodes.length; j++) {
+          adj.get(plate.nodes[i])?.add(plate.nodes[j]);
+          adj.get(plate.nodes[j])?.add(plate.nodes[i]);
+        }
+      }
+    }
+  }
+  if (quads) {
+    for (const quad of quads.values()) {
+      for (let i = 0; i < quad.nodes.length; i++) {
+        for (let j = i + 1; j < quad.nodes.length; j++) {
+          adj.get(quad.nodes[i])?.add(quad.nodes[j]);
+          adj.get(quad.nodes[j])?.add(quad.nodes[i]);
+        }
+      }
+    }
+  }
+}
+
+// ─── Shell stress post-processing ────────────────────────────────
+
+/** Run shell stress recovery on solver results (PRO-only post-processing). */
+export function postProcessShellStresses(
+  results: AnalysisResults3D,
+  nodes: Map<number, Node>,
+  quads: Map<number, QuadData>,
+  plates: Map<number, PlateData>,
+  materials: Map<number, Material>,
+): void {
+  if (quads.size > 0 || plates.size > 0) {
+    enrichWithShellStresses(results, nodes, quads as any, plates as any, materials);
+  }
+}

--- a/web/src/lib/engine/solver-worker.ts
+++ b/web/src/lib/engine/solver-worker.ts
@@ -1,0 +1,47 @@
+/**
+ * Web Worker for parallel 3D structural solving.
+ * Each worker loads its own WASM instance and solves independently.
+ *
+ * Messages:
+ *   { type: 'init', wasmBytes: ArrayBuffer }  → initialize WASM module
+ *   { type: 'solve3d', id: number, json: string } → solve and return results
+ */
+
+let initSync: ((moduleOrBytes: any) => void) | null = null;
+let solve_3d: ((json: string) => string) | null = null;
+let ready = false;
+
+self.onmessage = async (e: MessageEvent) => {
+  const msg = e.data;
+
+  if (msg.type === 'init') {
+    try {
+      // Dynamic import so the build doesn't fail when WASM files are absent
+      const wasm = await import(/* @vite-ignore */ '../wasm/dedaliano_engine.js');
+      initSync = wasm.initSync;
+      solve_3d = wasm.solve_3d;
+
+      const module = new WebAssembly.Module(msg.wasmBytes);
+      initSync(module);
+      ready = true;
+      self.postMessage({ type: 'ready' });
+    } catch (err: any) {
+      self.postMessage({ type: 'error', message: `Worker init failed: ${err.message}` });
+    }
+    return;
+  }
+
+  if (msg.type === 'solve3d') {
+    if (!ready || !solve_3d) {
+      self.postMessage({ type: 'result', id: msg.id, error: 'Worker not initialized' });
+      return;
+    }
+    try {
+      const resultJson = solve_3d(msg.json);
+      self.postMessage({ type: 'result', id: msg.id, resultJson });
+    } catch (err: any) {
+      self.postMessage({ type: 'result', id: msg.id, error: err.message });
+    }
+    return;
+  }
+};

--- a/web/src/lib/engine/spectral-3d.ts
+++ b/web/src/lib/engine/spectral-3d.ts
@@ -1,0 +1,384 @@
+// Response Spectrum Analysis for 3D Structures — Modal Spectral Method
+//
+// Combines 3D modal analysis results with a design response spectrum
+// to compute peak structural responses (displacements, forces).
+//
+// References:
+//   - Chopra, "Dynamics of Structures" (4th ed.), Ch. 13
+//   - INPRES-CIRSOC 103, Part I (Argentine seismic code)
+
+import { getSpectralAcceleration, cirsoc103Spectrum } from './spectral';
+import type { DesignSpectrum, CombinationRule } from './spectral';
+import type { ModalResult3D, ModeShape3D } from './modal-3d';
+import { assemble3D, buildDofNumbering3D, computeInternalForces3D, globalDof3D } from './solver-3d';
+import type { DofNumbering3D } from './solver-3d';
+import type { SolverInput3D, AnalysisResults3D, Displacement3D, Reaction3D, ElementForces3D } from './types-3d';
+import type { SolverDiagnostic } from './types';
+import { buildMassMatrix3D } from './mass-matrix-3d';
+import { matVec } from './matrix-utils';
+
+// ─── Configuration ───────────────────────────────────────────────
+
+export interface SpectralConfig3D {
+  direction: 'X' | 'Y' | 'Z';
+  spectrum: DesignSpectrum;
+  rule?: CombinationRule;       // 'SRSS' | 'CQC', default CQC
+  xi?: number;                  // damping ratio, default 0.05
+  importanceFactor?: number;    // default 1.0
+  reductionFactor?: number;     // R factor, default 1.0
+}
+
+// ─── Results ─────────────────────────────────────────────────────
+
+export interface SpectralResult3D {
+  baseShear: number;  // kN
+  results: AnalysisResults3D;  // peak envelope
+  perMode: Array<{
+    mode: number;
+    period: number;
+    sa: number;      // spectral acceleration (m/s²)
+    shear: number;   // modal base shear (kN)
+  }>;
+  rule: CombinationRule;
+  diagnostics?: SolverDiagnostic[];
+}
+
+// ─── CQC Correlation ─────────────────────────────────────────────
+
+/**
+ * CQC correlation coefficient (Chopra Eq. 13.7.5)
+ * ρ_ij = 8·ξ²·(1+r)·r^(3/2) / ((1-r²)² + 4·ξ²·r·(1+r)²)
+ * where r = ωi/ωj
+ */
+function cqcCoefficient(omegaI: number, omegaJ: number, xi: number): number {
+  const r = omegaI / omegaJ;
+  const xi2 = xi * xi;
+  const r2 = r * r;
+  const num = 8 * xi2 * (1 + r) * Math.pow(r, 1.5);
+  const den = (1 - r2) * (1 - r2) + 4 * xi2 * r * (1 + r) * (1 + r);
+  return den > 1e-20 ? num / den : (Math.abs(r - 1) < 0.01 ? 1 : 0);
+}
+
+/**
+ * Combine modal response values using SRSS or CQC.
+ * @param values  Per-mode response values
+ * @param omegas  Per-mode angular frequencies (for CQC)
+ * @param rule    Combination rule
+ * @param xi      Damping ratio
+ */
+function combineModal(
+  values: number[],
+  omegas: number[],
+  rule: CombinationRule,
+  xi: number,
+): number {
+  if (values.length === 0) return 0;
+
+  if (rule === 'SRSS') {
+    let sum = 0;
+    for (const v of values) sum += v * v;
+    return Math.sqrt(sum);
+  }
+
+  // CQC: R = sqrt(sum_i sum_j rho_ij * r_i * r_j)
+  let sum = 0;
+  for (let i = 0; i < values.length; i++) {
+    for (let j = 0; j < values.length; j++) {
+      const rho = cqcCoefficient(omegas[i], omegas[j], xi);
+      sum += values[i] * rho * values[j];
+    }
+  }
+  return Math.sqrt(Math.abs(sum));
+}
+
+// ─── DOF direction mapping ───────────────────────────────────────
+
+/** Map direction label to DOF index: X=0, Y=1, Z=2 */
+function directionDofIndex(dir: 'X' | 'Y' | 'Z'): number {
+  return dir === 'X' ? 0 : dir === 'Y' ? 1 : 2;
+}
+
+// ─── Main solver ─────────────────────────────────────────────────
+
+/**
+ * 3D Response Spectrum Analysis (Chopra Ch. 13).
+ *
+ * Steps:
+ * 1. For each mode m, get Sa_m = Sa(T_m) from the design spectrum
+ * 2. Peak modal displacement: u_m = Gamma_dir * Sa / omega^2 * phi_m
+ * 3. Compute element forces for each mode displacement
+ * 4. Combine modes via SRSS or CQC
+ */
+export function solveSpectral3D(
+  input: SolverInput3D,
+  modalResult: ModalResult3D,
+  densities: Map<number, number>,
+  config: SpectralConfig3D,
+): SpectralResult3D | string {
+  const rule = config.rule ?? 'CQC';
+  const xi = config.xi ?? 0.05;
+  const I = config.importanceFactor ?? 1.0;
+  const R = config.reductionFactor ?? 1.0;
+  const g = 9.81; // m/s²
+
+  const modes = modalResult.modes;
+  if (modes.length === 0) return 'No modes available for spectral analysis.';
+
+  const dofNum = buildDofNumbering3D(input);
+  const nf = dofNum.nFree;
+  const nt = dofNum.nTotal;
+
+  // Build mass matrix (needed for effective mass / participation)
+  const Mff = buildMassMatrix3D(input, dofNum, densities);
+
+  // Build influence vector for the specified direction
+  const dirDof = directionDofIndex(config.direction);
+  const rDir = new Float64Array(nf);
+  for (const [nodeId] of input.nodes) {
+    const key = `${nodeId}:${dirDof}`;
+    const idx = dofNum.map.get(key);
+    if (idx !== undefined && idx < nf) rDir[idx] = 1;
+  }
+
+  // M * rDir (used for participation factors)
+  const MrDir = matVec(Mff, rDir, nf);
+
+  // Per-mode data
+  const perMode: SpectralResult3D['perMode'] = [];
+  const modalDisplacements: Float64Array[] = [];
+  const modalElementForces: ElementForces3D[][] = [];
+  const modalReactions: Reaction3D[][] = [];
+  const omegas: number[] = [];
+
+  for (let m = 0; m < modes.length; m++) {
+    const mode = modes[m];
+    const T = mode.period;
+    let saRaw = getSpectralAcceleration(config.spectrum, T);
+
+    // Convert to m/s² if in g
+    if (config.spectrum.inG !== false) saRaw *= g;
+
+    // Apply importance and reduction factors
+    const sa = saRaw * I / R;
+    const sd = mode.omega > 1e-10 ? sa / (mode.omega * mode.omega) : 0;
+
+    // Extract raw eigenvector DOF values from mode shape displacements
+    const phiRaw = new Float64Array(nf);
+    for (const d of mode.displacements) {
+      const dofMap: [number, number][] = [
+        [0, d.ux], [1, d.uy], [2, d.uz],
+        [3, d.rx], [4, d.ry], [5, d.rz],
+      ];
+      for (const [dofIdx, val] of dofMap) {
+        const key = `${d.nodeId}:${dofIdx}`;
+        const gIdx = dofNum.map.get(key);
+        if (gIdx !== undefined && gIdx < nf) phiRaw[gIdx] = val;
+      }
+    }
+
+    // Participation factor: Gamma = phi^T * M * r / (phi^T * M * phi)
+    const Mphi = matVec(Mff, phiRaw, nf);
+    let phiMphi = 0;
+    for (let i = 0; i < nf; i++) phiMphi += phiRaw[i] * Mphi[i];
+    let phiMr = 0;
+    for (let i = 0; i < nf; i++) phiMr += phiRaw[i] * MrDir[i];
+
+    const gamma = phiMphi > 1e-20 ? phiMr / phiMphi : 0;
+
+    // Effective modal mass
+    const meff = gamma * gamma * phiMphi;
+
+    // Peak modal displacement vector: u_m = Gamma * Sd * phi
+    const uModal = new Float64Array(nf);
+    const scaleFactor = gamma * sd;
+    for (let i = 0; i < nf; i++) uModal[i] = phiRaw[i] * scaleFactor;
+    modalDisplacements.push(uModal);
+
+    // Build full displacement vector for internal forces computation
+    const uAll = new Float64Array(nt);
+    for (let i = 0; i < nf; i++) uAll[i] = uModal[i];
+
+    const ef = computeInternalForces3D(input, dofNum, uAll);
+    modalElementForces.push(ef);
+
+    // Compute reactions for this mode
+    const { K, F } = assemble3D(input, dofNum);
+    const reactions: Reaction3D[] = [];
+    for (const sup of input.supports.values()) {
+      const nodeId = sup.nodeId;
+      const fx = computeReactionComponent(K, uAll, F, dofNum, nodeId, 0, nt);
+      const fy = computeReactionComponent(K, uAll, F, dofNum, nodeId, 1, nt);
+      const fz = computeReactionComponent(K, uAll, F, dofNum, nodeId, 2, nt);
+      const mx = computeReactionComponent(K, uAll, F, dofNum, nodeId, 3, nt);
+      const my = computeReactionComponent(K, uAll, F, dofNum, nodeId, 4, nt);
+      const mz = computeReactionComponent(K, uAll, F, dofNum, nodeId, 5, nt);
+      reactions.push({ nodeId, fx, fy, fz, mx, my, mz });
+    }
+    modalReactions.push(reactions);
+
+    // Modal base shear: Meff * Sa
+    const modalShear = meff * sa;
+
+    omegas.push(mode.omega);
+    perMode.push({
+      mode: m + 1,
+      period: T,
+      sa: saRaw,  // store raw Sa (before I/R)
+      shear: modalShear,
+    });
+  }
+
+  // ─── Combine modal responses ───────────────────────────────────
+
+  // Displacements
+  const displacements: Displacement3D[] = [];
+  for (const [nodeId] of input.nodes) {
+    const components: number[][] = [[], [], [], [], [], []]; // ux, uy, uz, rx, ry, rz
+    for (let m = 0; m < modes.length; m++) {
+      for (let d = 0; d < 6; d++) {
+        const key = `${nodeId}:${d}`;
+        const gIdx = dofNum.map.get(key);
+        const val = (gIdx !== undefined && gIdx < nf) ? modalDisplacements[m][gIdx] : 0;
+        components[d].push(val);
+      }
+    }
+    displacements.push({
+      nodeId,
+      ux: combineModal(components[0], omegas, rule, xi),
+      uy: combineModal(components[1], omegas, rule, xi),
+      uz: combineModal(components[2], omegas, rule, xi),
+      rx: combineModal(components[3], omegas, rule, xi),
+      ry: combineModal(components[4], omegas, rule, xi),
+      rz: combineModal(components[5], omegas, rule, xi),
+    });
+  }
+
+  // Reactions
+  const reactions: Reaction3D[] = [];
+  for (const sup of input.supports.values()) {
+    const nodeId = sup.nodeId;
+    const fxVals: number[] = [], fyVals: number[] = [], fzVals: number[] = [];
+    const mxVals: number[] = [], myVals: number[] = [], mzVals: number[] = [];
+    for (let m = 0; m < modes.length; m++) {
+      const r = modalReactions[m].find(r => r.nodeId === nodeId);
+      fxVals.push(r?.fx ?? 0);
+      fyVals.push(r?.fy ?? 0);
+      fzVals.push(r?.fz ?? 0);
+      mxVals.push(r?.mx ?? 0);
+      myVals.push(r?.my ?? 0);
+      mzVals.push(r?.mz ?? 0);
+    }
+    reactions.push({
+      nodeId,
+      fx: combineModal(fxVals, omegas, rule, xi),
+      fy: combineModal(fyVals, omegas, rule, xi),
+      fz: combineModal(fzVals, omegas, rule, xi),
+      mx: combineModal(mxVals, omegas, rule, xi),
+      my: combineModal(myVals, omegas, rule, xi),
+      mz: combineModal(mzVals, omegas, rule, xi),
+    });
+  }
+
+  // Element forces
+  const elementForces: ElementForces3D[] = [];
+  // Use first mode's element forces as template for element list
+  const templateForces = modalElementForces[0] ?? [];
+
+  for (const template of templateForces) {
+    const eid = template.elementId;
+    const forceComponents: Record<string, number[]> = {
+      nStart: [], nEnd: [],
+      vyStart: [], vyEnd: [],
+      vzStart: [], vzEnd: [],
+      mxStart: [], mxEnd: [],
+      myStart: [], myEnd: [],
+      mzStart: [], mzEnd: [],
+    };
+
+    for (let m = 0; m < modes.length; m++) {
+      const ef = modalElementForces[m].find(e => e.elementId === eid);
+      forceComponents.nStart.push(ef?.nStart ?? 0);
+      forceComponents.nEnd.push(ef?.nEnd ?? 0);
+      forceComponents.vyStart.push(ef?.vyStart ?? 0);
+      forceComponents.vyEnd.push(ef?.vyEnd ?? 0);
+      forceComponents.vzStart.push(ef?.vzStart ?? 0);
+      forceComponents.vzEnd.push(ef?.vzEnd ?? 0);
+      forceComponents.mxStart.push(ef?.mxStart ?? 0);
+      forceComponents.mxEnd.push(ef?.mxEnd ?? 0);
+      forceComponents.myStart.push(ef?.myStart ?? 0);
+      forceComponents.myEnd.push(ef?.myEnd ?? 0);
+      forceComponents.mzStart.push(ef?.mzStart ?? 0);
+      forceComponents.mzEnd.push(ef?.mzEnd ?? 0);
+    }
+
+    elementForces.push({
+      elementId: eid,
+      length: template.length,
+      nStart: combineModal(forceComponents.nStart, omegas, rule, xi),
+      nEnd: combineModal(forceComponents.nEnd, omegas, rule, xi),
+      vyStart: combineModal(forceComponents.vyStart, omegas, rule, xi),
+      vyEnd: combineModal(forceComponents.vyEnd, omegas, rule, xi),
+      vzStart: combineModal(forceComponents.vzStart, omegas, rule, xi),
+      vzEnd: combineModal(forceComponents.vzEnd, omegas, rule, xi),
+      mxStart: combineModal(forceComponents.mxStart, omegas, rule, xi),
+      mxEnd: combineModal(forceComponents.mxEnd, omegas, rule, xi),
+      myStart: combineModal(forceComponents.myStart, omegas, rule, xi),
+      myEnd: combineModal(forceComponents.myEnd, omegas, rule, xi),
+      mzStart: combineModal(forceComponents.mzStart, omegas, rule, xi),
+      mzEnd: combineModal(forceComponents.mzEnd, omegas, rule, xi),
+      hingeStart: template.hingeStart,
+      hingeEnd: template.hingeEnd,
+      // Envelope has no meaningful load data (spectral is peak response)
+      qYI: 0, qYJ: 0,
+      distributedLoadsY: [],
+      pointLoadsY: [],
+      qZI: 0, qZJ: 0,
+      distributedLoadsZ: [],
+      pointLoadsZ: [],
+    });
+  }
+
+  // Base shear: combine modal base shears
+  const baseShearVals = perMode.map(pm => pm.shear);
+  const baseShear = combineModal(baseShearVals, omegas, rule, xi);
+
+  const diags: SolverDiagnostic[] = [];
+  if (modalResult.cumulativeMassRatioX < 0.9 || modalResult.cumulativeMassRatioY < 0.9 || modalResult.cumulativeMassRatioZ < 0.9) {
+    diags.push({ severity: 'warning', code: 'SPECTRAL_INSUFFICIENT_MODES', message: 'diag.spectralInsufficientModes', source: 'solver', details: { x: modalResult.cumulativeMassRatioX, y: modalResult.cumulativeMassRatioY, z: modalResult.cumulativeMassRatioZ } });
+  }
+
+  return {
+    baseShear,
+    results: { displacements, reactions, elementForces },
+    perMode,
+    rule,
+    diagnostics: diags.length > 0 ? diags : undefined,
+  };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+/**
+ * Compute a single reaction component for a restrained DOF.
+ * R_i = sum_j K[i][j]*u[j] - F[i]  (for restrained DOF i)
+ */
+function computeReactionComponent(
+  K: Float64Array, u: Float64Array, F: Float64Array,
+  dofNum: DofNumbering3D, nodeId: number, localDof: number,
+  nt: number,
+): number {
+  const gIdx = globalDof3D(dofNum, nodeId, localDof);
+  if (gIdx === undefined || gIdx < dofNum.nFree) return 0;
+
+  let reaction = 0;
+  for (let j = 0; j < nt; j++) {
+    reaction += K[gIdx * nt + j] * u[j];
+  }
+  reaction -= F[gIdx];
+  return reaction;
+}
+
+// ─── Re-exports for convenience ──────────────────────────────────
+
+export { cirsoc103Spectrum, getSpectralAcceleration } from './spectral';
+export type { DesignSpectrum, CombinationRule } from './spectral';

--- a/web/src/lib/engine/spectral.ts
+++ b/web/src/lib/engine/spectral.ts
@@ -13,6 +13,7 @@ import type { AnalysisResults, ElementForces, SolverInput } from './types';
 import { buildDofNumbering, assemble, computeInternalForces } from './solver-js';
 import { assembleMassMatrix } from './mass-matrix';
 import { matVec } from './matrix-utils';
+import { t } from '../i18n';
 
 // ─── Design Spectrum ─────────────────────────────────────────────
 
@@ -197,7 +198,7 @@ export function solveSpectral(
   const g = 9.81; // m/s²
 
   const modes = modalResult.modes;
-  if (modes.length === 0) return 'No hay modos disponibles';
+  if (modes.length === 0) return t('spectral.noModes');
 
   const dofNum = buildDofNumbering(input);
   const nf = dofNum.nFree;

--- a/web/src/lib/engine/types-3d.ts
+++ b/web/src/lib/engine/types-3d.ts
@@ -1,8 +1,8 @@
 // 3D Structural Analysis Types
 // Phase 1: Engine Core — types for 3D frame/truss solver (6 DOF/node)
 
-import type { SolverMaterial } from './types';
-export type { SolverMaterial };
+import type { SolverMaterial, SolverDiagnostic, ConstraintForce, DiagnosticSeverity } from './types';
+export type { SolverMaterial, SolverDiagnostic, ConstraintForce, DiagnosticSeverity };
 
 // ─── Geometry ────────────────────────────────────────────────────
 
@@ -121,6 +121,88 @@ export type SolverLoad3D =
   | { type: 'pointOnElement'; data: SolverPointLoad3D }
   | { type: 'thermal'; data: SolverThermalLoad3D };
 
+// ─── Shell / Plate Elements ─────────────────────────────────────
+
+/** Shell element families — currently implemented + planned */
+export type ShellFamily =
+  | 'DKT'       // 3-node thin plate (Kirchhoff) — implemented
+  | 'DKMT'      // 3-node thick plate (Mindlin)  — planned
+  | 'MITC4'     // 4-node quad, thin/thick        — implemented
+  | 'MITC9'     // 9-node quad, higher accuracy   — planned
+  | 'SHB8PS';   // 8-node solid-shell (ANS)       — planned
+
+/** Families that are actually available in the solver */
+export const AVAILABLE_SHELL_FAMILIES: readonly ShellFamily[] = ['DKT', 'MITC4'] as const;
+
+/** Result of the shell family selector — choice + explanation */
+export interface ShellRecommendation {
+  family: ShellFamily;
+  reason: string;            // human-readable explanation
+  confidence: 'high' | 'medium' | 'low';
+  alternatives: Array<{
+    family: ShellFamily;
+    reason: string;
+    available: boolean;      // implemented in solver?
+  }>;
+  warnings: string[];        // e.g. "element is highly warped"
+  metrics: {                 // computed geometry diagnostics
+    aspectRatio?: number;    // max edge / min edge
+    warpAngle?: number;      // degrees, 0 = perfectly flat (quads only)
+    skewAngle?: number;      // degrees, 90 = perfect (quads only)
+    thicknessRatio?: number; // t / min_edge_length
+  };
+}
+
+/** DKT triangular plate element (3-node shell) */
+export interface SolverPlateElement {
+  id: number;
+  nodes: [number, number, number]; // 3 node IDs
+  materialId: number;
+  thickness: number; // m
+  shellFamily?: ShellFamily;
+}
+
+/** MITC4 quadrilateral shell element (4-node shell) */
+export interface SolverQuadElement {
+  id: number;
+  nodes: [number, number, number, number]; // 4 node IDs
+  materialId: number;
+  thickness: number; // m
+  shellFamily?: ShellFamily;
+}
+
+// ─── Constraints ────────────────────────────────────────────────
+
+export type ConstraintType = 'rigidLink' | 'diaphragm' | 'equalDof' | 'linearMpc';
+
+export interface RigidLinkConstraint {
+  type: 'rigidLink';
+  masterNode: number;
+  slaveNode: number;
+  dofs?: number[]; // optional, empty = all translational
+}
+
+export interface DiaphragmConstraint {
+  type: 'diaphragm';
+  masterNode: number;
+  slaveNodes: number[];
+  plane?: string; // default "XY"
+}
+
+export interface EqualDofConstraint {
+  type: 'equalDof';
+  masterNode: number;
+  slaveNode: number;
+  dofs: number[];
+}
+
+export interface LinearMpcConstraint {
+  type: 'linearMpc';
+  terms: Array<{ nodeId: number; dof: number; coefficient: number }>;
+}
+
+export type Constraint3D = RigidLinkConstraint | DiaphragmConstraint | EqualDofConstraint | LinearMpcConstraint;
+
 // ─── Input ───────────────────────────────────────────────────────
 
 export interface SolverInput3D {
@@ -130,6 +212,9 @@ export interface SolverInput3D {
   elements: Map<number, SolverElement3D>;
   supports: Map<number, SolverSupport3D>;
   loads: SolverLoad3D[];
+  plates?: Map<number, SolverPlateElement>;
+  quads?: Map<number, SolverQuadElement>;
+  constraints?: Constraint3D[];
   leftHand?: boolean;  // Terna izquierda: negate ey in local axes
 }
 
@@ -192,10 +277,43 @@ export interface ElementForces3D {
   pointLoadsZ: Array<{ a: number; p: number }>;
 }
 
+/** Plate stress output (triangular) */
+export interface PlateStress {
+  elementId: number;
+  sigmaXx: number;
+  sigmaYy: number;
+  tauXy: number;
+  mx: number;
+  my: number;
+  mxy: number;
+  sigma1: number;
+  sigma2: number;
+  vonMises: number;
+  nodalVonMises?: number[];
+}
+
+/** Quad stress output */
+export interface QuadStress {
+  elementId: number;
+  sigmaXx: number;
+  sigmaYy: number;
+  tauXy: number;
+  mx: number;
+  my: number;
+  mxy: number;
+  vonMises: number;
+  nodalVonMises?: number[];
+}
+
 export interface AnalysisResults3D {
   displacements: Displacement3D[];
   reactions: Reaction3D[];
   elementForces: ElementForces3D[];
+  constraintForces?: import('./types').ConstraintForce[];
+  diagnostics?: import('./types').AssemblyDiagnostic[];
+  plateStresses?: PlateStress[];
+  quadStresses?: QuadStress[];
+  solverDiagnostics?: import('./types').SolverDiagnostic[];
 }
 
 // ─── Envelope types for 3D load combinations ─────────────────

--- a/web/src/lib/engine/types.ts
+++ b/web/src/lib/engine/types.ts
@@ -127,10 +127,34 @@ export interface ElementForces {
   hingeEnd: boolean;
 }
 
+export interface ConstraintForce {
+  nodeId: number;
+  dof: string;   // "ux", "uy", "rz", etc.
+  force: number; // kN or kN·m
+}
+
+export interface AssemblyDiagnostic {
+  elementId: number;
+  elementType: string;
+  metric: string;
+  value: number;
+  threshold: number;
+  message: string;
+}
+
+export interface SolverDiagnostic {
+  category: string;
+  message: string;
+  severity: 'info' | 'warning' | 'error';
+}
+
 export interface AnalysisResults {
   displacements: Displacement[];
   reactions: Reaction[];
   elementForces: ElementForces[];
+  constraintForces?: ConstraintForce[];
+  diagnostics?: AssemblyDiagnostic[];
+  solverDiagnostics?: SolverDiagnostic[];
 }
 
 /** Envolvente puntual pre-computada para un elemento */
@@ -151,6 +175,22 @@ export interface EnvelopeDiagramData {
   /** Máximo absoluto global (para escala uniforme) */
   globalMax: number;
 }
+
+// ─── Diagnostics ───────────────────────────────────────────────
+
+export type DiagnosticSeverity = 'error' | 'warning' | 'info';
+
+/** A single diagnostic message from the solver, verifier, or post-processor */
+export interface SolverDiagnostic {
+  severity: DiagnosticSeverity;
+  code: string;                    // machine-readable: 'VERIF_FAIL_SHEAR', 'PDELTA_NOT_CONVERGED', etc.
+  message: string;                 // i18n key or pre-translated string
+  elementIds?: number[];
+  nodeIds?: number[];
+  source: 'solver' | 'assembly' | 'kinematic' | 'verification' | 'serviceability' | 'stability' | 'model';
+  details?: Record<string, unknown>;
+}
+
 
 /** Envolvente completa con datos puntuales para M, V, N */
 export interface FullEnvelope {

--- a/web/src/lib/engine/wasm-solver.ts
+++ b/web/src/lib/engine/wasm-solver.ts
@@ -1,27 +1,9 @@
 /**
  * WASM solver wrapper — replaces the pure-TS solver pipeline.
  * Serializes SolverInput (with Maps) → JSON → Rust/WASM → JSON → AnalysisResults.
+ *
+ * Uses dynamic imports so the app works without the WASM build (falls back to JS solver).
  */
-
-import initWasm, {
-  solve_2d as wasmSolve2d,
-  solve_3d as wasmSolve3d,
-  solve_pdelta_2d as wasmSolvePdelta2d,
-  solve_buckling_2d as wasmSolveBuckling2d,
-  solve_modal_2d as wasmSolveModal2d,
-  solve_spectral_2d as wasmSolveSpectral2d,
-  solve_plastic_2d as wasmSolvePlastic2d,
-  solve_moving_loads_2d as wasmSolveMovingLoads2d,
-  analyze_kinematics_2d as wasmAnalyzeKinematics2d,
-  analyze_kinematics_3d as wasmAnalyzeKinematics3d,
-  combine_results_2d as wasmCombineResults2d,
-  combine_results_3d as wasmCombineResults3d,
-  compute_envelope_2d as wasmComputeEnvelope2d,
-  compute_envelope_3d as wasmComputeEnvelope3d,
-  compute_influence_line as wasmComputeInfluenceLine,
-  compute_section_stress_2d as wasmComputeSectionStress2d,
-  compute_section_stress_3d as wasmComputeSectionStress3d,
-} from '../wasm/dedaliano_engine';
 
 import type { SolverInput, AnalysisResults, FullEnvelope } from './types';
 import type { SolverInput3D, AnalysisResults3D, FullEnvelope3D } from './types-3d';
@@ -29,12 +11,243 @@ import type { SolverInput3D, AnalysisResults3D, FullEnvelope3D } from './types-3
 let wasmReady = false;
 let wasmInitPromise: Promise<void> | null = null;
 
+// Dynamically loaded WASM functions
+let wasmSolve2d: ((json: string) => string) | null = null;
+let wasmSolve3d: ((json: string) => string) | null = null;
+let wasmSolvePdelta2d: ((json: string, maxIter: number, tolerance: number) => string) | null = null;
+let wasmSolveBuckling2d: ((json: string, numModes: number) => string) | null = null;
+let wasmSolveModal2d: ((json: string, numModes: number) => string) | null = null;
+let wasmSolveSpectral2d: ((json: string) => string) | null = null;
+let wasmSolvePlastic2d: ((json: string) => string) | null = null;
+let wasmSolveMovingLoads2d: ((json: string) => string) | null = null;
+
+// 2D advanced analysis WASM functions
+let wasmSolveCorotational2d: ((json: string, maxIter: number, tolerance: number, nIncrements: number) => string) | null = null;
+let wasmSolveNonlinearMaterial2d: ((json: string) => string) | null = null;
+let wasmSolveTimeHistory2d: ((json: string) => string) | null = null;
+
+// 3D solver WASM functions
+let wasmSolvePdelta3d: ((json: string, maxIter: number, tolerance: number) => string) | null = null;
+let wasmSolveModal3d: ((json: string, numModes: number) => string) | null = null;
+let wasmSolveBuckling3d: ((json: string, numModes: number) => string) | null = null;
+let wasmSolveSpectral3d: ((json: string) => string) | null = null;
+
+// Kinematics
+let wasmAnalyzeKinematics2d: ((json: string) => string) | null = null;
+let wasmAnalyzeKinematics3d: ((json: string) => string) | null = null;
+
+// Combinations & Envelope
+let wasmCombineResults2d: ((json: string) => string) | null = null;
+let wasmCombineResults3d: ((json: string) => string) | null = null;
+let wasmComputeEnvelope2d: ((json: string) => string) | null = null;
+let wasmComputeEnvelope3d: ((json: string) => string) | null = null;
+
+// Influence Lines
+let wasmComputeInfluenceLine: ((json: string) => string) | null = null;
+
+// Section Stress
+let wasmComputeSectionStress2d: ((json: string) => string) | null = null;
+let wasmComputeSectionStress3d: ((json: string) => string) | null = null;
+
+// Diagrams & Deformed Shape
+let wasmComputeDiagrams2d: ((json: string) => string) | null = null;
+let wasmComputeDiagrams3d: ((json: string) => string) | null = null;
+let wasmComputeDeformedShape: ((json: string) => string) | null = null;
+
+// 3D advanced solver WASM functions
+let wasmSolveCorotational3d: ((json: string, maxIter: number, tolerance: number, nIncrements: number) => string) | null = null;
+let wasmSolveNonlinearMaterial3d: ((json: string) => string) | null = null;
+let wasmSolveTimeHistory3d: ((json: string) => string) | null = null;
+let wasmSolvePlastic3d: ((json: string) => string) | null = null;
+let wasmSolveMovingLoads3d: ((json: string) => string) | null = null;
+
+// Constrained / contact / SSI / Winkler solvers
+let wasmSolveConstrained2d: ((json: string) => string) | null = null;
+let wasmSolveConstrained3d: ((json: string) => string) | null = null;
+let wasmSolveContact2d: ((json: string) => string) | null = null;
+let wasmSolveContact3d: ((json: string) => string) | null = null;
+let wasmSolveSsi2d: ((json: string) => string) | null = null;
+let wasmSolveSsi3d: ((json: string) => string) | null = null;
+let wasmSolveWinkler2d: ((json: string) => string) | null = null;
+let wasmSolveWinkler3d: ((json: string) => string) | null = null;
+
+// Fiber nonlinear solvers
+let wasmSolveFiberNonlinear2d: ((json: string) => string) | null = null;
+let wasmSolveFiberNonlinear3d: ((json: string) => string) | null = null;
+
+// Staged construction solvers
+let wasmSolveStaged2d: ((json: string) => string) | null = null;
+let wasmSolveStaged3d: ((json: string) => string) | null = null;
+
+// Cable solver
+let wasmSolveCable2d: ((json: string, maxIter: number, tolerance: number) => string) | null = null;
+
+// Harmonic solvers
+let wasmSolveHarmonic2d: ((json: string) => string) | null = null;
+let wasmSolveHarmonic3d: ((json: string) => string) | null = null;
+
+// Creep & shrinkage solvers
+let wasmSolveCreepShrinkage2d: ((json: string) => string) | null = null;
+let wasmSolveCreepShrinkage3d: ((json: string) => string) | null = null;
+
+// Multi-case solvers
+let wasmSolveMultiCase2d: ((json: string) => string) | null = null;
+let wasmSolveMultiCase3d: ((json: string) => string) | null = null;
+
+// Nonlinear path-following solvers
+let wasmSolveArcLength: ((json: string) => string) | null = null;
+let wasmSolveDisplacementControl: ((json: string) => string) | null = null;
+
+// Imperfection solvers
+let wasmSolveWithImperfections2d: ((json: string) => string) | null = null;
+let wasmSolveWithImperfections3d: ((json: string) => string) | null = null;
+
+// 3D influence line
+let wasmComputeInfluenceLine3d: ((json: string) => string) | null = null;
+
+// Section analysis
+let wasmAnalyzeSection: ((json: string) => string) | null = null;
+
+// Model reduction
+let wasmGuyanReduce2d: ((json: string) => string) | null = null;
+let wasmCraigBampton2d: ((json: string) => string) | null = null;
+
+// Design Checks (not yet compiled into WASM binary — graceful fallback via ?? null)
+let wasmCheckSteelMembers: ((json: string) => string) | null = null;
+let wasmCheckRcMembers: ((json: string) => string) | null = null;
+let wasmCheckTimberMembers: ((json: string) => string) | null = null;
+let wasmCheckEc3Members: ((json: string) => string) | null = null;
+let wasmCheckEc2Members: ((json: string) => string) | null = null;
+let wasmCheckCirsoc201Members: ((json: string) => string) | null = null;
+let wasmCheckCfsMembers: ((json: string) => string) | null = null;
+let wasmCheckMasonryMembers: ((json: string) => string) | null = null;
+let wasmCheckServiceability: ((json: string) => string) | null = null;
+let wasmCheckBoltGroups: ((json: string) => string) | null = null;
+let wasmCheckWeldGroups: ((json: string) => string) | null = null;
+let wasmCheckSpreadFootings: ((json: string) => string) | null = null;
+
 /** Initialize the WASM module. Call once at app startup. */
 export async function initSolver(): Promise<void> {
   if (wasmReady) return;
   if (wasmInitPromise) return wasmInitPromise;
   wasmInitPromise = (async () => {
-    await initWasm();
+    // Use a variable path so Rollup/Vite doesn't try to resolve at build time
+    const wasmPath = '../wasm/dedaliano_engine';
+    const wasm = await import(/* @vite-ignore */ wasmPath);
+    await wasm.default();
+    wasmSolve2d = wasm.solve_2d;
+    wasmSolve3d = wasm.solve_3d;
+    wasmSolvePdelta2d = wasm.solve_pdelta_2d;
+    wasmSolveBuckling2d = wasm.solve_buckling_2d;
+    wasmSolveModal2d = wasm.solve_modal_2d;
+    wasmSolveSpectral2d = wasm.solve_spectral_2d;
+    wasmSolvePlastic2d = wasm.solve_plastic_2d;
+    wasmSolveMovingLoads2d = wasm.solve_moving_loads_2d;
+    // 2D advanced
+    wasmSolveCorotational2d = wasm.solve_corotational_2d;
+    wasmSolveNonlinearMaterial2d = wasm.solve_nonlinear_material_2d;
+    wasmSolveTimeHistory2d = wasm.solve_time_history_2d;
+
+    // 3D solvers
+    wasmSolvePdelta3d = wasm.solve_pdelta_3d;
+    wasmSolveModal3d = wasm.solve_modal_3d;
+    wasmSolveBuckling3d = wasm.solve_buckling_3d;
+    wasmSolveSpectral3d = wasm.solve_spectral_3d;
+
+    // Kinematics
+    wasmAnalyzeKinematics2d = wasm.analyze_kinematics_2d;
+    wasmAnalyzeKinematics3d = wasm.analyze_kinematics_3d;
+
+    // Combinations & Envelope
+    wasmCombineResults2d = wasm.combine_results_2d;
+    wasmCombineResults3d = wasm.combine_results_3d;
+    wasmComputeEnvelope2d = wasm.compute_envelope_2d;
+    wasmComputeEnvelope3d = wasm.compute_envelope_3d;
+
+    // Influence Lines
+    wasmComputeInfluenceLine = wasm.compute_influence_line;
+
+    // Section Stress
+    wasmComputeSectionStress2d = wasm.compute_section_stress_2d;
+    wasmComputeSectionStress3d = wasm.compute_section_stress_3d;
+
+    // Diagrams & Deformed Shape
+    wasmComputeDiagrams2d = wasm.compute_diagrams_2d;
+    wasmComputeDiagrams3d = wasm.compute_diagrams_3d;
+    wasmComputeDeformedShape = wasm.compute_deformed_shape;
+
+    // 3D advanced solvers
+    wasmSolveCorotational3d = wasm.solve_corotational_3d ?? null;
+    wasmSolveNonlinearMaterial3d = wasm.solve_nonlinear_material_3d ?? null;
+    wasmSolveTimeHistory3d = wasm.solve_time_history_3d ?? null;
+    wasmSolvePlastic3d = wasm.solve_plastic_3d ?? null;
+    wasmSolveMovingLoads3d = wasm.solve_moving_loads_3d ?? null;
+
+    // Constrained / contact / SSI / Winkler
+    wasmSolveConstrained2d = wasm.solve_constrained_2d ?? null;
+    wasmSolveConstrained3d = wasm.solve_constrained_3d ?? null;
+    wasmSolveContact2d = wasm.solve_contact_2d ?? null;
+    wasmSolveContact3d = wasm.solve_contact_3d ?? null;
+    wasmSolveSsi2d = wasm.solve_ssi_2d ?? null;
+    wasmSolveSsi3d = wasm.solve_ssi_3d ?? null;
+    wasmSolveWinkler2d = wasm.solve_winkler_2d ?? null;
+    wasmSolveWinkler3d = wasm.solve_winkler_3d ?? null;
+
+    // Fiber nonlinear
+    wasmSolveFiberNonlinear2d = wasm.solve_fiber_nonlinear_2d ?? null;
+    wasmSolveFiberNonlinear3d = wasm.solve_fiber_nonlinear_3d ?? null;
+
+    // Staged construction
+    wasmSolveStaged2d = wasm.solve_staged_2d ?? null;
+    wasmSolveStaged3d = wasm.solve_staged_3d ?? null;
+
+    // Cable
+    wasmSolveCable2d = wasm.solve_cable_2d ?? null;
+
+    // Harmonic
+    wasmSolveHarmonic2d = wasm.solve_harmonic_2d ?? null;
+    wasmSolveHarmonic3d = wasm.solve_harmonic_3d ?? null;
+
+    // Creep & shrinkage
+    wasmSolveCreepShrinkage2d = wasm.solve_creep_shrinkage_2d ?? null;
+    wasmSolveCreepShrinkage3d = wasm.solve_creep_shrinkage_3d ?? null;
+
+    // Multi-case
+    wasmSolveMultiCase2d = wasm.solve_multi_case_2d ?? null;
+    wasmSolveMultiCase3d = wasm.solve_multi_case_3d ?? null;
+
+    // Nonlinear path-following
+    wasmSolveArcLength = wasm.solve_arc_length ?? null;
+    wasmSolveDisplacementControl = wasm.solve_displacement_control ?? null;
+
+    // Imperfections
+    wasmSolveWithImperfections2d = wasm.solve_with_imperfections_2d ?? null;
+    wasmSolveWithImperfections3d = wasm.solve_with_imperfections_3d ?? null;
+
+    // 3D influence line
+    wasmComputeInfluenceLine3d = wasm.compute_influence_line_3d ?? null;
+
+    // Section analysis
+    wasmAnalyzeSection = wasm.analyze_section ?? null;
+
+    // Model reduction
+    wasmGuyanReduce2d = wasm.guyan_reduce_2d ?? null;
+    wasmCraigBampton2d = wasm.craig_bampton_2d ?? null;
+
+    // Design Checks (may not exist in current WASM binary — ?? null prevents crash)
+    wasmCheckSteelMembers = wasm.check_steel_members ?? null;
+    wasmCheckRcMembers = wasm.check_rc_members ?? null;
+    wasmCheckTimberMembers = wasm.check_timber_members ?? null;
+    wasmCheckEc3Members = wasm.check_ec3_members ?? null;
+    wasmCheckEc2Members = wasm.check_ec2_members ?? null;
+    wasmCheckCirsoc201Members = wasm.check_cirsoc201_members ?? null;
+    wasmCheckCfsMembers = wasm.check_cfs_members ?? null;
+    wasmCheckMasonryMembers = wasm.check_masonry_members ?? null;
+    wasmCheckServiceability = wasm.check_serviceability ?? null;
+    wasmCheckBoltGroups = wasm.check_bolt_groups ?? null;
+    wasmCheckWeldGroups = wasm.check_weld_groups ?? null;
+    wasmCheckSpreadFootings = wasm.check_spread_footings ?? null;
+
     wasmReady = true;
   })();
   return wasmInitPromise;
@@ -69,7 +282,7 @@ function serializeInput2D(input: SolverInput): string {
 }
 
 /** Serialize SolverInput3D (with Maps) to JSON string for WASM. */
-function serializeInput3D(input: SolverInput3D): string {
+export function serializeInput3D(input: SolverInput3D): string {
   return JSON.stringify({
     nodes: mapToObj(input.nodes),
     materials: mapToObj(input.materials),
@@ -77,7 +290,9 @@ function serializeInput3D(input: SolverInput3D): string {
     elements: mapToObj(input.elements),
     supports: mapToObj(input.supports),
     loads: input.loads,
-    leftHand: (input as any).leftHand,
+    plates: input.plates ? mapToObj(input.plates) : {},
+    quads: input.quads ? mapToObj(input.quads) : {},
+    constraints: input.constraints ?? [],
   });
 }
 
@@ -85,7 +300,7 @@ function serializeInput3D(input: SolverInput3D): string {
 
 /** Solve 2D linear static analysis via WASM. */
 export function solve(input: SolverInput): AnalysisResults {
-  if (!wasmReady) throw new Error('WASM solver not initialized. Call initSolver() first.');
+  if (!wasmReady || !wasmSolve2d) throw new Error('WASM solver not initialized. Call initSolver() first.');
   const json = serializeInput2D(input);
   const resultJson = wasmSolve2d(json);
   return JSON.parse(resultJson);
@@ -93,7 +308,7 @@ export function solve(input: SolverInput): AnalysisResults {
 
 /** Solve 3D linear static analysis via WASM. */
 export function solve3D(input: SolverInput3D): AnalysisResults3D {
-  if (!wasmReady) throw new Error('WASM solver not initialized. Call initSolver() first.');
+  if (!wasmReady || !wasmSolve3d) throw new Error('WASM solver not initialized. Call initSolver() first.');
   const json = serializeInput3D(input);
   const resultJson = wasmSolve3d(json);
   return JSON.parse(resultJson);
@@ -101,7 +316,7 @@ export function solve3D(input: SolverInput3D): AnalysisResults3D {
 
 /** Solve 2D P-Delta analysis via WASM. */
 export function solvePDelta(input: SolverInput, maxIter = 20, tolerance = 1e-4) {
-  if (!wasmReady) throw new Error('WASM solver not initialized.');
+  if (!wasmReady || !wasmSolvePdelta2d) throw new Error('WASM solver not initialized.');
   const json = serializeInput2D(input);
   const resultJson = wasmSolvePdelta2d(json, maxIter, tolerance);
   return JSON.parse(resultJson);
@@ -109,7 +324,7 @@ export function solvePDelta(input: SolverInput, maxIter = 20, tolerance = 1e-4) 
 
 /** Solve 2D buckling analysis via WASM. */
 export function solveBuckling(input: SolverInput, numModes = 4) {
-  if (!wasmReady) throw new Error('WASM solver not initialized.');
+  if (!wasmReady || !wasmSolveBuckling2d) throw new Error('WASM solver not initialized.');
   const json = serializeInput2D(input);
   const resultJson = wasmSolveBuckling2d(json, numModes);
   return JSON.parse(resultJson);
@@ -121,7 +336,7 @@ export function solveModal(
   densities: Map<number, number>,
   numModes = 6,
 ) {
-  if (!wasmReady) throw new Error('WASM solver not initialized.');
+  if (!wasmReady || !wasmSolveModal2d) throw new Error('WASM solver not initialized.');
   const payload = JSON.stringify({
     solver: {
       nodes: mapToObj(input.nodes),
@@ -149,7 +364,7 @@ export function solveSpectral(config: {
   importanceFactor?: number;
   reductionFactor?: number;
 }) {
-  if (!wasmReady) throw new Error('WASM solver not initialized.');
+  if (!wasmReady || !wasmSolveSpectral2d) throw new Error('WASM solver not available.');
   const payload = JSON.stringify({
     solver: {
       nodes: mapToObj(config.solver.nodes),
@@ -180,7 +395,7 @@ export function solvePlastic(config: {
   maxHinges?: number;
   mpOverrides?: Map<number, number>;
 }) {
-  if (!wasmReady) throw new Error('WASM solver not initialized.');
+  if (!wasmReady || !wasmSolvePlastic2d) throw new Error('WASM solver not available.');
   const payload = JSON.stringify({
     solver: {
       nodes: mapToObj(config.solver.nodes),
@@ -206,7 +421,7 @@ export function solveMovingLoads(config: {
   step?: number;
   pathElementIds?: number[];
 }) {
-  if (!wasmReady) throw new Error('WASM solver not initialized.');
+  if (!wasmReady || !wasmSolveMovingLoads2d) throw new Error('WASM solver not available.');
   const payload = JSON.stringify({
     solver: {
       nodes: mapToObj(config.solver.nodes),
@@ -224,18 +439,126 @@ export function solveMovingLoads(config: {
   return JSON.parse(resultJson);
 }
 
+// ─── 3D Advanced Analysis ─────────────────────────────────────────
+
+/** Solve 3D P-Delta analysis via WASM. */
+export function solvePDelta3D(input: SolverInput3D, maxIter = 20, tolerance = 1e-4) {
+  if (!wasmReady || !wasmSolvePdelta3d) throw new Error('WASM P-Delta 3D solver not available.');
+  const json = serializeInput3D(input);
+  const resultJson = wasmSolvePdelta3d(json, maxIter, tolerance);
+  return JSON.parse(resultJson);
+}
+
+/** Solve 3D modal analysis via WASM. */
+export function solveModal3D(input: SolverInput3D, densities: Map<number, number>, numModes = 6) {
+  if (!wasmReady || !wasmSolveModal3d) throw new Error('WASM Modal 3D solver not available.');
+  const payload = JSON.stringify({
+    solver: {
+      nodes: mapToObj(input.nodes),
+      materials: mapToObj(input.materials),
+      sections: mapToObj(input.sections),
+      elements: mapToObj(input.elements),
+      supports: mapToObj(input.supports),
+      loads: input.loads,
+    },
+    densities: mapToObj(densities),
+  });
+  const resultJson = wasmSolveModal3d(payload, numModes);
+  return JSON.parse(resultJson);
+}
+
+/** Solve 3D buckling analysis via WASM. */
+export function solveBuckling3D(input: SolverInput3D, numModes = 4) {
+  if (!wasmReady || !wasmSolveBuckling3d) throw new Error('WASM Buckling 3D solver not available.');
+  const json = serializeInput3D(input);
+  const resultJson = wasmSolveBuckling3d(json, numModes);
+  return JSON.parse(resultJson);
+}
+
+/** Solve 3D spectral analysis via WASM. */
+export function solveSpectral3D(config: {
+  solver: SolverInput3D;
+  densities: Map<number, number>;
+  spectrum: { name: string; points: { period: number; sa: number }[]; inG?: boolean };
+  directions: Array<'X' | 'Y' | 'Z'>;
+  combination: 'SRSS' | 'CQC';
+  numModes?: number;
+  xi?: number;
+  importanceFactor?: number;
+  reductionFactor?: number;
+}) {
+  if (!wasmReady || !wasmSolveSpectral3d) throw new Error('WASM Spectral 3D solver not available.');
+  const payload = JSON.stringify({
+    solver: {
+      nodes: mapToObj(config.solver.nodes),
+      materials: mapToObj(config.solver.materials),
+      sections: mapToObj(config.solver.sections),
+      elements: mapToObj(config.solver.elements),
+      supports: mapToObj(config.solver.supports),
+      loads: config.solver.loads,
+    },
+    densities: mapToObj(config.densities),
+    spectrum: config.spectrum,
+    directions: config.directions,
+    combination: config.combination,
+    numModes: config.numModes,
+    xi: config.xi,
+    importanceFactor: config.importanceFactor,
+    reductionFactor: config.reductionFactor,
+  });
+  const resultJson = wasmSolveSpectral3d(payload);
+  return JSON.parse(resultJson);
+}
+
+/** Solve 2D corotational (large displacement) analysis via WASM. */
+export function solveCorotational2D(input: SolverInput, maxIter = 50, tolerance = 1e-6, nIncrements = 10) {
+  if (!wasmReady || !wasmSolveCorotational2d) throw new Error('WASM Corotational solver not available.');
+  const json = serializeInput2D(input);
+  const resultJson = wasmSolveCorotational2d(json, maxIter, tolerance, nIncrements);
+  return JSON.parse(resultJson);
+}
+
+/** Solve 2D time history analysis via WASM. */
+export function solveTimeHistory2D(config: {
+  solver: SolverInput;
+  densities: Map<number, number>;
+  accelerogram: { dt: number; values: number[] };
+  direction: 'X' | 'Y';
+  damping?: number;
+  method?: 'Newmark' | 'Wilson';
+}) {
+  if (!wasmReady || !wasmSolveTimeHistory2d) throw new Error('WASM Time History solver not available.');
+  const payload = JSON.stringify({
+    solver: {
+      nodes: mapToObj(config.solver.nodes),
+      materials: mapToObj(config.solver.materials),
+      sections: mapToObj(config.solver.sections),
+      elements: mapToObj(config.solver.elements),
+      supports: mapToObj(config.solver.supports),
+      loads: config.solver.loads,
+    },
+    densities: mapToObj(config.densities),
+    accelerogram: config.accelerogram,
+    direction: config.direction,
+    damping: config.damping,
+    method: config.method,
+  });
+  const resultJson = wasmSolveTimeHistory2d(payload);
+  return JSON.parse(resultJson);
+}
+
 // ─── Kinematic analysis ──────────────────────────────────────────
 
 /** Analyze 2D kinematic stability via WASM. */
 export function analyzeKinematics(input: SolverInput) {
-  if (!wasmReady) throw new Error('WASM solver not initialized.');
+  if (!wasmReady || !wasmAnalyzeKinematics2d) throw new Error('WASM solver not initialized.');
   const json = serializeInput2D(input);
   return JSON.parse(wasmAnalyzeKinematics2d(json));
 }
 
 /** Analyze 3D kinematic stability via WASM. */
 export function analyzeKinematics3D(input: SolverInput3D) {
-  if (!wasmReady) throw new Error('WASM solver not initialized.');
+  if (!wasmReady || !wasmAnalyzeKinematics3d) throw new Error('WASM solver not initialized.');
   const json = serializeInput3D(input);
   return JSON.parse(wasmAnalyzeKinematics3d(json));
 }
@@ -247,7 +570,7 @@ export function combineResults(
   factors: Array<{ caseId: number; factor: number }>,
   perCase: Map<number, AnalysisResults>,
 ): AnalysisResults | null {
-  if (!wasmReady) throw new Error('WASM solver not initialized.');
+  if (!wasmReady || !wasmCombineResults2d) throw new Error('WASM solver not initialized.');
   const cases = factors
     .filter(f => perCase.has(f.caseId))
     .map(f => ({ caseId: f.caseId, results: perCase.get(f.caseId)! }));
@@ -262,7 +585,7 @@ export function combineResults3D(
   factors: Array<{ caseId: number; factor: number }>,
   perCase: Map<number, AnalysisResults3D>,
 ): AnalysisResults3D | null {
-  if (!wasmReady) throw new Error('WASM solver not initialized.');
+  if (!wasmReady || !wasmCombineResults3d) throw new Error('WASM solver not initialized.');
   const cases = factors
     .filter(f => perCase.has(f.caseId))
     .map(f => ({ caseId: f.caseId, results: perCase.get(f.caseId)! }));
@@ -274,17 +597,17 @@ export function combineResults3D(
 
 /** Compute 2D envelope via WASM. */
 export function computeEnvelope(results: AnalysisResults[]): FullEnvelope | null {
-  if (!wasmReady) throw new Error('WASM solver not initialized.');
+  if (!wasmReady || !wasmComputeEnvelope2d) throw new Error('WASM solver not initialized.');
   if (results.length === 0) return null;
-  const payload = JSON.stringify({ results });
+  const payload = JSON.stringify(results);
   return JSON.parse(wasmComputeEnvelope2d(payload));
 }
 
 /** Compute 3D envelope via WASM. */
 export function computeEnvelope3D(results: AnalysisResults3D[]): FullEnvelope3D | null {
-  if (!wasmReady) throw new Error('WASM solver not initialized.');
+  if (!wasmReady || !wasmComputeEnvelope3d) throw new Error('WASM solver not initialized.');
   if (results.length === 0) return null;
-  const payload = JSON.stringify({ results });
+  const payload = JSON.stringify(results);
   return JSON.parse(wasmComputeEnvelope3d(payload));
 }
 
@@ -299,7 +622,7 @@ export function computeInfluenceLineWasm(ilInput: {
   targetPosition?: number;
   nPointsPerElement?: number;
 }) {
-  if (!wasmReady) throw new Error('WASM solver not initialized.');
+  if (!wasmReady || !wasmComputeInfluenceLine) throw new Error('WASM solver not initialized.');
   const payload = JSON.stringify({
     solver: {
       nodes: mapToObj(ilInput.solver.nodes),
@@ -328,12 +651,496 @@ export function computeSectionStress2D(input: {
   t: number;
   yFiber?: number | null;
 }) {
-  if (!wasmReady) throw new Error('WASM solver not initialized.');
+  if (!wasmReady || !wasmComputeSectionStress2d) throw new Error('WASM solver not initialized.');
   return JSON.parse(wasmComputeSectionStress2d(JSON.stringify(input)));
 }
 
 /** Compute 3D section stress via WASM. Takes pre-resolved geometry. */
 export function computeSectionStress3D(input: any) {
-  if (!wasmReady) throw new Error('WASM solver not initialized.');
+  if (!wasmReady || !wasmComputeSectionStress3d) throw new Error('WASM solver not initialized.');
   return JSON.parse(wasmComputeSectionStress3d(JSON.stringify(input)));
+}
+
+// ─── Diagrams & Deformed Shape ───────────────────────────────────
+
+/** Compute 2D diagrams (moment, shear, axial) via WASM. */
+export function computeDiagrams2D(input: SolverInput, results: AnalysisResults) {
+  if (!wasmReady || !wasmComputeDiagrams2d) throw new Error('WASM solver not initialized.');
+  const payload = JSON.stringify({
+    input: {
+      nodes: mapToObj(input.nodes),
+      materials: mapToObj(input.materials),
+      sections: mapToObj(input.sections),
+      elements: mapToObj(input.elements),
+      supports: mapToObj(input.supports),
+      loads: input.loads,
+    },
+    results,
+  });
+  return JSON.parse(wasmComputeDiagrams2d(payload));
+}
+
+/** Compute 3D diagrams (My, Mz, Vy, Vz, N, T) via WASM. */
+export function computeDiagrams3D(input: SolverInput3D, results: AnalysisResults3D) {
+  if (!wasmReady || !wasmComputeDiagrams3d) throw new Error('WASM solver not initialized.');
+  const payload = JSON.stringify({
+    input: {
+      nodes: mapToObj(input.nodes),
+      materials: mapToObj(input.materials),
+      sections: mapToObj(input.sections),
+      elements: mapToObj(input.elements),
+      supports: mapToObj(input.supports),
+      loads: input.loads,
+    },
+    results,
+  });
+  return JSON.parse(wasmComputeDiagrams3d(payload));
+}
+
+/** Compute deformed shape for one element via WASM. */
+export function computeDeformedShape(input: any) {
+  if (!wasmReady || !wasmComputeDeformedShape) throw new Error('WASM solver not initialized.');
+  return JSON.parse(wasmComputeDeformedShape(JSON.stringify(input)));
+}
+
+// ─── Design Check Wrappers ───────────────────────────────────────
+// These return null gracefully if the WASM function is not yet compiled.
+
+/** AISC 360 LRFD steel member checks via WASM. */
+export function checkSteelMembers(input: any): any | null {
+  if (!wasmReady || !wasmCheckSteelMembers) return null;
+  try { return JSON.parse(wasmCheckSteelMembers(JSON.stringify(input))); }
+  catch { return null; }
+}
+
+/** Reinforced concrete member checks via WASM. */
+export function checkRcMembers(input: any): any | null {
+  if (!wasmReady || !wasmCheckRcMembers) return null;
+  try { return JSON.parse(wasmCheckRcMembers(JSON.stringify(input))); }
+  catch { return null; }
+}
+
+/** Timber member checks via WASM. */
+export function checkTimberMembers(input: any): any | null {
+  if (!wasmReady || !wasmCheckTimberMembers) return null;
+  try { return JSON.parse(wasmCheckTimberMembers(JSON.stringify(input))); }
+  catch { return null; }
+}
+
+/** Eurocode 3 steel member checks via WASM. */
+export function checkEc3Members(input: any): any | null {
+  if (!wasmReady || !wasmCheckEc3Members) return null;
+  try { return JSON.parse(wasmCheckEc3Members(JSON.stringify(input))); }
+  catch { return null; }
+}
+
+/** Eurocode 2 RC member checks via WASM. */
+export function checkEc2Members(input: any): any | null {
+  if (!wasmReady || !wasmCheckEc2Members) return null;
+  try { return JSON.parse(wasmCheckEc2Members(JSON.stringify(input))); }
+  catch { return null; }
+}
+
+/** CIRSOC 201 RC member checks via WASM. */
+export function checkCirsoc201Members(input: any): any | null {
+  if (!wasmReady || !wasmCheckCirsoc201Members) return null;
+  try { return JSON.parse(wasmCheckCirsoc201Members(JSON.stringify(input))); }
+  catch { return null; }
+}
+
+/** Cold-formed steel member checks via WASM. */
+export function checkCfsMembers(input: any): any | null {
+  if (!wasmReady || !wasmCheckCfsMembers) return null;
+  try { return JSON.parse(wasmCheckCfsMembers(JSON.stringify(input))); }
+  catch { return null; }
+}
+
+/** Masonry member checks via WASM. */
+export function checkMasonryMembers(input: any): any | null {
+  if (!wasmReady || !wasmCheckMasonryMembers) return null;
+  try { return JSON.parse(wasmCheckMasonryMembers(JSON.stringify(input))); }
+  catch { return null; }
+}
+
+/** Serviceability checks (deflection/vibration) via WASM. */
+export function checkServiceability(input: any): any | null {
+  if (!wasmReady || !wasmCheckServiceability) return null;
+  try { return JSON.parse(wasmCheckServiceability(JSON.stringify(input))); }
+  catch { return null; }
+}
+
+/** Bolt group capacity checks via WASM. */
+export function checkBoltGroups(input: any): any | null {
+  if (!wasmReady || !wasmCheckBoltGroups) return null;
+  try { return JSON.parse(wasmCheckBoltGroups(JSON.stringify(input))); }
+  catch { return null; }
+}
+
+/** Weld group capacity checks via WASM. */
+export function checkWeldGroups(input: any): any | null {
+  if (!wasmReady || !wasmCheckWeldGroups) return null;
+  try { return JSON.parse(wasmCheckWeldGroups(JSON.stringify(input))); }
+  catch { return null; }
+}
+
+/** Spread footing bearing checks via WASM. */
+export function checkSpreadFootings(input: any): any | null {
+  if (!wasmReady || !wasmCheckSpreadFootings) return null;
+  try { return JSON.parse(wasmCheckSpreadFootings(JSON.stringify(input))); }
+  catch { return null; }
+}
+
+/** Check if a specific WASM design check function is available. */
+export function isDesignCheckAvailable(name: string): boolean {
+  if (!wasmReady) return false;
+  const checks: Record<string, any> = {
+    steelMembers: wasmCheckSteelMembers,
+    rcMembers: wasmCheckRcMembers,
+    timberMembers: wasmCheckTimberMembers,
+    ec3Members: wasmCheckEc3Members,
+    ec2Members: wasmCheckEc2Members,
+    cirsoc201Members: wasmCheckCirsoc201Members,
+    cfsMembers: wasmCheckCfsMembers,
+    masonryMembers: wasmCheckMasonryMembers,
+    serviceability: wasmCheckServiceability,
+    boltGroups: wasmCheckBoltGroups,
+    weldGroups: wasmCheckWeldGroups,
+    spreadFootings: wasmCheckSpreadFootings,
+  };
+  return checks[name] != null;
+}
+
+/** Solve 2D nonlinear material analysis via WASM. */
+export function solveNonlinearMaterial2D(config: {
+  solver: SolverInput;
+  materialModels?: any;
+  sectionCapacities?: any;
+  maxIter?: number;
+  tolerance?: number;
+  nIncrements?: number;
+}) {
+  if (!wasmReady || !wasmSolveNonlinearMaterial2d) throw new Error('WASM nonlinear material solver not available.');
+  const payload = JSON.stringify({
+    solver: {
+      nodes: mapToObj(config.solver.nodes),
+      materials: mapToObj(config.solver.materials),
+      sections: mapToObj(config.solver.sections),
+      elements: mapToObj(config.solver.elements),
+      supports: mapToObj(config.solver.supports),
+      loads: config.solver.loads,
+    },
+    materialModels: config.materialModels,
+    sectionCapacities: config.sectionCapacities,
+    maxIter: config.maxIter,
+    tolerance: config.tolerance,
+    nIncrements: config.nIncrements,
+  });
+  return JSON.parse(wasmSolveNonlinearMaterial2d(payload));
+}
+
+// ─── 3D Advanced Solvers (new) ────────────────────────────────────
+
+/** Solve 3D corotational (large displacement) analysis via WASM. */
+export function solveCorotational3D(input: SolverInput3D, maxIter = 50, tolerance = 1e-6, nIncrements = 10): any {
+  if (!wasmReady || !wasmSolveCorotational3d) throw new Error('WASM Corotational 3D solver not available.');
+  return JSON.parse(wasmSolveCorotational3d(serializeInput3D(input), maxIter, tolerance, nIncrements));
+}
+
+/** Solve 3D nonlinear material analysis via WASM. */
+export function solveNonlinearMaterial3D(config: any): any {
+  if (!wasmReady || !wasmSolveNonlinearMaterial3d) throw new Error('WASM nonlinear material 3D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput3D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveNonlinearMaterial3d(JSON.stringify(config)));
+}
+
+/** Solve 3D time history analysis via WASM. */
+export function solveTimeHistory3D(config: any): any {
+  if (!wasmReady || !wasmSolveTimeHistory3d) throw new Error('WASM time history 3D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput3D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveTimeHistory3d(JSON.stringify(config)));
+}
+
+/** Solve 3D plastic analysis via WASM. */
+export function solvePlastic3D(config: any): any {
+  if (!wasmReady || !wasmSolvePlastic3d) throw new Error('WASM plastic 3D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput3D(config.solver)) };
+  }
+  return JSON.parse(wasmSolvePlastic3d(JSON.stringify(config)));
+}
+
+/** Solve 3D moving loads analysis via WASM. */
+export function solveMovingLoads3D(config: any): any {
+  if (!wasmReady || !wasmSolveMovingLoads3d) throw new Error('WASM moving loads 3D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput3D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveMovingLoads3d(JSON.stringify(config)));
+}
+
+// ─── Constrained / Contact / SSI / Winkler Solvers ────────────────
+
+/** Solve 2D constrained analysis via WASM. */
+export function solveConstrained2D(config: any): any {
+  if (!wasmReady || !wasmSolveConstrained2d) throw new Error('WASM constrained 2D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput2D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveConstrained2d(JSON.stringify(config)));
+}
+
+/** Solve 3D constrained analysis via WASM. */
+export function solveConstrained3D(config: any): any {
+  if (!wasmReady || !wasmSolveConstrained3d) throw new Error('WASM constrained 3D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput3D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveConstrained3d(JSON.stringify(config)));
+}
+
+/** Solve 2D contact analysis via WASM. */
+export function solveContact2D(config: any): any {
+  if (!wasmReady || !wasmSolveContact2d) throw new Error('WASM contact 2D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput2D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveContact2d(JSON.stringify(config)));
+}
+
+/** Solve 3D contact analysis via WASM. */
+export function solveContact3D(config: any): any {
+  if (!wasmReady || !wasmSolveContact3d) throw new Error('WASM contact 3D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput3D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveContact3d(JSON.stringify(config)));
+}
+
+/** Solve 2D soil-structure interaction via WASM. */
+export function solveSSI2D(config: any): any {
+  if (!wasmReady || !wasmSolveSsi2d) throw new Error('WASM SSI 2D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput2D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveSsi2d(JSON.stringify(config)));
+}
+
+/** Solve 3D soil-structure interaction via WASM. */
+export function solveSSI3D(config: any): any {
+  if (!wasmReady || !wasmSolveSsi3d) throw new Error('WASM SSI 3D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput3D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveSsi3d(JSON.stringify(config)));
+}
+
+/** Solve 2D Winkler foundation analysis via WASM. */
+export function solveWinkler2D(config: any): any {
+  if (!wasmReady || !wasmSolveWinkler2d) throw new Error('WASM Winkler 2D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput2D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveWinkler2d(JSON.stringify(config)));
+}
+
+/** Solve 3D Winkler foundation analysis via WASM. */
+export function solveWinkler3D(config: any): any {
+  if (!wasmReady || !wasmSolveWinkler3d) throw new Error('WASM Winkler 3D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput3D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveWinkler3d(JSON.stringify(config)));
+}
+
+// ─── Fiber Nonlinear Solvers ──────────────────────────────────────
+
+/** Solve 2D fiber nonlinear analysis via WASM. */
+export function solveFiberNonlinear2D(config: any): any {
+  if (!wasmReady || !wasmSolveFiberNonlinear2d) throw new Error('WASM fiber nonlinear 2D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput2D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveFiberNonlinear2d(JSON.stringify(config)));
+}
+
+/** Solve 3D fiber nonlinear analysis via WASM. */
+export function solveFiberNonlinear3D(config: any): any {
+  if (!wasmReady || !wasmSolveFiberNonlinear3d) throw new Error('WASM fiber nonlinear 3D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput3D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveFiberNonlinear3d(JSON.stringify(config)));
+}
+
+// ─── Staged Construction Solvers ──────────────────────────────────
+
+/** Solve 2D staged construction analysis via WASM. */
+export function solveStaged2D(config: any): any {
+  if (!wasmReady || !wasmSolveStaged2d) throw new Error('WASM staged 2D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput2D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveStaged2d(JSON.stringify(config)));
+}
+
+/** Solve 3D staged construction analysis via WASM. */
+export function solveStaged3D(config: any): any {
+  if (!wasmReady || !wasmSolveStaged3d) throw new Error('WASM staged 3D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput3D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveStaged3d(JSON.stringify(config)));
+}
+
+// ─── Cable Solver ─────────────────────────────────────────────────
+
+/** Solve 2D cable analysis via WASM. */
+export function solveCable2D(input: SolverInput, maxIter = 50, tolerance = 1e-6): any {
+  if (!wasmReady || !wasmSolveCable2d) throw new Error('WASM cable 2D solver not available.');
+  return JSON.parse(wasmSolveCable2d(serializeInput2D(input), maxIter, tolerance));
+}
+
+// ─── Harmonic Solvers ─────────────────────────────────────────────
+
+/** Solve 2D harmonic analysis via WASM. */
+export function solveHarmonic2D(config: any): any {
+  if (!wasmReady || !wasmSolveHarmonic2d) throw new Error('WASM harmonic 2D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput2D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveHarmonic2d(JSON.stringify(config)));
+}
+
+/** Solve 3D harmonic analysis via WASM. */
+export function solveHarmonic3D(config: any): any {
+  if (!wasmReady || !wasmSolveHarmonic3d) throw new Error('WASM harmonic 3D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput3D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveHarmonic3d(JSON.stringify(config)));
+}
+
+// ─── Creep & Shrinkage Solvers ────────────────────────────────────
+
+/** Solve 2D creep & shrinkage analysis via WASM. */
+export function solveCreepShrinkage2D(config: any): any {
+  if (!wasmReady || !wasmSolveCreepShrinkage2d) throw new Error('WASM creep/shrinkage 2D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput2D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveCreepShrinkage2d(JSON.stringify(config)));
+}
+
+/** Solve 3D creep & shrinkage analysis via WASM. */
+export function solveCreepShrinkage3D(config: any): any {
+  if (!wasmReady || !wasmSolveCreepShrinkage3d) throw new Error('WASM creep/shrinkage 3D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput3D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveCreepShrinkage3d(JSON.stringify(config)));
+}
+
+// ─── Multi-Case Solvers ───────────────────────────────────────────
+
+/** Solve 2D multi-case analysis via WASM. */
+export function solveMultiCase2D(config: any): any {
+  if (!wasmReady || !wasmSolveMultiCase2d) throw new Error('WASM multi-case 2D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput2D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveMultiCase2d(JSON.stringify(config)));
+}
+
+/** Solve 3D multi-case analysis via WASM. */
+export function solveMultiCase3D(config: any): any {
+  if (!wasmReady || !wasmSolveMultiCase3d) throw new Error('WASM multi-case 3D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput3D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveMultiCase3d(JSON.stringify(config)));
+}
+
+// ─── Nonlinear Path-Following Solvers ─────────────────────────────
+
+/** Solve arc-length (Riks) analysis via WASM. */
+export function solveArcLength(config: any): any {
+  if (!wasmReady || !wasmSolveArcLength) throw new Error('WASM arc-length solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    const is3D = config.solver.plates || config.solver.quads || config.solver.constraints;
+    config = { ...config, solver: JSON.parse(is3D ? serializeInput3D(config.solver) : serializeInput2D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveArcLength(JSON.stringify(config)));
+}
+
+/** Solve displacement-control analysis via WASM. */
+export function solveDisplacementControl(config: any): any {
+  if (!wasmReady || !wasmSolveDisplacementControl) throw new Error('WASM displacement-control solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    const is3D = config.solver.plates || config.solver.quads || config.solver.constraints;
+    config = { ...config, solver: JSON.parse(is3D ? serializeInput3D(config.solver) : serializeInput2D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveDisplacementControl(JSON.stringify(config)));
+}
+
+// ─── Imperfection Solvers ─────────────────────────────────────────
+
+/** Solve 2D analysis with geometric imperfections via WASM. */
+export function solveWithImperfections2D(config: any): any {
+  if (!wasmReady || !wasmSolveWithImperfections2d) throw new Error('WASM imperfections 2D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput2D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveWithImperfections2d(JSON.stringify(config)));
+}
+
+/** Solve 3D analysis with geometric imperfections via WASM. */
+export function solveWithImperfections3D(config: any): any {
+  if (!wasmReady || !wasmSolveWithImperfections3d) throw new Error('WASM imperfections 3D solver not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput3D(config.solver)) };
+  }
+  return JSON.parse(wasmSolveWithImperfections3d(JSON.stringify(config)));
+}
+
+// ─── 3D Influence Line ────────────────────────────────────────────
+
+/** Compute 3D influence line via WASM. */
+export function computeInfluenceLine3D(config: any): any {
+  if (!wasmReady || !wasmComputeInfluenceLine3d) throw new Error('WASM influence line 3D not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput3D(config.solver)) };
+  }
+  return JSON.parse(wasmComputeInfluenceLine3d(JSON.stringify(config)));
+}
+
+// ─── Section Analysis ─────────────────────────────────────────────
+
+/** Analyze cross-section properties via WASM. */
+export function analyzeSection(input: any): any {
+  if (!wasmReady || !wasmAnalyzeSection) throw new Error('WASM section analysis not available.');
+  return JSON.parse(wasmAnalyzeSection(JSON.stringify(input)));
+}
+
+// ─── Model Reduction ──────────────────────────────────────────────
+
+/** Guyan (static) condensation of a 2D model via WASM. */
+export function guyanReduce2D(config: any): any {
+  if (!wasmReady || !wasmGuyanReduce2d) throw new Error('WASM Guyan reduction not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput2D(config.solver)) };
+  }
+  return JSON.parse(wasmGuyanReduce2d(JSON.stringify(config)));
+}
+
+/** Craig-Bampton substructure reduction of a 2D model via WASM. */
+export function craigBampton2D(config: any): any {
+  if (!wasmReady || !wasmCraigBampton2d) throw new Error('WASM Craig-Bampton reduction not available.');
+  if (config.solver && config.solver.nodes instanceof Map) {
+    config = { ...config, solver: JSON.parse(serializeInput2D(config.solver)) };
+  }
+  return JSON.parse(wasmCraigBampton2d(JSON.stringify(config)));
 }

--- a/web/src/lib/export/excel.ts
+++ b/web/src/lib/export/excel.ts
@@ -14,6 +14,7 @@
 
 import * as XLSX from 'xlsx';
 import { modelStore, resultsStore, uiStore } from '../store';
+import { t } from '../i18n';
 
 interface ExcelExportOptions {
   filename?: string;
@@ -35,18 +36,18 @@ function createSummarySheet(): XLSX.WorkSheet {
   const r2d = resultsStore.results;
   const data: (string | number)[][] = [];
 
-  data.push([`ANÁLISIS ESTRUCTURAL ${is3D ? '3D' : '2D'} - RESUMEN`]);
+  data.push([`${t('excel.structuralAnalysis')} ${is3D ? '3D' : '2D'} - ${t('excel.summary')}`]);
   data.push([]);
 
-  data.push(['MODELO']);
-  data.push(['Nodos', modelStore.nodes.size]);
-  data.push(['Elementos', modelStore.elements.size]);
-  data.push(['Apoyos', modelStore.supports.size]);
-  data.push(['Cargas', modelStore.loads.length]);
+  data.push([t('excel.model')]);
+  data.push([t('excel.nodes'), modelStore.nodes.size]);
+  data.push([t('excel.elements'), modelStore.elements.size]);
+  data.push([t('excel.supports'), modelStore.supports.size]);
+  data.push([t('excel.loads'), modelStore.loads.length]);
   data.push([]);
 
   if (is3D && r3d) {
-    data.push(['RESULTADOS MÁXIMOS']);
+    data.push([t('excel.maxResults')]);
     let maxDisp = 0, maxN = 0, maxVy = 0, maxVz = 0, maxMy = 0, maxMz = 0, maxMx = 0;
     for (const d of r3d.displacements) {
       const mag = Math.sqrt(d.ux ** 2 + d.uy ** 2 + d.uz ** 2);
@@ -60,13 +61,13 @@ function createSummarySheet(): XLSX.WorkSheet {
       maxMy = Math.max(maxMy, Math.abs(ef.myStart), Math.abs(ef.myEnd));
       maxMz = Math.max(maxMz, Math.abs(ef.mzStart), Math.abs(ef.mzEnd));
     }
-    data.push(['Desplazamiento máximo', (maxDisp * 1000).toFixed(4), 'mm']);
-    data.push(['|N| máximo', maxN.toFixed(2), 'kN']);
-    data.push(['|Vy| máximo', maxVy.toFixed(2), 'kN']);
-    data.push(['|Vz| máximo', maxVz.toFixed(2), 'kN']);
-    data.push(['|Mx| máximo', maxMx.toFixed(2), 'kN·m']);
-    data.push(['|My| máximo', maxMy.toFixed(2), 'kN·m']);
-    data.push(['|Mz| máximo', maxMz.toFixed(2), 'kN·m']);
+    data.push([t('excel.maxDisplacement'), (maxDisp * 1000).toFixed(4), 'mm']);
+    data.push([t('excel.maxN'), maxN.toFixed(2), 'kN']);
+    data.push([t('excel.maxVy'), maxVy.toFixed(2), 'kN']);
+    data.push([t('excel.maxVz'), maxVz.toFixed(2), 'kN']);
+    data.push([t('excel.maxMx'), maxMx.toFixed(2), 'kN·m']);
+    data.push([t('excel.maxMy'), maxMy.toFixed(2), 'kN·m']);
+    data.push([t('excel.maxMz'), maxMz.toFixed(2), 'kN·m']);
     data.push([]);
 
     let sumFx = 0, sumFy = 0, sumFz = 0, sumMx2 = 0, sumMy2 = 0, sumMz2 = 0;
@@ -74,7 +75,7 @@ function createSummarySheet(): XLSX.WorkSheet {
       sumFx += r.fx; sumFy += r.fy; sumFz += r.fz;
       sumMx2 += r.mx; sumMy2 += r.my; sumMz2 += r.mz;
     }
-    data.push(['VERIFICACIÓN DE EQUILIBRIO']);
+    data.push([t('excel.equilibriumCheck')]);
     data.push(['ΣFx', sumFx.toFixed(4), 'kN']);
     data.push(['ΣFy', sumFy.toFixed(4), 'kN']);
     data.push(['ΣFz', sumFz.toFixed(4), 'kN']);
@@ -82,23 +83,23 @@ function createSummarySheet(): XLSX.WorkSheet {
     data.push(['ΣMy', sumMy2.toFixed(4), 'kN·m']);
     data.push(['ΣMz', sumMz2.toFixed(4), 'kN·m']);
   } else if (r2d) {
-    data.push(['RESULTADOS MÁXIMOS']);
-    data.push(['Desplazamiento máximo', (resultsStore.maxDisplacement * 1000).toFixed(4), 'mm']);
-    data.push(['Momento máximo', resultsStore.maxMoment.toFixed(2), 'kN·m']);
-    data.push(['Corte máximo', resultsStore.maxShear.toFixed(2), 'kN']);
+    data.push([t('excel.maxResults')]);
+    data.push([t('excel.maxDisplacement'), (resultsStore.maxDisplacement * 1000).toFixed(4), 'mm']);
+    data.push([t('excel.maxMoment'), resultsStore.maxMoment.toFixed(2), 'kN·m']);
+    data.push([t('excel.maxShear'), resultsStore.maxShear.toFixed(2), 'kN']);
 
     let maxAxial = 0;
     for (const ef of r2d.elementForces) {
       maxAxial = Math.max(maxAxial, Math.abs(ef.nStart), Math.abs(ef.nEnd));
     }
-    data.push(['Axil máximo', maxAxial.toFixed(2), 'kN']);
+    data.push([t('excel.maxAxial'), maxAxial.toFixed(2), 'kN']);
     data.push([]);
 
     let sumRx = 0, sumRy = 0, sumMz = 0;
     for (const r of r2d.reactions) {
       sumRx += r.rx; sumRy += r.ry; sumMz += r.mz;
     }
-    data.push(['VERIFICACIÓN DE EQUILIBRIO']);
+    data.push([t('excel.equilibriumCheck')]);
     data.push(['ΣRx', sumRx.toFixed(4), 'kN']);
     data.push(['ΣRy', sumRy.toFixed(4), 'kN']);
     data.push(['ΣMz', sumMz.toFixed(4), 'kN·m']);
@@ -116,12 +117,12 @@ function createElementsSheet(): XLSX.WorkSheet {
   const hasResults = is3D ? !!r3d : !!r2d;
 
   const headers = [
-    'ID', 'Tipo', 'Nodo I', 'Nodo J', 'L (m)',
-    'Material', 'E (MPa)',
-    'Sección', 'A (m²)', 'Iy (m⁴)',
+    'ID', t('excel.type'), t('excel.nodeI'), t('excel.nodeJ'), 'L (m)',
+    t('excel.material'), 'E (MPa)',
+    t('excel.section'), 'A (m²)', 'Iy (m⁴)',
   ];
   if (is3D) headers.push('Iz (m⁴)', 'J (m⁴)');
-  headers.push('Art. I', 'Art. J');
+  headers.push(t('excel.hingeI'), t('excel.hingeJ'));
 
   if (hasResults && is3D) {
     headers.push(
@@ -157,7 +158,7 @@ function createElementsSheet(): XLSX.WorkSheet {
       sec?.name ?? '-', sec?.a ?? 0, sec?.iy ?? sec?.iz ?? 0,
     ];
     if (is3D) row.push(sec?.iz ?? 0, sec?.j ?? 0);
-    row.push(elem.hingeStart ? 'Sí' : 'No', elem.hingeEnd ? 'Sí' : 'No');
+    row.push(elem.hingeStart ? t('excel.yes') : t('excel.no'), elem.hingeEnd ? t('excel.yes') : t('excel.no'));
 
     if (hasResults && is3D && r3d) {
       const f = r3d.elementForces.find(f => f.elementId === elem.id);
@@ -260,11 +261,11 @@ function createReactionsSheet(): XLSX.WorkSheet {
   const r2d = resultsStore.results;
 
   if (!r3d && !r2d) {
-    return XLSX.utils.aoa_to_sheet([['Sin resultados - calcular primero']]);
+    return XLSX.utils.aoa_to_sheet([[t('excel.noResults')]]);
   }
 
   if (is3D && r3d) {
-    const headers = ['Nodo', 'Tipo', 'Fx (kN)', 'Fy (kN)', 'Fz (kN)', 'Mx (kN·m)', 'My (kN·m)', 'Mz (kN·m)'];
+    const headers = [t('excel.node'), t('excel.type'), 'Fx (kN)', 'Fy (kN)', 'Fz (kN)', 'Mx (kN·m)', 'My (kN·m)', 'Mz (kN·m)'];
     const data: (string | number)[][] = [headers];
 
     for (const r of r3d.reactions) {
@@ -282,7 +283,7 @@ function createReactionsSheet(): XLSX.WorkSheet {
     );
     data.push([]);
     data.push([
-      'TOTAL', '',
+      t('excel.total'), '',
       Number(totals.fx.toFixed(4)), Number(totals.fy.toFixed(4)), Number(totals.fz.toFixed(4)),
       Number(totals.mx.toFixed(4)), Number(totals.my.toFixed(4)), Number(totals.mz.toFixed(4)),
     ]);
@@ -293,14 +294,14 @@ function createReactionsSheet(): XLSX.WorkSheet {
   }
 
   // 2D fallback
-  const headers = ['Nodo', 'Tipo Apoyo', 'Rx (kN)', 'Ry (kN)', 'Mz (kN·m)'];
+  const headers = [t('excel.node'), t('excel.supportType'), 'Rx (kN)', 'Ry (kN)', 'Mz (kN·m)'];
   const data: (string | number)[][] = [headers];
 
   for (const r of r2d!.reactions) {
     const sup = [...modelStore.supports.values()].find(s => s.nodeId === r.nodeId);
     const supType = sup ? {
-      fixed: 'Empotrado', pinned: 'Articulado',
-      rollerX: 'Móvil X', rollerY: 'Móvil Y', spring: 'Resorte',
+      fixed: t('excel.fixed'), pinned: t('excel.pinned'),
+      rollerX: t('excel.rollerX'), rollerY: t('excel.rollerY'), spring: t('excel.spring'),
     }[sup.type] ?? sup.type : '-';
 
     data.push([
@@ -314,7 +315,7 @@ function createReactionsSheet(): XLSX.WorkSheet {
     { rx: 0, ry: 0, mz: 0 }
   );
   data.push([]);
-  data.push(['TOTAL', '', Number(totals.rx.toFixed(4)), Number(totals.ry.toFixed(4)), Number(totals.mz.toFixed(4))]);
+  data.push([t('excel.total'), '', Number(totals.rx.toFixed(4)), Number(totals.ry.toFixed(4)), Number(totals.mz.toFixed(4))]);
 
   const ws = XLSX.utils.aoa_to_sheet(data);
   ws['!cols'] = [{ wch: 8 }, { wch: 14 }, { wch: 12 }, { wch: 12 }, { wch: 14 }];
@@ -322,7 +323,7 @@ function createReactionsSheet(): XLSX.WorkSheet {
 }
 
 function createMaterialsSheet(): XLSX.WorkSheet {
-  const headers = ['ID', 'Nombre', 'E (MPa)', 'ν', 'ρ (kN/m³)', 'fy (MPa)'];
+  const headers = ['ID', t('excel.name'), 'E (MPa)', 'ν', 'ρ (kN/m³)', 'fy (MPa)'];
   const data: (string | number)[][] = [headers];
 
   for (const mat of modelStore.materials.values()) {
@@ -336,7 +337,7 @@ function createMaterialsSheet(): XLSX.WorkSheet {
 
 function createSectionsSheet(): XLSX.WorkSheet {
   const is3D = uiStore.analysisMode === '3d';
-  const headers = ['ID', 'Nombre', 'Forma', 'A (m²)', 'Iy (m⁴)'];
+  const headers = ['ID', t('excel.name'), t('excel.shape'), 'A (m²)', 'Iy (m⁴)'];
   if (is3D) headers.push('Iz (m⁴)', 'J (m⁴)');
   headers.push('b (m)', 'h (m)', 'tw (m)', 'tf (m)');
 
@@ -365,16 +366,16 @@ export function exportToExcel(options: ExcelExportOptions = {}): void {
 
   const wb = XLSX.utils.book_new();
 
-  XLSX.utils.book_append_sheet(wb, createSummarySheet(), 'Resumen');
-  XLSX.utils.book_append_sheet(wb, createElementsSheet(), 'Elementos');
-  XLSX.utils.book_append_sheet(wb, createNodesSheet(), 'Nodos');
+  XLSX.utils.book_append_sheet(wb, createSummarySheet(), t('excel.sheetSummary'));
+  XLSX.utils.book_append_sheet(wb, createElementsSheet(), t('excel.sheetElements'));
+  XLSX.utils.book_append_sheet(wb, createNodesSheet(), t('excel.sheetNodes'));
 
   if (includeResults && hasResults) {
-    XLSX.utils.book_append_sheet(wb, createReactionsSheet(), 'Reacciones');
+    XLSX.utils.book_append_sheet(wb, createReactionsSheet(), t('excel.sheetReactions'));
   }
 
-  XLSX.utils.book_append_sheet(wb, createMaterialsSheet(), 'Materiales');
-  XLSX.utils.book_append_sheet(wb, createSectionsSheet(), 'Secciones');
+  XLSX.utils.book_append_sheet(wb, createMaterialsSheet(), t('excel.sheetMaterials'));
+  XLSX.utils.book_append_sheet(wb, createSectionsSheet(), t('excel.sheetSections'));
 
   XLSX.writeFile(wb, filename);
 }

--- a/web/src/lib/ifc/ifc-mapper.ts
+++ b/web/src/lib/ifc/ifc-mapper.ts
@@ -2,6 +2,7 @@
 // This mapper is independent of web-ifc and operates on pre-parsed data.
 
 import { searchProfiles, profileToSectionFull } from '../data/steel-profiles';
+import { t } from '../i18n';
 
 // ─── Types ────────────────────────────────────────────────────
 
@@ -154,10 +155,10 @@ export function mapIfcToModel(
           name, a, iz, h, b, t,
           shape: t ? 'RHS' : 'rect',
         });
-        warnings.push(`Perfil "${name}" estimado de dimensiones`);
+        warnings.push(t('ifc.profileEstimated').replace('{n}', name));
       } else {
         // Fallback: generic rectangular 200x200
-        warnings.push(`Perfil "${name}" no reconocido — usando genérico 200x200mm`);
+        warnings.push(t('ifc.profileUnknown').replace('{n}', name));
         sections.push({
           name,
           a: 0.04,     // 200mm x 200mm

--- a/web/src/lib/ifc/ifc-parser.ts
+++ b/web/src/lib/ifc/ifc-parser.ts
@@ -2,6 +2,7 @@
 // This module requires the web-ifc WASM to be available at /web-ifc.wasm
 
 import type { IfcMember } from './ifc-mapper';
+import { t } from '../i18n';
 
 // IFC entity type constants
 const IFCBEAM = 753729222;
@@ -230,7 +231,7 @@ export async function parseIfc(data: ArrayBuffer): Promise<IfcParseResult> {
   api.CloseModel(modelID);
 
   if (members.length === 0) {
-    warnings.push('No se encontraron miembros estructurales (IfcBeam, IfcColumn, IfcMember)');
+    warnings.push(t('ifc.noMembers'));
   }
 
   return { members, warnings };

--- a/web/src/lib/templates/generators.ts
+++ b/web/src/lib/templates/generators.ts
@@ -3,6 +3,7 @@
 
 import type { ModelSnapshot } from '../store/history.svelte';
 import { computeLocalAxes3D } from '../engine/solver-3d';
+import { t } from '../i18n';
 
 // Default material and section
 const DEFAULT_MATERIAL = { id: 1, name: 'Acero S235', e: 210000000, nu: 0.3, rho: 78.5 }; // kN/m² for E
@@ -426,6 +427,73 @@ export interface TemplateParam {
   integer?: boolean;
 }
 
+export function getTemplateCatalog(): TemplateInfo[] {
+  return [
+    {
+      id: 'simpleBeam', name: t('tmpl.simpleBeam'), category: t('tmpl.catBeams'),
+      params: [
+        { key: 'L', label: t('tmpl.span'), unit: 'm', default: 6, min: 1, max: 50, step: 0.5 },
+        { key: 'q', label: t('tmpl.load'), unit: 'kN/m', default: -10, min: -100, max: 100, step: 1 },
+        { key: 'nDiv', label: t('tmpl.divisions'), unit: '', default: 4, min: 1, max: 20, step: 1, integer: true },
+      ],
+    },
+    {
+      id: 'cantilever', name: t('tmpl.cantilever'), category: t('tmpl.catBeams'),
+      params: [
+        { key: 'L', label: t('tmpl.length'), unit: 'm', default: 3, min: 1, max: 30, step: 0.5 },
+        { key: 'P', label: t('tmpl.pointLoad'), unit: 'kN', default: -15, min: -200, max: 200, step: 1 },
+        { key: 'nDiv', label: t('tmpl.divisions'), unit: '', default: 3, min: 1, max: 20, step: 1, integer: true },
+      ],
+    },
+    {
+      id: 'continuousBeam', name: t('tmpl.continuousBeam'), category: t('tmpl.catBeams'),
+      params: [
+        { key: 'nSpans', label: t('tmpl.spans'), unit: '', default: 3, min: 2, max: 10, step: 1, integer: true },
+        { key: 'spanLength', label: t('tmpl.spanLength'), unit: 'm', default: 5, min: 1, max: 30, step: 0.5 },
+        { key: 'q', label: t('tmpl.load'), unit: 'kN/m', default: -10, min: -100, max: 100, step: 1 },
+        { key: 'nDivPerSpan', label: t('tmpl.divPerSpan'), unit: '', default: 4, min: 1, max: 10, step: 1, integer: true },
+      ],
+    },
+    {
+      id: 'portalFrame', name: t('tmpl.portalFrame'), category: t('tmpl.catFrames'),
+      params: [
+        { key: 'width', label: t('tmpl.width'), unit: 'm', default: 6, min: 2, max: 30, step: 0.5 },
+        { key: 'height', label: t('tmpl.height'), unit: 'm', default: 4, min: 2, max: 20, step: 0.5 },
+        { key: 'qBeam', label: t('tmpl.beamLoad'), unit: 'kN/m', default: -15, min: -100, max: 100, step: 1 },
+        { key: 'Hlateral', label: t('tmpl.lateralLoad'), unit: 'kN', default: 10, min: -100, max: 100, step: 1 },
+      ],
+    },
+    {
+      id: 'multiStory', name: t('tmpl.multiStory'), category: t('tmpl.catFrames'),
+      params: [
+        { key: 'nBays', label: t('tmpl.bays'), unit: '', default: 2, min: 1, max: 6, step: 1, integer: true },
+        { key: 'nFloors', label: t('tmpl.floors'), unit: '', default: 3, min: 1, max: 10, step: 1, integer: true },
+        { key: 'bayWidth', label: t('tmpl.bayWidth'), unit: 'm', default: 5, min: 2, max: 15, step: 0.5 },
+        { key: 'floorHeight', label: t('tmpl.floorHeight'), unit: 'm', default: 3, min: 2, max: 6, step: 0.5 },
+        { key: 'qBeam', label: t('tmpl.beamLoad'), unit: 'kN/m', default: -20, min: -100, max: 100, step: 1 },
+        { key: 'Hlateral', label: t('tmpl.lateralPerFloor'), unit: 'kN', default: 10, min: -100, max: 100, step: 1 },
+      ],
+    },
+    {
+      id: 'prattTruss', name: t('tmpl.prattTruss'), category: t('tmpl.catTrusses'),
+      params: [
+        { key: 'span', label: t('tmpl.span'), unit: 'm', default: 12, min: 4, max: 60, step: 1 },
+        { key: 'height', label: t('tmpl.height'), unit: 'm', default: 2, min: 0.5, max: 10, step: 0.5 },
+        { key: 'nPanels', label: t('tmpl.panels'), unit: '', default: 6, min: 4, max: 20, step: 2, integer: true },
+      ],
+    },
+    {
+      id: 'warrenTruss', name: t('tmpl.warrenTruss'), category: t('tmpl.catTrusses'),
+      params: [
+        { key: 'span', label: t('tmpl.span'), unit: 'm', default: 12, min: 4, max: 60, step: 1 },
+        { key: 'height', label: t('tmpl.height'), unit: 'm', default: 2, min: 0.5, max: 10, step: 0.5 },
+        { key: 'nPanels', label: t('tmpl.panels'), unit: '', default: 6, min: 4, max: 20, step: 2, integer: true },
+      ],
+    },
+  ];
+}
+
+/** @deprecated Use getTemplateCatalog() instead */
 export const TEMPLATE_CATALOG: TemplateInfo[] = [
   {
     id: 'simpleBeam', name: 'Viga biarticulada', category: 'Vigas',
@@ -834,83 +902,88 @@ export interface TemplateInfo3D {
   generate: (store: ModelStore, paramValues?: Record<string, number>) => void;
 }
 
-export const TEMPLATE_CATALOG_3D: TemplateInfo3D[] = [
-  {
-    id: 'hingedArch3D',
-    name: 'Arco Articulado 3D',
-    desc: 'Arco parabólico con articulaciones en cuartos de luz',
-    params: [
-      { key: 'span', label: 'Luz', unit: 'm', default: 12, min: 4, max: 60, step: 1 },
-      { key: 'rise', label: 'Flecha', unit: 'm', default: 4, min: 0.5, max: 15, step: 0.5 },
-      { key: 'nSegments', label: 'Segmentos', unit: '', default: 12, min: 4, max: 40, step: 2, integer: true },
-      { key: 'q', label: 'Carga', unit: 'kN/m', default: -8, min: -100, max: 100, step: 1 },
-    ],
+export function getTemplateCatalog3D(): TemplateInfo3D[] {
+  return [
+    {
+      id: 'hingedArch3D',
+      name: t('tmpl3d.hingedArch'),
+      desc: t('tmpl3d.hingedArchDesc'),
+      params: [
+        { key: 'span', label: t('tmpl.span'), unit: 'm', default: 12, min: 4, max: 60, step: 1 },
+        { key: 'rise', label: t('tmpl.rise'), unit: 'm', default: 4, min: 0.5, max: 15, step: 0.5 },
+        { key: 'nSegments', label: t('tmpl.segments'), unit: '', default: 12, min: 4, max: 40, step: 2, integer: true },
+        { key: 'q', label: t('tmpl.load'), unit: 'kN/m', default: -8, min: -100, max: 100, step: 1 },
+      ],
     generate: (s, p) => generate3DHingedArch(s, {
       span: p?.span ?? 12, rise: p?.rise ?? 4, nSegments: p?.nSegments ?? 12, q: p?.q ?? -8,
     }),
   },
-  {
-    id: 'gridBeams',
-    name: 'Emparrillado',
-    desc: 'Grilla de vigas en plano XZ con apoyos en esquinas',
-    params: [
-      { key: 'Lx', label: 'Largo X', unit: 'm', default: 8, min: 2, max: 30, step: 0.5 },
-      { key: 'Lz', label: 'Largo Z', unit: 'm', default: 8, min: 2, max: 30, step: 0.5 },
-      { key: 'nDivX', label: 'Divisiones X', unit: '', default: 4, min: 2, max: 10, step: 1, integer: true },
-      { key: 'nDivZ', label: 'Divisiones Z', unit: '', default: 4, min: 2, max: 10, step: 1, integer: true },
-      { key: 'q', label: 'Carga nodos', unit: 'kN', default: -20, min: -100, max: 100, step: 1 },
-    ],
-    generate: (s, p) => generateGridBeams(s, {
-      Lx: p?.Lx ?? 8, Lz: p?.Lz ?? 8, nDivX: p?.nDivX ?? 4, nDivZ: p?.nDivZ ?? 4, q: p?.q ?? -20,
-    }),
-  },
-  {
-    id: 'spaceFrame3D',
-    name: 'Pórtico Espacial',
-    desc: 'Pórtico espacial con vigas y columnas',
-    params: [
-      { key: 'nBaysX', label: 'Vanos X', unit: '', default: 2, min: 1, max: 6, step: 1, integer: true },
-      { key: 'nBaysY', label: 'Vanos Z', unit: '', default: 2, min: 1, max: 6, step: 1, integer: true },
-      { key: 'nFloors', label: 'Pisos', unit: '', default: 2, min: 1, max: 10, step: 1, integer: true },
-      { key: 'bayWidth', label: 'Ancho vano', unit: 'm', default: 5, min: 2, max: 15, step: 0.5 },
-      { key: 'storyHeight', label: 'Alto piso', unit: 'm', default: 3, min: 2, max: 6, step: 0.5 },
-      { key: 'q', label: 'Carga vigas', unit: 'kN/m', default: -10, min: -100, max: 100, step: 1 },
-    ],
-    generate: (s, p) => generateSpaceFrame3D(s, {
-      nBaysX: p?.nBaysX ?? 2, nBaysY: p?.nBaysY ?? 2, nFloors: p?.nFloors ?? 2,
-      bayWidth: p?.bayWidth ?? 5, storyHeight: p?.storyHeight ?? 3, q: p?.q ?? -10,
-    }),
-  },
-  {
-    id: 'tower3D_2',
-    name: 'Torre 2 pisos',
-    desc: 'Torre arriostrada con 4 columnas',
-    params: [
-      { key: 'H', label: 'Altura', unit: 'm', default: 6, min: 3, max: 30, step: 0.5 },
-      { key: 'nLevels', label: 'Niveles', unit: '', default: 2, min: 1, max: 10, step: 1, integer: true },
-      { key: 'baseWidth', label: 'Ancho base', unit: 'm', default: 3, min: 1, max: 10, step: 0.5 },
-      { key: 'topWidth', label: 'Ancho arriba', unit: 'm', default: 2.5, min: 0.5, max: 10, step: 0.5 },
-      { key: 'lateralLoad', label: 'Carga lateral', unit: 'kN', default: 10, min: 0, max: 100, step: 1 },
-    ],
-    generate: (s, p) => generateTower3D(s, {
-      H: p?.H ?? 6, nLevels: p?.nLevels ?? 2, baseWidth: p?.baseWidth ?? 3,
-      topWidth: p?.topWidth ?? 2.5, withBracing: true, lateralLoad: p?.lateralLoad ?? 10,
-    }),
-  },
-  {
-    id: 'tower3D_4',
-    name: 'Torre 4 pisos',
-    desc: 'Torre arriostrada con estrechamiento',
-    params: [
-      { key: 'H', label: 'Altura', unit: 'm', default: 12, min: 4, max: 40, step: 0.5 },
-      { key: 'nLevels', label: 'Niveles', unit: '', default: 4, min: 2, max: 10, step: 1, integer: true },
-      { key: 'baseWidth', label: 'Ancho base', unit: 'm', default: 3, min: 1, max: 10, step: 0.5 },
-      { key: 'topWidth', label: 'Ancho arriba', unit: 'm', default: 2, min: 0.5, max: 10, step: 0.5 },
-      { key: 'lateralLoad', label: 'Carga lateral', unit: 'kN', default: 10, min: 0, max: 100, step: 1 },
-    ],
-    generate: (s, p) => generateTower3D(s, {
-      H: p?.H ?? 12, nLevels: p?.nLevels ?? 4, baseWidth: p?.baseWidth ?? 3,
-      topWidth: p?.topWidth ?? 2, withBracing: true, lateralLoad: p?.lateralLoad ?? 10,
-    }),
-  },
-];
+    {
+      id: 'gridBeams',
+      name: t('tmpl3d.gridBeams'),
+      desc: t('tmpl3d.gridBeamsDesc'),
+      params: [
+        { key: 'Lx', label: t('tmpl.lengthX'), unit: 'm', default: 8, min: 2, max: 30, step: 0.5 },
+        { key: 'Lz', label: t('tmpl.lengthZ'), unit: 'm', default: 8, min: 2, max: 30, step: 0.5 },
+        { key: 'nDivX', label: t('tmpl.divisionsX'), unit: '', default: 4, min: 2, max: 10, step: 1, integer: true },
+        { key: 'nDivZ', label: t('tmpl.divisionsZ'), unit: '', default: 4, min: 2, max: 10, step: 1, integer: true },
+        { key: 'q', label: t('tmpl.nodeLoad'), unit: 'kN', default: -20, min: -100, max: 100, step: 1 },
+      ],
+      generate: (s, p) => generateGridBeams(s, {
+        Lx: p?.Lx ?? 8, Lz: p?.Lz ?? 8, nDivX: p?.nDivX ?? 4, nDivZ: p?.nDivZ ?? 4, q: p?.q ?? -20,
+      }),
+    },
+    {
+      id: 'spaceFrame3D',
+      name: t('tmpl3d.spaceFrame'),
+      desc: t('tmpl3d.spaceFrameDesc'),
+      params: [
+        { key: 'nBaysX', label: t('tmpl.baysX'), unit: '', default: 2, min: 1, max: 6, step: 1, integer: true },
+        { key: 'nBaysY', label: t('tmpl.baysZ'), unit: '', default: 2, min: 1, max: 6, step: 1, integer: true },
+        { key: 'nFloors', label: t('tmpl.floors'), unit: '', default: 2, min: 1, max: 10, step: 1, integer: true },
+        { key: 'bayWidth', label: t('tmpl.bayWidth'), unit: 'm', default: 5, min: 2, max: 15, step: 0.5 },
+        { key: 'storyHeight', label: t('tmpl.floorHeight'), unit: 'm', default: 3, min: 2, max: 6, step: 0.5 },
+        { key: 'q', label: t('tmpl.beamLoad'), unit: 'kN/m', default: -10, min: -100, max: 100, step: 1 },
+      ],
+      generate: (s, p) => generateSpaceFrame3D(s, {
+        nBaysX: p?.nBaysX ?? 2, nBaysY: p?.nBaysY ?? 2, nFloors: p?.nFloors ?? 2,
+        bayWidth: p?.bayWidth ?? 5, storyHeight: p?.storyHeight ?? 3, q: p?.q ?? -10,
+      }),
+    },
+    {
+      id: 'tower3D_2',
+      name: t('tmpl3d.tower2'),
+      desc: t('tmpl3d.tower2Desc'),
+      params: [
+        { key: 'H', label: t('tmpl.totalHeight'), unit: 'm', default: 6, min: 3, max: 30, step: 0.5 },
+        { key: 'nLevels', label: t('tmpl.levels'), unit: '', default: 2, min: 1, max: 10, step: 1, integer: true },
+        { key: 'baseWidth', label: t('tmpl.baseWidth'), unit: 'm', default: 3, min: 1, max: 10, step: 0.5 },
+        { key: 'topWidth', label: t('tmpl.topWidth'), unit: 'm', default: 2.5, min: 0.5, max: 10, step: 0.5 },
+        { key: 'lateralLoad', label: t('tmpl.lateralLoad'), unit: 'kN', default: 10, min: 0, max: 100, step: 1 },
+      ],
+      generate: (s, p) => generateTower3D(s, {
+        H: p?.H ?? 6, nLevels: p?.nLevels ?? 2, baseWidth: p?.baseWidth ?? 3,
+        topWidth: p?.topWidth ?? 2.5, withBracing: true, lateralLoad: p?.lateralLoad ?? 10,
+      }),
+    },
+    {
+      id: 'tower3D_4',
+      name: t('tmpl3d.tower4'),
+      desc: t('tmpl3d.tower4Desc'),
+      params: [
+        { key: 'H', label: t('tmpl.totalHeight'), unit: 'm', default: 12, min: 4, max: 40, step: 0.5 },
+        { key: 'nLevels', label: t('tmpl.levels'), unit: '', default: 4, min: 2, max: 10, step: 1, integer: true },
+        { key: 'baseWidth', label: t('tmpl.baseWidth'), unit: 'm', default: 3, min: 1, max: 10, step: 0.5 },
+        { key: 'topWidth', label: t('tmpl.topWidth'), unit: 'm', default: 2, min: 0.5, max: 10, step: 0.5 },
+        { key: 'lateralLoad', label: t('tmpl.lateralLoad'), unit: 'kN', default: 10, min: 0, max: 100, step: 1 },
+      ],
+      generate: (s, p) => generateTower3D(s, {
+        H: p?.H ?? 12, nLevels: p?.nLevels ?? 4, baseWidth: p?.baseWidth ?? 3,
+        topWidth: p?.topWidth ?? 2, withBracing: true, lateralLoad: p?.lateralLoad ?? 10,
+      }),
+    },
+  ];
+}
+
+/** @deprecated Use getTemplateCatalog3D() instead */
+export const TEMPLATE_CATALOG_3D = getTemplateCatalog3D();

--- a/web/src/lib/three/axis-display.ts
+++ b/web/src/lib/three/axis-display.ts
@@ -1,0 +1,14 @@
+import type { LocalAxes3D } from '../engine/solver-3d';
+
+/**
+ * Apply visual axis convention for diagram rendering.
+ * Terna izquierda: negate ey so positive diagrams flip to opposite side.
+ * Terna derecha (default): keep ey as-is (solver already uses right-hand rule).
+ */
+export function applyAxisConvention(axes: LocalAxes3D, leftHand: boolean): LocalAxes3D {
+  if (!leftHand) return axes;
+  return {
+    ...axes,
+    ey: [-axes.ey[0], -axes.ey[1], -axes.ey[2]] as [number, number, number],
+  };
+}

--- a/web/src/lib/three/create-load-arrow.ts
+++ b/web/src/lib/three/create-load-arrow.ts
@@ -324,3 +324,61 @@ export function createReactionArrow(
 
   return group;
 }
+
+const CONSTRAINT_COLOR = 0xf0a500;
+
+const DOF_DIR: Record<string, THREE.Vector3> = {
+  ux: new THREE.Vector3(1, 0, 0),
+  uy: new THREE.Vector3(0, 1, 0),
+  uz: new THREE.Vector3(0, 0, 1),
+  rx: new THREE.Vector3(1, 0, 0),
+  ry: new THREE.Vector3(0, 1, 0),
+  rz: new THREE.Vector3(0, 0, 1),
+};
+
+/**
+ * Create an arrow for a constraint force at a node.
+ * Similar to reaction arrows but with a distinct orange color.
+ */
+export function createConstraintForceArrow(
+  pos: { x: number; y: number; z: number },
+  dof: string,
+  force: number,
+  maxForce: number,
+): THREE.Group {
+  const group = new THREE.Group();
+  const origin = new THREE.Vector3(pos.x, pos.y, pos.z);
+  const baseDir = DOF_DIR[dof];
+  if (!baseDir || Math.abs(force) < 1e-10) return group;
+
+  const isRotational = dof.startsWith('r');
+
+  if (isRotational) {
+    // Moment-type constraint force — show as label only (like reaction moments)
+    const axisName = dof.toUpperCase().replace('R', 'M'); // rx -> MX
+    const label = createTextSprite(`${axisName}=${force.toFixed(2)} kN·m`, '#f0a500', 22);
+    label.position.copy(origin).add(baseDir.clone().multiplyScalar(0.5));
+    group.add(label);
+  } else {
+    // Translational constraint force — show as arrow
+    const dir = baseDir.clone();
+    if (force < 0) dir.negate();
+    const len = arrowLength(force, maxForce) * 0.8;
+
+    // Arrow starts away from node and points TOWARD the node (tip = node)
+    const farEnd = origin.clone().sub(dir.clone().multiplyScalar(len));
+    const arrow = new THREE.ArrowHelper(
+      dir, farEnd, len,
+      CONSTRAINT_COLOR, ARROW_HEAD_LENGTH, ARROW_HEAD_WIDTH,
+    );
+    group.add(arrow);
+
+    // Label at the far end of the arrow
+    const unit = 'kN';
+    const label = createTextSprite(`${force.toFixed(2)} ${unit}`, '#f0a500', 24);
+    label.position.copy(farEnd).sub(dir.clone().multiplyScalar(0.2));
+    group.add(label);
+  }
+
+  return group;
+}

--- a/web/src/lib/three/create-shell-mesh.ts
+++ b/web/src/lib/three/create-shell-mesh.ts
@@ -1,0 +1,102 @@
+// Create Three.js meshes for plate (DKT triangle) and quad (MITC4) shell elements
+import * as THREE from 'three';
+
+const SHELL_COLOR = 0x4ecdc4;
+const SHELL_OPACITY = 0.45;
+const EDGE_COLOR = 0x88ddcc;
+
+/** Shared material for shell faces (translucent, double-sided) */
+const shellMaterial = new THREE.MeshStandardMaterial({
+  color: SHELL_COLOR,
+  transparent: true,
+  opacity: SHELL_OPACITY,
+  side: THREE.DoubleSide,
+  depthWrite: false,
+  polygonOffset: true,
+  polygonOffsetFactor: 1,
+  polygonOffsetUnits: 1,
+});
+
+const edgeMaterial = new THREE.LineBasicMaterial({ color: EDGE_COLOR, linewidth: 1 });
+
+type Vec3 = { x: number; y: number; z: number };
+
+/**
+ * Create a triangular plate mesh (3-node DKT element)
+ */
+export function createPlateMesh(
+  n0: Vec3, n1: Vec3, n2: Vec3,
+  plateId: number,
+): THREE.Group {
+  const group = new THREE.Group();
+  group.userData = { type: 'plate', id: plateId };
+
+  // Face geometry
+  const geo = new THREE.BufferGeometry();
+  const verts = new Float32Array([
+    n0.x, n0.y, n0.z,
+    n1.x, n1.y, n1.z,
+    n2.x, n2.y, n2.z,
+  ]);
+  geo.setAttribute('position', new THREE.BufferAttribute(verts, 3));
+  geo.computeVertexNormals();
+
+  const mesh = new THREE.Mesh(geo, shellMaterial.clone());
+  group.add(mesh);
+
+  // Edges
+  const edgeGeo = new THREE.BufferGeometry();
+  const edgeVerts = new Float32Array([
+    n0.x, n0.y, n0.z,
+    n1.x, n1.y, n1.z,
+    n1.x, n1.y, n1.z,
+    n2.x, n2.y, n2.z,
+    n2.x, n2.y, n2.z,
+    n0.x, n0.y, n0.z,
+  ]);
+  edgeGeo.setAttribute('position', new THREE.BufferAttribute(edgeVerts, 3));
+  group.add(new THREE.LineSegments(edgeGeo, edgeMaterial));
+
+  return group;
+}
+
+/**
+ * Create a quadrilateral shell mesh (4-node MITC4 element)
+ * Nodes should be in order (CCW or CW, the material is double-sided)
+ */
+export function createQuadMesh(
+  n0: Vec3, n1: Vec3, n2: Vec3, n3: Vec3,
+  quadId: number,
+): THREE.Group {
+  const group = new THREE.Group();
+  group.userData = { type: 'quad', id: quadId };
+
+  // Face: two triangles (0-1-2, 0-2-3)
+  const geo = new THREE.BufferGeometry();
+  const verts = new Float32Array([
+    n0.x, n0.y, n0.z,
+    n1.x, n1.y, n1.z,
+    n2.x, n2.y, n2.z,
+    n0.x, n0.y, n0.z,
+    n2.x, n2.y, n2.z,
+    n3.x, n3.y, n3.z,
+  ]);
+  geo.setAttribute('position', new THREE.BufferAttribute(verts, 3));
+  geo.computeVertexNormals();
+
+  const mesh = new THREE.Mesh(geo, shellMaterial.clone());
+  group.add(mesh);
+
+  // Edges
+  const edgeGeo = new THREE.BufferGeometry();
+  const edgeVerts = new Float32Array([
+    n0.x, n0.y, n0.z, n1.x, n1.y, n1.z,
+    n1.x, n1.y, n1.z, n2.x, n2.y, n2.z,
+    n2.x, n2.y, n2.z, n3.x, n3.y, n3.z,
+    n3.x, n3.y, n3.z, n0.x, n0.y, n0.z,
+  ]);
+  edgeGeo.setAttribute('position', new THREE.BufferAttribute(edgeVerts, 3));
+  group.add(new THREE.LineSegments(edgeGeo, edgeMaterial));
+
+  return group;
+}

--- a/web/src/lib/three/selection-helpers.ts
+++ b/web/src/lib/three/selection-helpers.ts
@@ -95,6 +95,19 @@ export function heatmapColor(norm: number): number {
 }
 
 /**
+ * Verification status color: ok → green, warn → yellow, fail → red.
+ * Ratio-based: uses continuous gradient from green(0) → yellow(0.8) → red(1.2+).
+ */
+export function verificationColor(ratio: number | null): number {
+  if (ratio === null) return 0x888888; // no verification → gray
+  if (ratio <= 0.5) return 0x22cc66;     // green (safe)
+  if (ratio <= 0.9) return 0x88cc22;     // yellow-green
+  if (ratio <= 1.0) return 0xddaa00;     // amber (near limit)
+  if (ratio <= 1.1) return 0xff6600;     // orange (marginal fail)
+  return 0xee2222;                        // red (fail)
+}
+
+/**
  * Axial force color: tension (positive) → red, compression (negative) → blue, ~zero → gray
  */
 export function axialForceColor(nAvg: number): number {

--- a/web/src/lib/three/stress-heatmap.ts
+++ b/web/src/lib/three/stress-heatmap.ts
@@ -1,0 +1,188 @@
+// Continuous stress heatmap for frame elements and shell elements.
+// Creates per-vertex colored geometries that show stress/force variation along each member.
+
+import * as THREE from 'three';
+import { evaluateDiagramAt } from '../engine/diagrams-3d';
+import { computeSectionStress } from '../engine/section-stress-3d';
+import type { ElementForces3D } from '../engine/types-3d';
+import { heatmapColor } from './selection-helpers';
+
+const HEATMAP_SEGMENTS = 16; // Number of segments along each element
+const HEATMAP_RADIUS = 0.07; // Slightly larger than default cylinder (0.06)
+const RADIAL_SEGMENTS = 8;
+
+export type HeatmapVariable = 'moment' | 'shear' | 'axial' | 'stressRatio' | 'vonMises';
+
+interface SectionProps {
+  A: number;
+  Iz: number;
+  Iy: number;
+  h: number;
+  b: number;
+  fy: number;
+}
+
+/**
+ * Compute the heatmap value at a given t ∈ [0,1] along an element.
+ * Returns the raw (unsigned) value for normalization.
+ */
+function sampleValue(ef: ElementForces3D, variable: HeatmapVariable, t: number, sec: SectionProps): number {
+  switch (variable) {
+    case 'moment': {
+      const my = Math.abs(evaluateDiagramAt(ef, 'momentY', t));
+      const mz = Math.abs(evaluateDiagramAt(ef, 'momentZ', t));
+      return Math.max(my, mz);
+    }
+    case 'shear': {
+      const vy = Math.abs(evaluateDiagramAt(ef, 'shearY', t));
+      const vz = Math.abs(evaluateDiagramAt(ef, 'shearZ', t));
+      return Math.sqrt(vy * vy + vz * vz);
+    }
+    case 'axial':
+      return Math.abs(evaluateDiagramAt(ef, 'axial', t));
+    case 'stressRatio':
+    case 'vonMises': {
+      const N = evaluateDiagramAt(ef, 'axial', t);
+      const Vy = evaluateDiagramAt(ef, 'shearY', t);
+      const Vz = evaluateDiagramAt(ef, 'shearZ', t);
+      const Mx = evaluateDiagramAt(ef, 'torsion', t);
+      const My = evaluateDiagramAt(ef, 'momentY', t);
+      const Mz = evaluateDiagramAt(ef, 'momentZ', t);
+      const stress = computeSectionStress(N, Vy, Vz, Mx, My, Mz, sec.A, sec.Iz, sec.Iy, sec.h, sec.b, sec.fy);
+      return variable === 'stressRatio' ? stress.ratio : stress.vonMises;
+    }
+  }
+}
+
+/**
+ * Sample values at all segment positions for an element.
+ * Returns array of (HEATMAP_SEGMENTS + 1) values.
+ */
+export function sampleElementValues(
+  ef: ElementForces3D,
+  variable: HeatmapVariable,
+  sec: SectionProps,
+): number[] {
+  const values: number[] = [];
+  for (let i = 0; i <= HEATMAP_SEGMENTS; i++) {
+    const t = i / HEATMAP_SEGMENTS;
+    values.push(sampleValue(ef, variable, t, sec));
+  }
+  return values;
+}
+
+/**
+ * Create a CylinderGeometry with per-vertex colors based on sampled stress values.
+ * The cylinder is Y-aligned (matching Three.js default) and centered at origin.
+ */
+export function createHeatmapCylinder(
+  length: number,
+  values: number[],
+  globalMax: number,
+): THREE.Mesh {
+  const geo = new THREE.CylinderGeometry(
+    HEATMAP_RADIUS, HEATMAP_RADIUS,
+    length,
+    RADIAL_SEGMENTS,
+    HEATMAP_SEGMENTS,
+    true, // open ended — no caps needed
+  );
+
+  const posAttr = geo.getAttribute('position');
+  const vertexCount = posAttr.count;
+  const colors = new Float32Array(vertexCount * 3);
+  const tmpColor = new THREE.Color();
+
+  // CylinderGeometry (open) has (heightSegments+1) rings of (radialSegments+1) vertices.
+  // Rings go from bottom (-length/2) to top (+length/2), i.e. ring 0 = bottom = t=0
+  const ringsCount = HEATMAP_SEGMENTS + 1;
+  const vertsPerRing = RADIAL_SEGMENTS + 1;
+
+  for (let ring = 0; ring < ringsCount; ring++) {
+    const norm = globalMax > 1e-10 ? values[ring] / globalMax : 0;
+    tmpColor.setHex(heatmapColor(norm));
+
+    for (let v = 0; v < vertsPerRing; v++) {
+      const idx = ring * vertsPerRing + v;
+      colors[idx * 3] = tmpColor.r;
+      colors[idx * 3 + 1] = tmpColor.g;
+      colors[idx * 3 + 2] = tmpColor.b;
+    }
+  }
+
+  geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+
+  const mat = new THREE.MeshStandardMaterial({
+    vertexColors: true,
+    roughness: 0.5,
+    metalness: 0.15,
+    side: THREE.DoubleSide,
+  });
+
+  const mesh = new THREE.Mesh(geo, mat);
+  mesh.userData.heatmapMesh = true;
+  return mesh;
+}
+
+/**
+ * Orient and position a heatmap cylinder between two nodes.
+ * CylinderGeometry is Y-aligned by default, centered at origin.
+ */
+export function orientHeatmapMesh(
+  mesh: THREE.Mesh,
+  nI: { x: number; y: number; z: number },
+  nJ: { x: number; y: number; z: number },
+): void {
+  const mx = (nI.x + nJ.x) / 2;
+  const my = (nI.y + nJ.y) / 2;
+  const mz = (nI.z + nJ.z) / 2;
+  mesh.position.set(mx, my, mz);
+
+  const dir = new THREE.Vector3(nJ.x - nI.x, nJ.y - nI.y, nJ.z - nI.z).normalize();
+  const yAxis = new THREE.Vector3(0, 1, 0);
+  mesh.quaternion.setFromUnitVectors(yAxis, dir);
+}
+
+/**
+ * Apply per-vertex colors to a shell mesh (plate=3 nodes, quad=4 nodes).
+ * nodalValues: stress value at each node (3 for plates, 4 for quads).
+ * globalMax: global maximum for normalization.
+ */
+export function applyShellVertexColors(
+  mesh: THREE.Mesh,
+  nodalValues: number[],
+  globalMax: number,
+  isQuad: boolean,
+): void {
+  const geo = mesh.geometry;
+  const posCount = geo.getAttribute('position').count;
+  const colors = new Float32Array(posCount * 3);
+  const tmpColor = new THREE.Color();
+
+  if (!isQuad && nodalValues.length >= 3) {
+    // Triangle: 3 vertices
+    for (let i = 0; i < Math.min(posCount, 3); i++) {
+      const norm = globalMax > 1e-10 ? nodalValues[i] / globalMax : 0;
+      tmpColor.setHex(heatmapColor(norm));
+      colors[i * 3] = tmpColor.r;
+      colors[i * 3 + 1] = tmpColor.g;
+      colors[i * 3 + 2] = tmpColor.b;
+    }
+  } else if (isQuad && nodalValues.length >= 4) {
+    // Quad: 6 vertices (triangles 0-1-2, 0-2-3)
+    const vertexToNode = [0, 1, 2, 0, 2, 3];
+    for (let i = 0; i < Math.min(posCount, 6); i++) {
+      const norm = globalMax > 1e-10 ? nodalValues[vertexToNode[i]] / globalMax : 0;
+      tmpColor.setHex(heatmapColor(norm));
+      colors[i * 3] = tmpColor.r;
+      colors[i * 3 + 1] = tmpColor.g;
+      colors[i * 3 + 2] = tmpColor.b;
+    }
+  }
+
+  geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+  const mat = mesh.material as THREE.MeshStandardMaterial;
+  mat.vertexColors = true;
+  mat.color.setHex(0xffffff);
+  mat.needsUpdate = true;
+}

--- a/web/src/lib/viewport3d/results-sync.ts
+++ b/web/src/lib/viewport3d/results-sync.ts
@@ -4,16 +4,19 @@
 // Exports:
 //   - ResultsSyncContext (interface)
 //   - DIAGRAM_3D_TYPES (constant)
-//   - syncDeformed(), syncDiagrams3D(), syncColorMap3D(), syncReactions(), syncLabels3D()
+//   - syncDeformed(), syncDiagrams3D(), syncColorMap3D(), syncVerificationLabels(), syncReactions(), syncConstraintForces(), syncLabels3D()
 
 import * as THREE from 'three';
 import { modelStore, uiStore, resultsStore } from '../store';
 import { createDeformedLines, type ElementEI } from '../three/deformed-shape-3d';
 import { createDiagramGroup3D, createEnvelopeDiagramGroup3D } from '../three/diagram-render-3d';
-import { COLORS, setGroupColor, disposeObject, heatmapColor, axialForceColor, createTextSprite } from '../three/selection-helpers';
-import { createReactionArrow } from '../three/create-load-arrow';
+import { COLORS, setGroupColor, disposeObject, heatmapColor, axialForceColor, verificationColor, createTextSprite } from '../three/selection-helpers';
+import { verificationStore } from '../store/verification.svelte';
+import { createReactionArrow, createConstraintForceArrow } from '../three/create-load-arrow';
 import { computeElementStress3D } from '../engine/section-stress-3d';
 import type { Diagram3DKind } from '../engine/diagrams-3d';
+import type { Displacement3D } from '../engine/types-3d';
+import { sampleElementValues, createHeatmapCylinder, orientHeatmapMesh, applyShellVertexColors, type HeatmapVariable } from '../three/stress-heatmap';
 
 export const DIAGRAM_3D_TYPES: Set<string> = new Set(['momentY', 'momentZ', 'shearY', 'shearZ', 'axial', 'torsion']);
 
@@ -31,14 +34,19 @@ export interface ResultsSyncContext {
   // Element groups (needed for color map + deformed opacity)
   elementGroups: Map<number, THREE.Group>;
 
+  // Shell groups (needed for shell stress heatmap) — key: "p{id}" or "q{id}"
+  shellGroups: Map<string, THREE.Group>;
+
   // Results groups (replaced on each sync)
   deformedGroup: THREE.Group | null;
   diagramGroup: THREE.Group | null;
   overlayDiagramGroup: THREE.Group | null;
   reactionGroup: THREE.Group | null;
+  constraintForcesGroup: THREE.Group | null;
   nodeLabelsGroup: THREE.Group | null;
   elementLabelsGroup: THREE.Group | null;
   lengthLabelsGroup: THREE.Group | null;
+  verificationLabelsGroup: THREE.Group | null;
 
   // Mutable state flags
   lastDeformedAnimScale: number | null;
@@ -57,12 +65,16 @@ export function syncDeformed(ctx: ResultsSyncContext, scaleOverride?: number): v
     ctx.deformedGroup = null;
   }
 
+  const dt = resultsStore.diagramType;
+  const isDeformedLike = dt === 'deformed' || dt === 'modeShape' || dt === 'bucklingMode';
+
   // Restore element opacity when not showing deformed shape
-  const showingDeformed = resultsStore.results3D && resultsStore.diagramType === 'deformed';
+  const showingDeformed = resultsStore.results3D && isDeformedLike;
   for (const group of ctx.elementGroups.values()) {
     group.traverse((child) => {
-      // Skip invisible picking helpers — they must stay transparent
+      // Skip picking helpers and heatmap overlays — they manage their own state
       if (child.userData?.pickingHelper) return;
+      if (child.userData?.heatmapMesh) return;
       if ((child as THREE.Mesh).material) {
         const mat = (child as THREE.Mesh).material as THREE.Material;
         if (showingDeformed) {
@@ -76,37 +88,83 @@ export function syncDeformed(ctx: ResultsSyncContext, scaleOverride?: number): v
     });
   }
 
+  // Determine displacements source: static deformed, modal mode, or buckling mode
+  let displacements: Displacement3D[] | null = null;
+  let scale = scaleOverride ?? resultsStore.deformedScale;
+  let modeColor: number | null = null;
+
+  if (dt === 'deformed') {
+    const r3d = resultsStore.results3D;
+    if (!r3d) return;
+    displacements = r3d.displacements;
+  } else if (dt === 'modeShape') {
+    const modal = resultsStore.modalResult3D;
+    if (!modal || !modal.modes.length) return;
+    const mode = modal.modes[resultsStore.activeModeIndex];
+    if (!mode) return;
+    // Animated sinusoidal oscillation for mode shapes
+    scale = scale * Math.sin(performance.now() / 500);
+    displacements = mode.displacements;
+    modeColor = 0x4ecdc4; // cyan
+  } else if (dt === 'bucklingMode') {
+    const buckling = resultsStore.bucklingResult3D;
+    if (!buckling || !buckling.modes.length) return;
+    const mode = buckling.modes[resultsStore.activeBucklingMode];
+    if (!mode) return;
+    // Animated sinusoidal oscillation for buckling modes
+    scale = scale * Math.sin(performance.now() / 500);
+    displacements = mode.displacements;
+    modeColor = 0xe96941; // orange-red
+  } else {
+    return;
+  }
+
+  if (!displacements) return;
+
+  // Build EI map for particular solution (only for static deformed — modes don't need it)
+  let eiMap: Map<number, ElementEI> | undefined;
   const r3d = resultsStore.results3D;
-  if (!r3d || resultsStore.diagramType !== 'deformed') return;
-
-  // Use override scale (from animation loop) or store scale (from slider)
-  const scale = scaleOverride ?? resultsStore.deformedScale;
-
-  // Build EI map for particular solution (intra-element deflection from loads)
-  // Direct mapping: EIy = E·Iy (about Y horizontal), EIz = E·Iz (about Z vertical)
-  const eiMap = new Map<number, ElementEI>();
-  for (const [id, elem] of modelStore.elements) {
-    const mat = modelStore.materials.get(elem.materialId);
-    const sec = modelStore.sections.get(elem.sectionId);
-    if (mat && sec) {
-      const E = mat.e * 1000; // MPa → kN/m²
-      const modelIy = sec.iy ?? (sec.b && sec.h ? (sec.b * sec.h ** 3) / 12 : sec.iz);
-      eiMap.set(id, {
-        EIy: E * modelIy,    // Iy (about Y horizontal) → Z-plane bending (w, θy)
-        EIz: E * sec.iz,     // Iz (about Z vertical) → Y-plane bending (v, θz)
-      });
+  if (dt === 'deformed') {
+    eiMap = new Map<number, ElementEI>();
+    for (const [id, elem] of modelStore.elements) {
+      const mat = modelStore.materials.get(elem.materialId);
+      const sec = modelStore.sections.get(elem.sectionId);
+      if (mat && sec) {
+        const E = mat.e * 1000; // MPa → kN/m²
+        const modelIy = sec.iy ?? (sec.b && sec.h ? (sec.b * sec.h ** 3) / 12 : sec.iz);
+        eiMap.set(id, {
+          EIy: E * modelIy,    // Iy (about Y horizontal) → Z-plane bending (w, θy)
+          EIz: E * sec.iz,     // Iz (about Z vertical) → Y-plane bending (v, θz)
+        });
+      }
     }
   }
 
   ctx.deformedGroup = createDeformedLines(
     modelStore.elements,
     modelStore.nodes,
-    r3d.displacements,
-    r3d.elementForces,
+    displacements,
+    dt === 'deformed' && r3d ? r3d.elementForces : [],
     scale,
     eiMap,
     uiStore.axisConvention3D === 'leftHand',
   );
+
+  // Tint mode shapes with their distinctive color
+  if (modeColor !== null) {
+    const color = new THREE.Color(modeColor);
+    ctx.deformedGroup.traverse((child) => {
+      if ((child as THREE.Line).isLine && (child as THREE.Line).material) {
+        const mat = (child as THREE.Line).material as THREE.LineBasicMaterial;
+        mat.color.copy(color);
+      } else if ((child as THREE.Mesh).isMesh && (child as THREE.Mesh).material) {
+        const mat = (child as THREE.Mesh).material as THREE.MeshBasicMaterial;
+        if (!mat.color) return;
+        mat.color.copy(color);
+      }
+    });
+  }
+
   ctx.resultsParent.add(ctx.deformedGroup);
 }
 
@@ -203,15 +261,18 @@ export function syncColorMap3D(ctx: ResultsSyncContext): void {
   const r3d = resultsStore.results3D;
   const dt = resultsStore.diagramType;
 
-  // Restore default colors if not in color mode
-  if (!r3d || (dt !== 'axialColor' && dt !== 'colorMap')) {
+  // Restore default state if not in color mode
+  if (!r3d || (dt !== 'axialColor' && dt !== 'colorMap' && dt !== 'verification')) {
     if (ctx.colorMapApplied) {
+      clearHeatmapMeshes(ctx);
       for (const [id, group] of ctx.elementGroups) {
+        showOriginalMeshes(group, true);
         const elem = modelStore.elements.get(id);
         const baseColor = elem?.type === 'truss' ? COLORS.truss : COLORS.frame;
         const selected = uiStore.selectedElements.has(id);
         setGroupColor(group, selected ? COLORS.elementSelected : baseColor);
       }
+      resetShellColors(ctx);
       ctx.colorMapApplied = false;
     }
     return;
@@ -224,63 +285,276 @@ export function syncColorMap3D(ctx: ResultsSyncContext): void {
   }
 
   if (dt === 'axialColor') {
-    // Color by axial force: tension=red, compression=blue
+    clearHeatmapMeshes(ctx);
     for (const [id, group] of ctx.elementGroups) {
+      showOriginalMeshes(group, true);
       const ef = forcesMap.get(id);
       if (!ef) continue;
       const nAvg = (ef.nStart + ef.nEnd) / 2;
       setGroupColor(group, axialForceColor(nAvg));
     }
+    resetShellColors(ctx);
     ctx.colorMapApplied = true;
   } else if (dt === 'colorMap') {
-    // Color by selected variable (moment, shear, axial, stressRatio)
     const cmKind = resultsStore.colorMapKind;
 
-    // Compute values for normalization
-    const values = new Map<number, number>();
-    let maxVal = 0;
-
-    for (const [id] of ctx.elementGroups) {
-      const ef = forcesMap.get(id);
-      if (!ef) continue;
-
-      let val: number;
-      switch (cmKind) {
-        case 'moment':
-          val = Math.max(Math.abs(ef.mzStart), Math.abs(ef.mzEnd),
-                        Math.abs(ef.myStart), Math.abs(ef.myEnd));
-          break;
-        case 'shear':
-          val = Math.max(Math.abs(ef.vyStart), Math.abs(ef.vyEnd),
-                        Math.abs(ef.vzStart), Math.abs(ef.vzEnd));
-          break;
-        case 'axial':
-          val = Math.max(Math.abs(ef.nStart), Math.abs(ef.nEnd));
-          break;
-        case 'stressRatio': {
-          const elem = modelStore.elements.get(id);
-          if (!elem) { val = 0; break; }
-          const sec = modelStore.sections.get(elem.sectionId);
-          if (!sec) { val = 0; break; }
-          const stress = computeElementStress3D(
-            ef, sec.a, sec.iz, sec.iy ?? sec.iz,
-            sec.h ?? 0, sec.b ?? 0,
-          );
-          val = stress.max.ratio;
-          break;
-        }
+    if (cmKind === 'shellVonMises') {
+      // Shell-only mode: restore frame elements, apply shell heatmap
+      clearHeatmapMeshes(ctx);
+      for (const [id, group] of ctx.elementGroups) {
+        showOriginalMeshes(group, true);
+        setGroupColor(group, 0x888888); // dim frames
       }
-      values.set(id, val);
-      if (val > maxVal) maxVal = val;
+      applyShellHeatmap(ctx, r3d);
+    } else {
+      // Continuous heatmap on frame elements
+      resetShellColors(ctx);
+      applyFrameHeatmap(ctx, forcesMap, cmKind as HeatmapVariable);
     }
 
-    // Apply colors (neutral gray when all values are ~0, e.g. moment on truss-only models)
-    for (const [id, group] of ctx.elementGroups) {
-      const val = values.get(id) ?? 0;
-      const norm = maxVal > 1e-10 ? val / maxVal : 0;
-      setGroupColor(group, maxVal > 1e-10 ? heatmapColor(norm) : 0x888888);
-    }
     ctx.colorMapApplied = true;
+  } else if (dt === 'verification') {
+    // Verification status color map: flat per-element colors based on CIRSOC ratio
+    clearHeatmapMeshes(ctx);
+    for (const [id, group] of ctx.elementGroups) {
+      showOriginalMeshes(group, true);
+      const ratio = verificationStore.getMaxRatio(id);
+      setGroupColor(group, verificationColor(ratio));
+    }
+    resetShellColors(ctx);
+    ctx.colorMapApplied = true;
+  }
+}
+
+// ─── Verification ratio labels ────────────────────────────────
+
+/**
+ * Show floating ratio labels (e.g. "0.87") on each element at its midpoint.
+ * Only visible when diagramType === 'verification'.
+ */
+export function syncVerificationLabels(ctx: ResultsSyncContext): void {
+  if (!ctx.initialized) return;
+
+  // Remove old labels
+  if (ctx.verificationLabelsGroup) {
+    ctx.resultsParent.remove(ctx.verificationLabelsGroup);
+    disposeObject(ctx.verificationLabelsGroup);
+    ctx.verificationLabelsGroup = null;
+  }
+
+  if (resultsStore.diagramType !== 'verification' || !verificationStore.hasResults) return;
+
+  const group = new THREE.Group();
+  group.name = 'verification-labels';
+
+  for (const [id] of ctx.elementGroups) {
+    const ratio = verificationStore.getMaxRatio(id);
+    if (ratio === null) continue;
+
+    const elem = modelStore.elements.get(id);
+    if (!elem) continue;
+    const nI = modelStore.nodes.get(elem.nodeI);
+    const nJ = modelStore.nodes.get(elem.nodeJ);
+    if (!nI || !nJ) continue;
+
+    // Position at element midpoint
+    const mx = (nI.x + nJ.x) / 2;
+    const my = (nI.y + nJ.y) / 2;
+    const mz = ((nI.z ?? 0) + (nJ.z ?? 0)) / 2;
+
+    // Color based on status
+    const status = verificationStore.getStatus(id);
+    const textColor = status === 'fail' ? '#ff4444' : status === 'warn' ? '#ffaa00' : '#44ff88';
+
+    const sprite = createTextSprite(ratio.toFixed(2), textColor, 32);
+    sprite.position.set(mx, my + 0.15, mz); // offset slightly above element
+    sprite.scale.set(0.45, 0.45, 1);
+    group.add(sprite);
+  }
+
+  ctx.verificationLabelsGroup = group;
+  ctx.resultsParent.add(group);
+}
+
+// ─── Heatmap helpers ─────────────────────────────────────────
+
+const SHELL_DEFAULT_COLOR = 0x4ecdc4;
+
+/** Remove all heatmap overlay meshes from element groups */
+function clearHeatmapMeshes(ctx: ResultsSyncContext): void {
+  for (const [, group] of ctx.elementGroups) {
+    const toRemove: THREE.Object3D[] = [];
+    group.traverse((child) => {
+      if (child.userData?.heatmapMesh) toRemove.push(child);
+    });
+    for (const obj of toRemove) {
+      group.remove(obj);
+      disposeObject(obj);
+    }
+  }
+}
+
+/** Show or hide original (non-heatmap) meshes in an element group */
+function showOriginalMeshes(group: THREE.Group, visible: boolean): void {
+  group.traverse((child) => {
+    if (child === group) return;
+    if (child.userData?.heatmapMesh) return;
+    if (child.userData?.pickingHelper) return;
+    child.visible = visible;
+  });
+}
+
+/** Reset shell meshes to default teal */
+function resetShellColors(ctx: ResultsSyncContext): void {
+  for (const [, group] of ctx.shellGroups) {
+    group.traverse((child) => {
+      if (child instanceof THREE.Mesh) {
+        const geo = child.geometry;
+        if (geo.hasAttribute('color')) geo.deleteAttribute('color');
+        const mat = child.material as THREE.MeshStandardMaterial;
+        mat.vertexColors = false;
+        mat.color.setHex(SHELL_DEFAULT_COLOR);
+        mat.needsUpdate = true;
+      }
+    });
+  }
+}
+
+/** Build section props for an element */
+function getSectionProps(elemId: number) {
+  const elem = modelStore.elements.get(elemId);
+  if (!elem) return null;
+  const sec = modelStore.sections.get(elem.sectionId);
+  if (!sec) return null;
+  const mat = modelStore.materials.get(elem.materialId);
+  return {
+    A: sec.a,
+    Iz: sec.iz,
+    Iy: sec.iy ?? sec.iz,
+    h: sec.h ?? 0,
+    b: sec.b ?? 0,
+    fy: mat?.fy ?? 355_000,
+  };
+}
+
+/**
+ * Apply continuous per-vertex heatmap on frame elements.
+ * Creates overlay cylinder meshes with color gradients along length.
+ */
+function applyFrameHeatmap(
+  ctx: ResultsSyncContext,
+  forcesMap: Map<number, import('../engine/types-3d').ElementForces3D>,
+  variable: HeatmapVariable,
+): void {
+  // Remove old heatmap meshes first
+  clearHeatmapMeshes(ctx);
+
+  // Pass 1: sample values for all elements and find global max
+  const elemSamples = new Map<number, number[]>();
+  let globalMax = 0;
+
+  for (const [id] of ctx.elementGroups) {
+    const ef = forcesMap.get(id);
+    if (!ef) continue;
+    const sec = getSectionProps(id);
+    if (!sec) continue;
+    const values = sampleElementValues(ef, variable, sec);
+    elemSamples.set(id, values);
+    for (const v of values) {
+      if (v > globalMax) globalMax = v;
+    }
+  }
+
+  // For stressRatio, fix scale at 1.0 (100% of fy)
+  if (variable === 'stressRatio') globalMax = Math.max(globalMax, 1.0);
+
+  // Pass 2: create heatmap meshes (or restore visibility for skipped elements)
+  for (const [id, group] of ctx.elementGroups) {
+    const values = elemSamples.get(id);
+    if (!values) {
+      // Element has no sampled data — ensure originals stay visible (dimmed)
+      showOriginalMeshes(group, true);
+      setGroupColor(group, 0x555555);
+      continue;
+    }
+    const ef = forcesMap.get(id);
+    if (!ef) {
+      showOriginalMeshes(group, true);
+      setGroupColor(group, 0x555555);
+      continue;
+    }
+
+    // Get node positions
+    const elem = modelStore.elements.get(id);
+    if (!elem) { showOriginalMeshes(group, true); setGroupColor(group, 0x555555); continue; }
+    const nI = modelStore.nodes.get(elem.nodeI);
+    const nJ = modelStore.nodes.get(elem.nodeJ);
+    if (!nI || !nJ) { showOriginalMeshes(group, true); setGroupColor(group, 0x555555); continue; }
+
+    // Hide original mesh, show heatmap overlay
+    showOriginalMeshes(group, false);
+
+    const heatMesh = createHeatmapCylinder(ef.length, values, globalMax);
+    // Node.z is optional (undefined when z===0), must default to 0
+    orientHeatmapMesh(heatMesh,
+      { x: nI.x, y: nI.y, z: nI.z ?? 0 },
+      { x: nJ.x, y: nJ.y, z: nJ.z ?? 0 },
+    );
+    heatMesh.renderOrder = 2;
+    group.add(heatMesh);
+  }
+}
+
+/** Apply Von Mises heatmap on plates and quads */
+function applyShellHeatmap(
+  ctx: ResultsSyncContext,
+  r3d: NonNullable<typeof resultsStore.results3D>,
+): void {
+  let globalMax = 0;
+  const plateMap = new Map<number, number[]>();
+  const quadMap = new Map<number, number[]>();
+
+  if (r3d.plateStresses) {
+    for (const ps of r3d.plateStresses) {
+      // Use nodal values if available, otherwise uniform centroidal vonMises
+      const nvm = ps.nodalVonMises?.length ? [...ps.nodalVonMises] : [ps.vonMises, ps.vonMises, ps.vonMises];
+      plateMap.set(ps.elementId, nvm);
+      for (const v of nvm) if (v > globalMax) globalMax = v;
+    }
+  }
+  if (r3d.quadStresses) {
+    for (const qs of r3d.quadStresses) {
+      const nvm = qs.nodalVonMises?.length ? [...qs.nodalVonMises] : [qs.vonMises, qs.vonMises, qs.vonMises, qs.vonMises];
+      quadMap.set(qs.elementId, nvm);
+      for (const v of nvm) if (v > globalMax) globalMax = v;
+    }
+  }
+
+  if (globalMax < 1e-10) {
+    for (const [, group] of ctx.shellGroups) {
+      group.traverse((child) => {
+        if (child instanceof THREE.Mesh) {
+          const mat = child.material as THREE.MeshStandardMaterial;
+          mat.vertexColors = false;
+          mat.color.setHex(0x888888);
+          mat.needsUpdate = true;
+        }
+      });
+    }
+    return;
+  }
+
+  for (const [key, group] of ctx.shellGroups) {
+    const isPlate = key.startsWith('p');
+    const id = parseInt(key.substring(1));
+    const nodalVM = isPlate ? plateMap.get(id) : quadMap.get(id);
+    if (!nodalVM) continue;
+
+    group.traverse((child) => {
+      if (child instanceof THREE.Mesh) {
+        applyShellVertexColors(child, nodalVM, globalMax, !isPlate);
+      }
+    });
   }
 }
 
@@ -321,6 +595,54 @@ export function syncReactions(ctx: ResultsSyncContext): void {
   }
 
   ctx.resultsParent.add(ctx.reactionGroup);
+}
+
+// ─── Constraint Forces ───────────────────────────────────────
+
+export function syncConstraintForces(ctx: ResultsSyncContext): void {
+  if (!ctx.initialized) return;
+
+  if (ctx.constraintForcesGroup) {
+    ctx.resultsParent.remove(ctx.constraintForcesGroup);
+    disposeObject(ctx.constraintForcesGroup);
+    ctx.constraintForcesGroup = null;
+  }
+
+  const forces = resultsStore.constraintForces3D;
+  if (!forces || forces.length === 0 || !resultsStore.showConstraintForces) return;
+
+  ctx.constraintForcesGroup = new THREE.Group();
+  ctx.constraintForcesGroup.name = 'constraintForces';
+
+  // Max force for scaling (translational only)
+  let maxF = 0;
+  for (const cf of forces) {
+    if (!cf.dof.startsWith('r')) {
+      maxF = Math.max(maxF, Math.abs(cf.force));
+    }
+  }
+  if (maxF < 1e-10) maxF = 10;
+
+  // Group by nodeId so arrows at same node are positioned together
+  const byNode = new Map<number, typeof forces>();
+  for (const cf of forces) {
+    let arr = byNode.get(cf.nodeId);
+    if (!arr) { arr = []; byNode.set(cf.nodeId, arr); }
+    arr.push(cf);
+  }
+
+  for (const [nodeId, cfs] of byNode) {
+    const node = modelStore.nodes.get(nodeId);
+    if (!node) continue;
+    const pos = { x: node.x, y: node.y, z: node.z ?? 0 };
+
+    for (const cf of cfs) {
+      const arrow = createConstraintForceArrow(pos, cf.dof, cf.force, maxF);
+      ctx.constraintForcesGroup.add(arrow);
+    }
+  }
+
+  ctx.resultsParent.add(ctx.constraintForcesGroup);
 }
 
 // ─── Labels (node/element IDs, lengths) ─────────────────────

--- a/web/src/lib/viewport3d/scene-sync.ts
+++ b/web/src/lib/viewport3d/scene-sync.ts
@@ -12,6 +12,7 @@ import { createSupportGizmo } from '../three/create-support-gizmo';
 import type { SupportGizmoType } from '../three/create-support-gizmo';
 import { createNodalLoadArrow, createDistributedLoadGroup } from '../three/create-load-arrow';
 import { COLORS, setMeshColor, setGroupColor, disposeObject } from '../three/selection-helpers';
+import { createPlateMesh, createQuadMesh } from '../three/create-shell-mesh';
 import { computeLocalAxes3D } from '../engine/solver-3d';
 
 /**
@@ -28,12 +29,14 @@ export interface SceneSyncContext {
   supportsParent: THREE.Group;
   loadsParent: THREE.Group;
   resultsParent: THREE.Group;
+  shellsParent: THREE.Group;
   scene: THREE.Scene;
 
   // Reconciliation maps (mutated in place)
   nodeMeshes: Map<number, THREE.Mesh>;
   elementGroups: Map<number, THREE.Group>;
   supportGizmos: Map<number, THREE.Group>;
+  shellGroups: Map<string, THREE.Group>; // key: "p{id}" or "q{id}"
 
   // Single-instance groups (replaced on each sync)
   loadGroup: THREE.Group | null;
@@ -164,6 +167,44 @@ export function syncSupports(ctx: SceneSyncContext): void {
   }
 }
 
+// ─── Shells (Plates + Quads) ────────────────────────────────
+
+export function syncShells(ctx: SceneSyncContext): void {
+  if (!ctx.initialized) return;
+
+  const getNode = (id: number) => {
+    const n = modelStore.nodes.get(id);
+    return n ? { x: n.x, y: n.y, z: n.z ?? 0 } : null;
+  };
+
+  // Clear all existing shell meshes (simple rebuild, like elements)
+  for (const [key, group] of ctx.shellGroups) {
+    ctx.shellsParent.remove(group);
+    disposeObject(group);
+  }
+  ctx.shellGroups.clear();
+
+  // Plates (triangular DKT)
+  for (const [id, plate] of modelStore.plates) {
+    const [n0, n1, n2] = plate.nodes.map(nid => getNode(nid));
+    if (!n0 || !n1 || !n2) continue;
+
+    const group = createPlateMesh(n0, n1, n2, id);
+    ctx.shellsParent.add(group);
+    ctx.shellGroups.set(`p${id}`, group);
+  }
+
+  // Quads (MITC4)
+  for (const [id, quad] of modelStore.quads) {
+    const [n0, n1, n2, n3] = quad.nodes.map(nid => getNode(nid));
+    if (!n0 || !n1 || !n2 || !n3) continue;
+
+    const group = createQuadMesh(n0, n1, n2, n3, id);
+    ctx.shellsParent.add(group);
+    ctx.shellGroups.set(`q${id}`, group);
+  }
+}
+
 // ─── Loads ───────────────────────────────────────────────────
 
 export function syncLoads(ctx: SceneSyncContext): void {
@@ -280,6 +321,24 @@ export function syncLoads(ctx: SceneSyncContext): void {
         loadGrp.add(grpZ);
       }
     }
+    // surface3d: render as a downward arrow at the quad centroid
+    else if (load.type === 'surface3d') {
+      const quad = modelStore.model.quads.get(load.data.quadId);
+      if (!quad) continue;
+      const ns = quad.nodes.map(nid => modelStore.nodes.get(nid));
+      if (ns.some(n => !n)) continue;
+      const cx = ns.reduce((s, n) => s + n!.x, 0) / 4;
+      const cy = ns.reduce((s, n) => s + n!.y, 0) / 4;
+      const cz = ns.reduce((s, n) => s + (n!.z ?? 0), 0) / 4;
+      const totalForce = load.data.q * 1; // representative 1 m² for arrow sizing
+      const arrow = createNodalLoadArrow(
+        { x: cx, y: cy, z: cz },
+        0, -Math.abs(totalForce), 0,
+        0, 0, 0,
+        maxForce, i,
+      );
+      loadGrp.add(arrow);
+    }
     // pointOnElement and pointOnElement3d: simplified as nodal for now
     else if (load.type === 'pointOnElement') {
       const elem = modelStore.elements.get(load.data.elementId);
@@ -345,7 +404,7 @@ export function syncSelection(ctx: SceneSyncContext): void {
 
   // Re-apply color map if active (syncSelection overwrites element colors)
   const dt = resultsStore.diagramType;
-  if (resultsStore.results3D && (dt === 'axialColor' || dt === 'colorMap')) {
+  if (resultsStore.results3D && (dt === 'axialColor' || dt === 'colorMap' || dt === 'verification')) {
     // Import dynamically avoided — call syncColorMap3D from Viewport3D after syncSelection
     // The caller is responsible for re-applying color map.
     // We just set a flag so the caller knows.

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,11 +1,38 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Stub out the WASM glue module when it hasn't been built yet.
+ * This lets CI run `npm run build` without `wasm-pack build` first.
+ */
+function wasmStubPlugin(): Plugin {
+  const wasmGlue = resolve(__dirname, 'src/lib/wasm/dedaliano_engine.js');
+  return {
+    name: 'wasm-stub',
+    resolveId(id) {
+      if (id.includes('wasm/dedaliano_engine') && id.endsWith('.js') && !existsSync(wasmGlue)) {
+        return '\0wasm-stub';
+      }
+    },
+    load(id) {
+      if (id === '\0wasm-stub') {
+        return 'export function initSync() {} export function solve_3d() { return "{}"; }';
+      }
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [svelte()],
+  plugins: [wasmStubPlugin(), svelte()],
   base: process.env.BASE_PATH || '/',
   server: {
     port: 4000,
+  },
+  worker: {
+    format: 'es',
+    plugins: () => [wasmStubPlugin()],
   },
   build: {
     target: 'esnext',


### PR DESCRIPTION
## Summary
- Add 3D analysis engines: P-Delta, modal, buckling, spectral for 3D structures
- Add solver pool and shell solver infrastructure
- Fix moving load envelope symmetry (bidirectional pass + mirror positions)
- Fix diagram scale computation (include point loads via `computeDiagramValueAt`)
- Add WASM stub for CI builds, stress heatmap, shell mesh, DXF plan import

## PR Chain (1 of 6)
`main` ← **pr/1-engine** ← pr/2-i18n ← pr/3-landing ← pr/4-edu ← pr/5-pro-engine ← pr/6-pro-ui

## Test plan
- [ ] Moving load envelope is symmetric for single axle on simply supported beam
- [ ] Diagram scale correct with point loads
- [ ] Build passes
- [ ] `moving-loads-symmetry.test.ts` passes