### PR TITLE
feat: PRO mode, EDU mode, and app mode switching

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -28,6 +28,8 @@
   import TabBar from './components/TabBar.svelte';
   import FeedbackWidget from './components/FeedbackWidget.svelte';
   import MobileResultsPanel from './components/MobileResultsPanel.svelte';
+  import ProPanel from './components/pro/ProPanel.svelte';
+  import EducativePanel from './components/edu/EducativePanel.svelte';
   import TourOverlay from './components/TourOverlay.svelte';
   import HelpOverlay from './components/HelpOverlay.svelte';
   import ContextMenu from './components/ContextMenu.svelte';
@@ -46,6 +48,42 @@
   // Listen for enter-app event from LandingPage "Try Demo" buttons
   if (typeof window !== 'undefined') {
     window.addEventListener('dedaliano-enter-app', enterApp);
+  }
+
+  // ─── Per-mode model persistence ───
+  // When switching between básico/edu/pro, save the current model and restore
+  // the target mode's model (or start empty if first visit to that mode).
+  import type { ModelSnapshot } from './lib/store/history.svelte';
+  type AppMode = 'basico' | 'educativo' | 'pro';
+  const modeSnapshots = new Map<AppMode, ModelSnapshot>();
+  let currentAppMode: AppMode = 'basico';
+
+  function switchAppMode(target: AppMode) {
+    const prev = currentAppMode;
+    if (target === prev) return;
+    // Save current model into the mode we're leaving
+    modeSnapshots.set(prev, modelStore.snapshot());
+    // Clear results + UI state
+    resultsStore.clear();
+    resultsStore.showReactions = false;
+    resultsStore.diagramType = 'none';
+    historyStore.clear();
+    // Restore target mode's model or start empty
+    const saved = modeSnapshots.get(target);
+    if (saved) {
+      modelStore.restore(saved);
+    } else {
+      modelStore.clear();
+    }
+    // Set the actual analysis mode
+    if (target === 'basico') {
+      uiStore.analysisMode = '2d';
+    } else if (target === 'educativo') {
+      uiStore.analysisMode = 'edu';
+    } else {
+      uiStore.analysisMode = 'pro';
+    }
+    currentAppMode = target;
   }
 
   let showTemplateDialog = $state(false);
@@ -234,8 +272,8 @@
         }
       }
 
-      // If live calc is ON, auto-solve
-      if (_lc) {
+      // If live calc is ON, auto-solve (skip in PRO/EDU mode — manual solve only)
+      if (_lc && _mode !== 'pro' && _mode !== 'edu') {
         runLiveCalc(_mode, uiStore.axisConvention3D, prevDiagram);
       }
     });
@@ -252,8 +290,11 @@
       <span class="logo-icon">△</span>
       <span class="logo-text">Dedaliano</span>
       <div class="mode-toggle" data-tour="mode-toggle">
-        <button class:active={uiStore.analysisMode === '2d'} onclick={() => uiStore.analysisMode = '2d'}>2D</button>
-        <button class:active={uiStore.analysisMode === '3d'} onclick={() => uiStore.analysisMode = '3d'}>3D</button>
+        <button class:active={uiStore.appMode === 'basico'} onclick={() => switchAppMode('basico')}>
+          {t('app.modeBasic')}
+        </button>
+        <button class:active={uiStore.appMode === 'educativo'} class="edu-mode-btn" onclick={() => switchAppMode('educativo')}>{t('app.modeEdu')}<span class="demo-badge">DEMO</span></button>
+        <button class:active={uiStore.appMode === 'pro'} class="pro-mode-btn" onclick={() => switchAppMode('pro')}>{t('app.modePro')}<span class="demo-badge">DEMO</span></button>
       </div>
     </div>
     <span class="separator">|</span>
@@ -290,25 +331,29 @@
   {/if}
 
   <div class="app-body">
-    {#if !uiStore.isMobile}
-      {#if uiStore.leftSidebarOpen}
-        <aside class="sidebar left">
-          <Toolbar />
-        </aside>
+    {#if uiStore.appMode === 'basico'}
+      {#if !uiStore.isMobile}
+        {#if uiStore.leftSidebarOpen}
+          <aside class="sidebar left">
+            <Toolbar />
+          </aside>
+        {/if}
+        <button class="sidebar-toggle-btn left-toggle" class:sidebar-closed={!uiStore.leftSidebarOpen} onclick={() => uiStore.leftSidebarOpen = !uiStore.leftSidebarOpen} title={uiStore.leftSidebarOpen ? t('app.hideLeftPanel') : t('app.showLeftPanel')}>
+          {uiStore.leftSidebarOpen ? '◂' : '▸'}
+        </button>
       {/if}
-      <button class="sidebar-toggle-btn left-toggle" class:sidebar-closed={!uiStore.leftSidebarOpen} onclick={() => uiStore.leftSidebarOpen = !uiStore.leftSidebarOpen} title={uiStore.leftSidebarOpen ? t('app.hideLeftPanel') : t('app.showLeftPanel')}>
-        {uiStore.leftSidebarOpen ? '◂' : '▸'}
-      </button>
     {/if}
 
     <div class="main-area">
       <main class="viewport-container">
-        {#if uiStore.analysisMode === '2d'}
-          <Viewport {showResults} />
+        {#if uiStore.analysisMode === '2d' || uiStore.analysisMode === 'edu'}
+          <Viewport showResults={uiStore.analysisMode === '2d' && showResults} />
         {:else}
           <Viewport3D />
         {/if}
-        <FloatingTools />
+        {#if uiStore.appMode === 'basico'}
+          <FloatingTools />
+        {/if}
         <WhatIfPanel />
         <SectionStressPanel />
         <KinematicPanel />
@@ -317,24 +362,34 @@
     </div>
 
     {#if !uiStore.isMobile}
-      <button class="sidebar-toggle-btn right-toggle" class:sidebar-closed={!uiStore.rightSidebarOpen} onclick={() => uiStore.rightSidebarOpen = !uiStore.rightSidebarOpen} title={uiStore.rightSidebarOpen ? t('app.hideRightPanel') : t('app.showRightPanel')}>
-        {uiStore.rightSidebarOpen ? '▸' : '◂'}
-      </button>
-      {#if uiStore.rightSidebarOpen}
-        <aside class="sidebar right" data-tour="right-sidebar" class:wizard-open={dsmStepsStore.isOpen}>
-          {#if dsmStepsStore.isOpen}
-            <StepWizard />
-          {:else}
-            <button class="datatable-toggle" onclick={() => uiStore.showDataTable = !uiStore.showDataTable}>
-              {uiStore.showDataTable ? '▾' : '▸'} {t('app.modelData')}
-            </button>
-            {#if uiStore.showDataTable}
-              <div class="data-table-sidebar">
-                <DataTable />
-              </div>
-            {/if}
-          {/if}
+      {#if uiStore.appMode === 'pro'}
+        <aside class="sidebar right pro-sidebar">
+          <ProPanel />
         </aside>
+      {:else if uiStore.appMode === 'educativo'}
+        <aside class="sidebar right edu-sidebar">
+          <EducativePanel />
+        </aside>
+      {:else}
+        <button class="sidebar-toggle-btn right-toggle" class:sidebar-closed={!uiStore.rightSidebarOpen} onclick={() => uiStore.rightSidebarOpen = !uiStore.rightSidebarOpen} title={uiStore.rightSidebarOpen ? t('app.hideRightPanel') : t('app.showRightPanel')}>
+          {uiStore.rightSidebarOpen ? '▸' : '◂'}
+        </button>
+        {#if uiStore.rightSidebarOpen}
+          <aside class="sidebar right" data-tour="right-sidebar" class:wizard-open={dsmStepsStore.isOpen}>
+            {#if dsmStepsStore.isOpen}
+              <StepWizard />
+            {:else}
+              <button class="datatable-toggle" onclick={() => uiStore.showDataTable = !uiStore.showDataTable}>
+                {uiStore.showDataTable ? '▾' : '▸'} {t('app.modelData')}
+              </button>
+              {#if uiStore.showDataTable}
+                <div class="data-table-sidebar">
+                  <DataTable />
+                </div>
+              {/if}
+            {/if}
+          </aside>
+        {/if}
       {/if}
     {/if}
   </div>
@@ -346,7 +401,7 @@
   {/if}
 
   <!-- Mobile drawers (overlay on top of canvas) -->
-  {#if uiStore.isMobile && uiStore.leftDrawerOpen}
+  {#if uiStore.isMobile && uiStore.leftDrawerOpen && uiStore.appMode === 'basico'}
     <div class="drawer-backdrop" onclick={() => uiStore.leftDrawerOpen = false}></div>
     <aside class="drawer drawer-left">
       <Toolbar />
@@ -549,24 +604,28 @@
   }
 
   .mode-toggle {
-    display: flex;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
     gap: 0;
     border-radius: 4px;
     overflow: hidden;
     border: 1px solid #334;
     margin-left: 0.25rem;
+    min-width: 180px;
   }
 
   .mode-toggle button {
     background: transparent;
     border: none;
     color: #888;
-    font-size: 0.75rem;
+    font-size: 0.68rem;
     font-weight: 600;
-    padding: 0.2rem 0.5rem;
+    padding: 0.2rem 0.35rem;
     cursor: pointer;
     transition: background 0.15s, color 0.15s;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.03em;
+    text-align: center;
+    white-space: nowrap;
   }
 
   .mode-toggle button:hover {
@@ -577,6 +636,57 @@
   .mode-toggle button.active {
     background: #e94560;
     color: white;
+  }
+
+  .mode-toggle button.edu-mode-btn {
+    background: linear-gradient(135deg, #1a1a3a, #0f1a30);
+    color: #4ecdc4;
+    border-left: 1px solid #334;
+  }
+
+  .mode-toggle button.edu-mode-btn.active {
+    background: linear-gradient(135deg, #2a8a7a, #1a6a5a);
+    color: white;
+  }
+
+  .mode-toggle button.pro-mode-btn {
+    background: linear-gradient(135deg, #1a1a3a, #0f1a30);
+    color: #f0a500;
+    border-left: 1px solid #334;
+  }
+
+  .mode-toggle button.pro-mode-btn.active {
+    background: linear-gradient(135deg, #e94560, #c73e54);
+    color: white;
+  }
+
+  .demo-badge {
+    font-size: 0.45rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    background: rgba(255,255,255,0.15);
+    color: rgba(255,255,255,0.7);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    margin-left: 0.3rem;
+    vertical-align: middle;
+  }
+
+  .mode-toggle button.active .demo-badge {
+    background: rgba(255,255,255,0.2);
+    color: rgba(255,255,255,0.85);
+  }
+
+  .pro-sidebar {
+    width: 540px;
+    min-width: 540px;
+    max-width: 540px;
+  }
+
+  .edu-sidebar {
+    width: 420px;
+    min-width: 420px;
+    max-width: 420px;
   }
 
   .project-name {

--- a/web/src/components/edu/EduExerciseView.svelte
+++ b/web/src/components/edu/EduExerciseView.svelte
@@ -1,0 +1,685 @@
+<script lang="ts">
+  import { resultsStore } from '../../lib/store';
+  import type { EduExercise } from './exercises';
+  import { t } from '../../lib/i18n';
+  import { eduStore } from './edu-store.svelte';
+
+  interface Props {
+    exercise: EduExercise;
+  }
+
+  let { exercise }: Props = $props();
+
+  // ─── Student answers ───────────────────────────────────────
+  type ReactionAnswer = Record<string, string>;
+  let reactionAnswers = $state<ReactionAnswer[]>(
+    exercise.supports.map(s => {
+      const ans: ReactionAnswer = {};
+      for (const dof of s.dofs) ans[dof] = '';
+      return ans;
+    })
+  );
+  let charAnswers = $state<string[]>(exercise.characteristics.map(() => ''));
+  let diagramAnswers = $state<string[]>(exercise.diagramQuestions.map(() => ''));
+
+  // ─── Verification state ────────────────────────────────────
+  type VerifState = 'pending' | 'correct' | 'incorrect';
+  let reactionVerif = $state<Array<Record<string, VerifState>>>(
+    exercise.supports.map(s => {
+      const v: Record<string, VerifState> = {};
+      for (const dof of s.dofs) v[dof] = 'pending';
+      return v;
+    })
+  );
+  let charVerif = $state<VerifState[]>(exercise.characteristics.map(() => 'pending'));
+  let diagramVerif = $state<VerifState[]>(exercise.diagramQuestions.map(() => 'pending'));
+  let hints = $state<string[]>([]);
+  let diagramHints = $state<string[]>([]);
+  let charHints = $state<string[]>([]);
+
+  // ─── Reveal state ──────────────────────────────────────────
+  let revealedReactions = $state<Array<Record<string, boolean>>>(
+    exercise.supports.map(s => {
+      const r: Record<string, boolean> = {};
+      for (const dof of s.dofs) r[dof] = false;
+      return r;
+    })
+  );
+  let revealedChars = $state<boolean[]>(exercise.characteristics.map(() => false));
+  let revealedDiagrams = $state<boolean[]>(exercise.diagramQuestions.map(() => false));
+
+  const TOLERANCE = 0.05;
+
+  // ─── Step completion ───────────────────────────────────────
+  const step1Complete = $derived(
+    reactionVerif.every(v => Object.values(v).every(s => s === 'correct'))
+  );
+  const step2Complete = $derived(
+    exercise.diagramQuestions.length === 0 || diagramVerif.every(s => s === 'correct')
+  );
+  const step3Complete = $derived(
+    charVerif.every(s => s === 'correct')
+  );
+  const allCorrect = $derived(step1Complete && step2Complete && step3Complete);
+
+  // ─── Reaction verification ─────────────────────────────────
+  function getCorrectReaction(supportIndex: number, dof: string): number | null {
+    const results = eduStore.results;
+    if (!results) return null;
+    const reactions = results.reactions;
+    if (supportIndex >= reactions.length) return null;
+    const r = reactions[supportIndex];
+    switch (dof) {
+      case 'Rx': return r.rx;
+      case 'Ry': return r.ry;
+      case 'M': return r.mz ?? 0;
+      default: return null;
+    }
+  }
+
+  function checkTolerance(student: number, correct: number): VerifState {
+    const abs = Math.abs(correct);
+    const tol = abs > 0.01 ? abs * TOLERANCE : 0.1;
+    return Math.abs(student - correct) <= tol ? 'correct' : 'incorrect';
+  }
+
+  function generateHint(student: number, correct: number, label: string, dof: string): string | null {
+    const abs = Math.abs(correct);
+    const tol = abs > 0.01 ? abs * TOLERANCE : 0.1;
+    if (Math.abs(student - correct) <= tol) return null;
+
+    const prefix = dof ? `${label}, ${dof}` : label;
+    if (Math.abs(Math.abs(student) - Math.abs(correct)) < tol && Math.sign(student) !== Math.sign(correct)) {
+      return `${prefix}: ${t('edu.hintSign')}`;
+    } else if (Math.abs(Math.abs(student) - Math.abs(correct)) / (abs || 1) > 0.5) {
+      return `${prefix}: ${t('edu.hintFarOff')}`;
+    }
+    return `${prefix}: ${t('edu.hintClose')}`;
+  }
+
+  function verifyReactions() {
+    hints = [];
+    const newVerif = reactionVerif.map(v => ({ ...v }));
+
+    for (let i = 0; i < exercise.supports.length; i++) {
+      const sup = exercise.supports[i];
+      for (const dof of sup.dofs) {
+        if (revealedReactions[i][dof]) { newVerif[i][dof] = 'correct'; continue; }
+        const studentVal = parseFloat(reactionAnswers[i][dof].replace(',', '.'));
+        const correct = getCorrectReaction(i, dof);
+        if (correct === null || isNaN(studentVal)) { newVerif[i][dof] = 'pending'; continue; }
+
+        newVerif[i][dof] = checkTolerance(studentVal, correct);
+        if (newVerif[i][dof] === 'incorrect') {
+          const hint = generateHint(studentVal, correct, sup.label, dof);
+          if (hint) hints.push(hint);
+        }
+      }
+    }
+    reactionVerif = newVerif;
+  }
+
+  function revealReaction(supIdx: number, dof: string) {
+    const correct = getCorrectReaction(supIdx, dof);
+    if (correct === null) return;
+    // Clone and reassign all arrays to force Svelte 5 reactivity
+    const newRevealed = revealedReactions.map(r => ({ ...r }));
+    newRevealed[supIdx][dof] = true;
+    revealedReactions = newRevealed;
+
+    const newAnswers = reactionAnswers.map(a => ({ ...a }));
+    newAnswers[supIdx][dof] = correct.toFixed(2);
+    reactionAnswers = newAnswers;
+
+    const newVerif = reactionVerif.map(v => ({ ...v }));
+    newVerif[supIdx][dof] = 'correct';
+    reactionVerif = newVerif;
+
+    hints = hints.filter(h => !h.startsWith(`${exercise.supports[supIdx].label}, ${dof}`));
+  }
+
+  // ─── Diagram question verification ─────────────────────────
+  function verifyDiagrams() {
+    const results = eduStore.results;
+    if (!results) return;
+    diagramHints = [];
+    const newVerif = [...diagramVerif];
+
+    for (let i = 0; i < exercise.diagramQuestions.length; i++) {
+      if (revealedDiagrams[i]) { newVerif[i] = 'correct'; continue; }
+      const dq = exercise.diagramQuestions[i];
+      const studentVal = parseFloat(diagramAnswers[i].replace(',', '.'));
+      if (isNaN(studentVal)) { newVerif[i] = 'pending'; continue; }
+
+      const correct = dq.getCorrect(results.elementForces);
+      newVerif[i] = checkTolerance(Math.abs(studentVal), Math.abs(correct));
+      if (newVerif[i] === 'incorrect') {
+        const hint = generateHint(studentVal, correct, dq.question, '');
+        if (hint) diagramHints.push(hint);
+      }
+    }
+    diagramVerif = newVerif;
+  }
+
+  function revealDiagram(idx: number) {
+    const results = eduStore.results;
+    if (!results) return;
+    const correct = exercise.diagramQuestions[idx].getCorrect(results.elementForces);
+    revealedDiagrams = revealedDiagrams.map((v, j) => j === idx ? true : v);
+    diagramAnswers = diagramAnswers.map((v, j) => j === idx ? Math.abs(correct).toFixed(2) : v);
+    diagramVerif = diagramVerif.map((v, j) => j === idx ? 'correct' as VerifState : v);
+    diagramHints = diagramHints.filter(h => !h.startsWith(exercise.diagramQuestions[idx].question));
+  }
+
+  // ─── Characteristic verification ───────────────────────────
+  function verifyCharacteristics() {
+    const results = eduStore.results;
+    if (!results) return;
+    charHints = [];
+    const newVerif = [...charVerif];
+
+    for (let i = 0; i < exercise.characteristics.length; i++) {
+      if (revealedChars[i]) { newVerif[i] = 'correct'; continue; }
+      const ch = exercise.characteristics[i];
+      const studentVal = parseFloat(charAnswers[i].replace(',', '.'));
+      if (isNaN(studentVal)) { newVerif[i] = 'pending'; continue; }
+
+      const correct = ch.getCorrect(results.elementForces);
+      newVerif[i] = checkTolerance(Math.abs(studentVal), Math.abs(correct));
+      if (newVerif[i] === 'incorrect') {
+        const hint = generateHint(studentVal, correct, ch.label, '');
+        if (hint) charHints.push(hint);
+      }
+    }
+    charVerif = newVerif;
+  }
+
+  function revealChar(idx: number) {
+    const results = eduStore.results;
+    if (!results) return;
+    const correct = exercise.characteristics[idx].getCorrect(results.elementForces);
+    revealedChars = revealedChars.map((v, j) => j === idx ? true : v);
+    charAnswers = charAnswers.map((v, j) => j === idx ? Math.abs(correct).toFixed(2) : v);
+    charVerif = charVerif.map((v, j) => j === idx ? 'correct' as VerifState : v);
+    charHints = charHints.filter(h => !h.startsWith(exercise.characteristics[idx].label));
+  }
+
+  function verifClass(state: VerifState): string {
+    if (state === 'correct') return 'verif-correct';
+    if (state === 'incorrect') return 'verif-incorrect';
+    return '';
+  }
+
+  // When step 1 completes, show reactions in the viewport
+  $effect(() => {
+    if (step1Complete) {
+      resultsStore.showReactions = true;
+    }
+  });
+
+  // When all steps complete, show moment diagram as a reward
+  $effect(() => {
+    if (allCorrect) {
+      resultsStore.diagramType = 'moment';
+    }
+  });
+</script>
+
+<div class="exercise-view">
+  <!-- Progress bar -->
+  <div class="progress-bar">
+    <div class="progress-step" class:done={step1Complete}>
+      <span class="step-check">{step1Complete ? '\u2713' : '1'}</span>
+      <span class="step-label">{t('edu.reactions')}</span>
+    </div>
+    <div class="progress-line" class:done={step1Complete}></div>
+    <div class="progress-step" class:done={step2Complete}>
+      <span class="step-check">{step2Complete ? '\u2713' : '2'}</span>
+      <span class="step-label">{t('edu.diagrams')}</span>
+    </div>
+    <div class="progress-line" class:done={step2Complete}></div>
+    <div class="progress-step" class:done={step3Complete}>
+      <span class="step-check">{step3Complete ? '\u2713' : '3'}</span>
+      <span class="step-label">{t('edu.values')}</span>
+    </div>
+  </div>
+
+  <div class="exercise-description">
+    <p>{exercise.description}</p>
+  </div>
+
+  <!-- Step 1: Reactions -->
+  <section class="step-section" class:completed={step1Complete}>
+    <h3 class="step-title">
+      {t('edu.step1Title')}
+      {#if step1Complete}<span class="step-done">\u2713</span>{/if}
+    </h3>
+
+    {#each exercise.supports as sup, i}
+      <div class="support-row">
+        <span class="support-label">{sup.label}</span>
+        <div class="dof-inputs">
+          {#each sup.dofs as dof}
+            <div class="input-group {verifClass(reactionVerif[i][dof])}">
+              <label class="dof-input">
+                <span class="dof-name">{dof} =</span>
+                <input
+                  type="text"
+                  inputmode="decimal"
+                  placeholder="0.00"
+                  value={reactionAnswers[i][dof]}
+                  oninput={(e) => { reactionAnswers[i][dof] = (e.target as HTMLInputElement).value; }}
+                  class={verifClass(reactionVerif[i][dof])}
+                  class:revealed={revealedReactions[i][dof]}
+                  readonly={revealedReactions[i][dof]}
+                />
+                <span class="dof-unit">{dof === 'M' ? 'kN·m' : 'kN'}</span>
+              </label>
+              {#if reactionVerif[i][dof] === 'incorrect' && !revealedReactions[i][dof]}
+                <button class="reveal-btn" onclick={() => revealReaction(i, dof)} title={t('edu.reveal')}>
+                  {t('edu.reveal')}
+                </button>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/each}
+
+    <button class="verify-btn" onclick={verifyReactions} disabled={step1Complete}>
+      {step1Complete ? '\u2713 ' + t('edu.verified') : t('edu.verifyReactions')}
+    </button>
+
+    {#if hints.length > 0}
+      <div class="hints">
+        {#each hints as hint}
+          <p class="hint">{hint}</p>
+        {/each}
+      </div>
+    {/if}
+  </section>
+
+  <!-- Step 2: Diagram questions -->
+  <section class="step-section" class:completed={step2Complete}>
+    <h3 class="step-title">
+      {t('edu.step2Title')}
+      {#if step2Complete}<span class="step-done">\u2713</span>{/if}
+    </h3>
+
+    {#if exercise.diagramQuestions.length > 0}
+      <p class="step-info">{t('edu.step2DescNew')}</p>
+
+      <div class="diagram-questions">
+        {#each exercise.diagramQuestions as dq, i}
+          <div class="input-group {verifClass(diagramVerif[i])}">
+            <label class="char-input">
+              <span class="char-name">{dq.question}</span>
+              <input
+                type="text"
+                inputmode="decimal"
+                placeholder="0.00"
+                value={diagramAnswers[i]}
+                oninput={(e) => { diagramAnswers[i] = (e.target as HTMLInputElement).value; }}
+                class={verifClass(diagramVerif[i])}
+                class:revealed={revealedDiagrams[i]}
+                readonly={revealedDiagrams[i]}
+              />
+              <span class="char-unit">{dq.unit}</span>
+            </label>
+            {#if diagramVerif[i] === 'incorrect' && !revealedDiagrams[i]}
+              <button class="reveal-btn" onclick={() => revealDiagram(i)} title={t('edu.reveal')}>
+                {t('edu.reveal')}
+              </button>
+            {/if}
+          </div>
+        {/each}
+      </div>
+
+      <button class="verify-btn" onclick={verifyDiagrams} disabled={step2Complete}>
+        {step2Complete ? '\u2713 ' + t('edu.verified') : t('edu.verifyDiagrams')}
+      </button>
+
+      {#if diagramHints.length > 0}
+        <div class="hints">
+          {#each diagramHints as hint}
+            <p class="hint">{hint}</p>
+          {/each}
+        </div>
+      {/if}
+    {:else}
+      <p class="step-info step-info-auto">{t('edu.noDiagramQuestions')}</p>
+    {/if}
+  </section>
+
+  <!-- Step 3: Characteristic values -->
+  <section class="step-section" class:completed={step3Complete}>
+    <h3 class="step-title">
+      {t('edu.step3Title')}
+      {#if step3Complete}<span class="step-done">\u2713</span>{/if}
+    </h3>
+
+    <div class="char-inputs">
+      {#each exercise.characteristics as ch, i}
+        <div class="input-group {verifClass(charVerif[i])}">
+          <label class="char-input">
+            <span class="char-name">{ch.label} =</span>
+            <input
+              type="text"
+              inputmode="decimal"
+              placeholder="0.00"
+              value={charAnswers[i]}
+              oninput={(e) => { charAnswers[i] = (e.target as HTMLInputElement).value; }}
+              class={verifClass(charVerif[i])}
+              class:revealed={revealedChars[i]}
+              readonly={revealedChars[i]}
+            />
+            <span class="char-unit">{ch.unit}</span>
+          </label>
+          {#if charVerif[i] === 'incorrect' && !revealedChars[i]}
+            <button class="reveal-btn" onclick={() => revealChar(i)} title={t('edu.reveal')}>
+              {t('edu.reveal')}
+            </button>
+          {/if}
+        </div>
+      {/each}
+    </div>
+
+    <button class="verify-btn" onclick={verifyCharacteristics} disabled={step3Complete}>
+      {step3Complete ? '\u2713 ' + t('edu.verified') : t('edu.verifyValues')}
+    </button>
+
+    {#if charHints.length > 0}
+      <div class="hints">
+        {#each charHints as hint}
+          <p class="hint">{hint}</p>
+        {/each}
+      </div>
+    {/if}
+  </section>
+
+  {#if allCorrect}
+    <div class="success-banner">
+      {t('edu.exerciseSolved')}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .exercise-view {
+    padding: 12px 14px;
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  /* ─── Progress bar ─── */
+  .progress-bar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+    margin-bottom: 16px;
+    padding: 10px 0;
+  }
+
+  .progress-step {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .step-check {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.7rem;
+    font-weight: 700;
+    background: #1a2a44;
+    color: #666;
+    border: 1.5px solid #334;
+    transition: all 0.3s;
+  }
+
+  .progress-step.done .step-check {
+    background: #1a3a2a;
+    color: #4caf50;
+    border-color: #4caf50;
+  }
+
+  .step-label {
+    font-size: 0.65rem;
+    color: #666;
+    transition: color 0.3s;
+  }
+
+  .progress-step.done .step-label {
+    color: #4caf50;
+  }
+
+  .progress-line {
+    width: 30px;
+    height: 2px;
+    background: #334;
+    margin: 0 6px;
+    transition: background 0.3s;
+  }
+
+  .progress-line.done {
+    background: #4caf50;
+  }
+
+  /* ─── Exercise description ─── */
+  .exercise-description {
+    background: #0f2840;
+    border: 1px solid #1a4a7a;
+    border-radius: 6px;
+    padding: 10px 14px;
+    margin-bottom: 16px;
+  }
+
+  .exercise-description p {
+    font-size: 0.78rem;
+    color: #bbb;
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  /* ─── Steps ─── */
+  .step-section {
+    margin-bottom: 20px;
+    transition: opacity 0.3s;
+  }
+
+  .step-section.completed {
+    opacity: 0.7;
+  }
+
+  .step-title {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #4ecdc4;
+    margin: 0 0 10px;
+    padding-bottom: 4px;
+    border-bottom: 1px solid #1a3a5a;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .step-done {
+    color: #4caf50;
+    font-size: 0.9rem;
+  }
+
+  .step-info {
+    font-size: 0.72rem;
+    color: #888;
+    margin: 0 0 10px;
+    line-height: 1.4;
+  }
+
+  .step-info-auto {
+    color: #4caf50;
+    font-style: italic;
+  }
+
+  /* ─── Inputs ─── */
+  .support-row {
+    margin-bottom: 10px;
+  }
+
+  .support-label {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #aaa;
+    display: block;
+    margin-bottom: 4px;
+  }
+
+  .dof-inputs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .input-group {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .dof-input, .char-input {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.72rem;
+  }
+
+  .dof-name, .char-name {
+    color: #aaa;
+    font-weight: 500;
+    min-width: 28px;
+  }
+
+  .dof-input input, .char-input input {
+    width: 70px;
+    padding: 4px 6px;
+    background: #0a1628;
+    border: 1px solid #334;
+    border-radius: 4px;
+    color: #eee;
+    font-size: 0.75rem;
+    font-family: monospace;
+    text-align: right;
+  }
+
+  .dof-input input:focus, .char-input input:focus {
+    outline: none;
+    border-color: #4ecdc4;
+  }
+
+  .dof-unit, .char-unit {
+    color: #666;
+    font-size: 0.65rem;
+  }
+
+  /* ─── Verification colors ─── */
+  .verif-correct input, input.verif-correct {
+    border-color: #4caf50 !important;
+    background: #0a200a;
+  }
+
+  .verif-incorrect input, input.verif-incorrect {
+    border-color: #e94560 !important;
+    background: #200a0a;
+  }
+
+  input.revealed {
+    color: #f0a500 !important;
+    font-style: italic;
+    cursor: default;
+    background: #1a1a0a !important;
+    border-color: #f0a500 !important;
+  }
+
+  /* ─── Buttons ─── */
+  .verify-btn {
+    margin-top: 8px;
+    padding: 6px 16px;
+    background: #0f3460;
+    border: 1px solid #1a4a7a;
+    border-radius: 4px;
+    color: #4ecdc4;
+    font-size: 0.72rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+
+  .verify-btn:hover:not(:disabled) {
+    background: #1a4a7a;
+  }
+
+  .verify-btn:disabled {
+    opacity: 0.6;
+    cursor: default;
+    color: #4caf50;
+    border-color: #4caf50;
+  }
+
+  .reveal-btn {
+    padding: 2px 8px;
+    background: none;
+    border: 1px solid #555;
+    border-radius: 3px;
+    color: #888;
+    font-size: 0.6rem;
+    cursor: pointer;
+    transition: all 0.15s;
+    white-space: nowrap;
+  }
+
+  .reveal-btn:hover {
+    color: #f0a500;
+    border-color: #f0a500;
+  }
+
+  /* ─── Hints ─── */
+  .hints {
+    margin-top: 8px;
+  }
+
+  .hint {
+    font-size: 0.7rem;
+    color: #f0a500;
+    margin: 2px 0;
+    line-height: 1.4;
+  }
+
+  /* ─── Diagram questions ─── */
+  .diagram-questions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .char-inputs {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  /* ─── Success banner ─── */
+  .success-banner {
+    background: #1a3a2a;
+    border: 1px solid #4caf50;
+    border-radius: 6px;
+    padding: 12px 16px;
+    text-align: center;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #4caf50;
+  }
+</style>

--- a/web/src/components/edu/EducativePanel.svelte
+++ b/web/src/components/edu/EducativePanel.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+  import { modelStore, resultsStore, uiStore } from '../../lib/store';
+  import { getExercises, type EduExercise } from './exercises';
+  import EduExerciseView from './EduExerciseView.svelte';
+  import { t } from '../../lib/i18n';
+  import { solveForEdu, registerEduSolveHandler } from './edu-solver';
+  import { eduStore } from './edu-store.svelte';
+
+  const exerciseList = $derived(getExercises());
+
+  // Register the edu global-solve listener once on mount
+  registerEduSolveHandler();
+
+  function loadExercise(ex: EduExercise) {
+    modelStore.clear();
+    resultsStore.clear();
+
+    // Build the exercise structure via the shared model store
+    ex.build({
+      addNode: (x, y) => modelStore.addNode(x, y),
+      addElement: (nI, nJ) => modelStore.addElement(nI, nJ),
+      addSupport: (nodeId, type) => modelStore.addSupport(nodeId, type),
+      addNodalLoad: (nodeId, fx, fy, mz) => modelStore.addNodalLoad(nodeId, fx, fy, mz ?? 0),
+      addDistributedLoad: (elementId, qI, qJ) => modelStore.addDistributedLoad(elementId, qI, qJ),
+    });
+
+    // Track in edu store
+    eduStore.loadExercise(ex);
+
+    // Solve internally (results stored but hidden from viewport)
+    setTimeout(() => solveForEdu(), 100);
+
+    // Zoom to fit
+    setTimeout(() => {
+      const canvas = document.querySelector('.viewport-container canvas') as HTMLCanvasElement | null;
+      if (canvas && modelStore.nodes.size > 0) {
+        uiStore.zoomToFit(modelStore.nodes.values(), canvas.width, canvas.height);
+      }
+    }, 150);
+  }
+
+  function goBack() {
+    eduStore.clearExercise();
+    modelStore.clear();
+    resultsStore.clear();
+  }
+</script>
+
+<div class="edu-panel">
+  {#if !eduStore.hasExercise}
+    <div class="edu-welcome">
+      <h2>{t('edu.title')}</h2>
+      <p class="edu-subtitle">{t('edu.subtitle')}</p>
+
+      <div class="exercise-list">
+        {#each exerciseList as ex}
+          <button class="exercise-card" onclick={() => loadExercise(ex)}>
+            <div class="exercise-header">
+              <span class="exercise-title">{ex.title}</span>
+              <span class="difficulty difficulty-{ex.difficulty}">
+                {t('edu.' + ex.difficulty)}
+              </span>
+            </div>
+            <p class="exercise-desc">{ex.description}</p>
+          </button>
+        {/each}
+      </div>
+
+      <div class="edu-footer">
+        <p>{t('edu.moreExercises')}</p>
+      </div>
+    </div>
+  {:else}
+    <div class="edu-exercise-container">
+      <div class="edu-topbar">
+        <button class="edu-back-btn" onclick={goBack}>
+          {t('edu.back')}
+        </button>
+        <span class="edu-exercise-name">{eduStore.exercise!.title}</span>
+      </div>
+
+      {#key eduStore.exerciseKey}
+        <EduExerciseView exercise={eduStore.exercise!} />
+      {/key}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .edu-panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    background: #16213e;
+    color: #ddd;
+    overflow-y: auto;
+  }
+
+  .edu-welcome {
+    padding: 24px 20px;
+  }
+
+  .edu-welcome h2 {
+    font-size: 1.3rem;
+    color: #4ecdc4;
+    margin: 0 0 4px;
+  }
+
+  .edu-subtitle {
+    font-size: 0.82rem;
+    color: #888;
+    margin: 0 0 20px;
+  }
+
+  .exercise-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .exercise-card {
+    text-align: left;
+    background: #0f2840;
+    border: 1px solid #1a4a7a;
+    border-radius: 8px;
+    padding: 14px 16px;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+
+  .exercise-card:hover {
+    background: #1a3860;
+    border-color: #4ecdc4;
+  }
+
+  .exercise-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 6px;
+  }
+
+  .exercise-title {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #eee;
+  }
+
+  .difficulty {
+    font-size: 0.65rem;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .difficulty-easy {
+    background: #1a3a2a;
+    color: #4caf50;
+  }
+
+  .difficulty-medium {
+    background: #3a3a1a;
+    color: #f0a500;
+  }
+
+  .difficulty-hard {
+    background: #3a1a1a;
+    color: #e94560;
+  }
+
+  .exercise-desc {
+    font-size: 0.75rem;
+    color: #999;
+    margin: 0;
+    line-height: 1.4;
+  }
+
+  .edu-footer {
+    margin-top: 24px;
+    padding: 10px 16px;
+  }
+
+  .edu-footer p {
+    font-size: 0.68rem;
+    color: #555;
+    margin: 0;
+    text-align: center;
+    font-style: italic;
+  }
+
+  .edu-exercise-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .edu-topbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    background: #0a1a30;
+    border-bottom: 1px solid #1a4a7a;
+    flex-shrink: 0;
+  }
+
+  .edu-back-btn {
+    background: none;
+    border: 1px solid #334;
+    color: #888;
+    padding: 4px 10px;
+    border-radius: 4px;
+    font-size: 0.72rem;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+
+  .edu-back-btn:hover {
+    color: #4ecdc4;
+    border-color: #4ecdc4;
+  }
+
+  .edu-exercise-name {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: #aaa;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/web/src/components/edu/edu-solver.ts
+++ b/web/src/components/edu/edu-solver.ts
@@ -1,0 +1,61 @@
+/**
+ * edu-solver.ts — Educational mode solver service.
+ *
+ * Self-contained module: uses the shared 2D solver (modelStore.solve)
+ * but manages its own result lifecycle. No other module needs to
+ * import or dispatch to this — edu-solver registers its own listeners.
+ */
+
+import { modelStore, resultsStore, uiStore } from '../../lib/store';
+import { t } from '../../lib/i18n';
+import { eduStore } from './edu-store.svelte';
+
+/**
+ * Solve the current model silently for educational mode.
+ * Results are stored in eduStore (for verification) AND resultsStore
+ * (for the viewport to read reactions/forces), but all visual output
+ * is suppressed.
+ */
+export function solveForEdu(): void {
+  const r = modelStore.solve(uiStore.includeSelfWeight);
+  if (typeof r === 'string') {
+    uiStore.toast(r, 'error');
+    return;
+  }
+  if (!r) {
+    uiStore.toast(t('results.emptyModelError'), 'error');
+    return;
+  }
+
+  // Store results in edu's own store
+  eduStore.results = r;
+
+  // Also push to resultsStore so EduExerciseView can read reactions
+  // (resultsStore.setResults auto-sets diagramType='deformed', so override)
+  resultsStore.setResults(r);
+  resultsStore.diagramType = 'none';
+  resultsStore.showReactions = false;
+
+  // Notify any listener that edu solve completed
+  window.dispatchEvent(new Event('dedaliano-edu-solved'));
+}
+
+// ─── Global solve handler ──────────────────────────────────────────
+// When the 'dedaliano-solve' event fires and we're in edu mode,
+// this module handles it directly — no routing through live-calc.ts.
+
+let registered = false;
+
+/**
+ * Call once (e.g. from EducativePanel mount) to register the edu
+ * global solve listener. Idempotent — safe to call multiple times.
+ */
+export function registerEduSolveHandler(): void {
+  if (registered) return;
+  registered = true;
+
+  window.addEventListener('dedaliano-solve', () => {
+    if (uiStore.analysisMode !== 'edu') return;
+    solveForEdu();
+  });
+}

--- a/web/src/components/edu/edu-store.svelte.ts
+++ b/web/src/components/edu/edu-store.svelte.ts
@@ -1,0 +1,46 @@
+/**
+ * edu-store.svelte.ts — Educational mode state.
+ *
+ * Centralises all edu-specific state (current exercise, answers,
+ * verification, step completion) so it lives outside the shared stores
+ * and can evolve independently of Basic / PRO modes.
+ */
+
+import type { EduExercise } from './exercises';
+import type { AnalysisResults } from '../../lib/engine/types';
+
+// ─── Types ─────────────────────────────────────────────────────────
+export type VerifState = 'pending' | 'correct' | 'incorrect';
+export type ReactionAnswer = Record<string, string>;
+
+// ─── Singleton state ───────────────────────────────────────────────
+
+let currentExercise = $state<EduExercise | null>(null);
+let exerciseKey = $state(0);
+
+/** Internal copy of solver results — edu owns its own reference */
+let solvedResults = $state<AnalysisResults | null>(null);
+
+// ─── Public API ────────────────────────────────────────────────────
+
+export const eduStore = {
+  // ── Exercise lifecycle ────────────────────────────────────────
+  get exercise() { return currentExercise; },
+  get exerciseKey() { return exerciseKey; },
+
+  get results() { return solvedResults; },
+  set results(r: AnalysisResults | null) { solvedResults = r; },
+
+  loadExercise(ex: EduExercise) {
+    currentExercise = ex;
+    exerciseKey++;
+    solvedResults = null;
+  },
+
+  clearExercise() {
+    currentExercise = null;
+    solvedResults = null;
+  },
+
+  get hasExercise() { return currentExercise !== null; },
+};

--- a/web/src/components/edu/exercises.ts
+++ b/web/src/components/edu/exercises.ts
@@ -1,0 +1,307 @@
+/**
+ * Predefined exercises for Educational mode.
+ * Each exercise defines a structure (nodes, elements, supports, loads)
+ * that the solver resolves internally. The student must find the answers.
+ */
+
+import type { SupportType } from '../../lib/store/ui.svelte';
+import { t } from '../../lib/i18n';
+import type { ElementForces } from '../../lib/engine/types';
+
+export interface EduExerciseAPI {
+  addNode: (x: number, y: number) => number;
+  addElement: (nI: number, nJ: number) => number;
+  addSupport: (nodeId: number, type: SupportType) => void;
+  addNodalLoad: (nodeId: number, fx: number, fy: number, mz?: number) => void;
+  addDistributedLoad: (elementId: number, qI: number, qJ?: number) => void;
+}
+
+export interface DiagramQuestion {
+  /** i18n key or plain text — the question prompt */
+  question: string;
+  /** Function that extracts the correct answer from element forces */
+  getCorrect: (forces: ElementForces[]) => number;
+  unit: string;
+}
+
+export interface EduExercise {
+  id: string;
+  title: string;
+  description: string;
+  difficulty: 'easy' | 'medium' | 'hard';
+  build: (api: EduExerciseAPI) => void;
+  supports: Array<{
+    label: string;
+    nodeIndex: number;
+    dofs: ('Rx' | 'Ry' | 'M')[];
+  }>;
+  characteristics: Array<{
+    label: string;
+    unit: string;
+    /** Function that extracts the correct value from element forces */
+    getCorrect: (forces: ElementForces[]) => number;
+  }>;
+  /** Questions about diagrams (Step 2) — the solver computes answers from results */
+  diagramQuestions: DiagramQuestion[];
+}
+
+// ─── Helper extractors ───────────────────────────────────────────
+
+function maxAbsMoment(forces: ElementForces[]): number {
+  let m = 0;
+  for (const ef of forces) m = Math.max(m, Math.abs(ef.mStart), Math.abs(ef.mEnd));
+  return m;
+}
+
+function maxAbsShear(forces: ElementForces[]): number {
+  let v = 0;
+  for (const ef of forces) v = Math.max(v, Math.abs(ef.vStart), Math.abs(ef.vEnd));
+  return v;
+}
+
+function maxAbsAxial(forces: ElementForces[]): number {
+  let n = 0;
+  for (const ef of forces) n = Math.max(n, Math.abs(ef.nStart), Math.abs(ef.nEnd));
+  return n;
+}
+
+/** Max moment in a subset of elements (by 0-based indices) */
+function maxMomentIn(indices: number[]) {
+  return (forces: ElementForces[]): number => {
+    let m = 0;
+    for (const i of indices) {
+      if (i < forces.length) {
+        m = Math.max(m, Math.abs(forces[i].mStart), Math.abs(forces[i].mEnd));
+      }
+    }
+    return m;
+  };
+}
+
+// ─── Exercise definitions ────────────────────────────────────────
+
+export function getExercises(): EduExercise[] {
+  return [
+  // ── 1. Simply supported beam — Point load ──────────────────
+  {
+    id: 'simply-supported-point',
+    title: t('edu.ex1Title'),
+    description: t('edu.ex1Desc'),
+    difficulty: 'easy',
+    build(api) {
+      const n1 = api.addNode(0, 0);
+      const n2 = api.addNode(3, 0);
+      const n3 = api.addNode(6, 0);
+      api.addElement(n1, n2);
+      api.addElement(n2, n3);
+      api.addSupport(n1, 'pinned');
+      api.addSupport(n3, 'rollerX');
+      api.addNodalLoad(n2, 0, -10);
+    },
+    supports: [
+      { label: t('edu.ex1SupportA'), nodeIndex: 0, dofs: ['Rx', 'Ry'] },
+      { label: t('edu.ex1SupportB'), nodeIndex: 2, dofs: ['Ry'] },
+    ],
+    characteristics: [
+      { label: 'Mmax', unit: 'kN·m', getCorrect: maxAbsMoment },
+      { label: 'Vmax', unit: 'kN', getCorrect: maxAbsShear },
+    ],
+    diagramQuestions: [
+      { question: t('edu.dq.shearAtSupport'), getCorrect: f => Math.abs(f[0].vStart), unit: 'kN' },
+      { question: t('edu.dq.momentAtCenter'), getCorrect: f => Math.abs(f[0].mEnd), unit: 'kN·m' },
+    ],
+  },
+  // ── 2. Simply supported beam — Distributed load ────────────
+  {
+    id: 'simply-supported-distributed',
+    title: t('edu.ex2Title'),
+    description: t('edu.ex2Desc'),
+    difficulty: 'easy',
+    build(api) {
+      const n1 = api.addNode(0, 0);
+      const n2 = api.addNode(8, 0);
+      const e1 = api.addElement(n1, n2);
+      api.addSupport(n1, 'pinned');
+      api.addSupport(n2, 'rollerX');
+      api.addDistributedLoad(e1, -5);
+    },
+    supports: [
+      { label: t('edu.ex2SupportA'), nodeIndex: 0, dofs: ['Rx', 'Ry'] },
+      { label: t('edu.ex2SupportB'), nodeIndex: 1, dofs: ['Ry'] },
+    ],
+    characteristics: [
+      { label: 'Mmax', unit: 'kN·m', getCorrect: maxAbsMoment },
+      { label: 'Vmax', unit: 'kN', getCorrect: maxAbsShear },
+    ],
+    diagramQuestions: [
+      { question: t('edu.dq.shearAtSupport'), getCorrect: f => Math.abs(f[0].vStart), unit: 'kN' },
+      { question: t('edu.dq.momentAtMidspan'), getCorrect: f => maxAbsMoment(f), unit: 'kN·m' },
+    ],
+  },
+  // ── 3. Portal frame — Horizontal load ──────────────────────
+  {
+    id: 'portal-frame',
+    title: t('edu.ex3Title'),
+    description: t('edu.ex3Desc'),
+    difficulty: 'medium',
+    build(api) {
+      const n1 = api.addNode(0, 0);
+      const n2 = api.addNode(0, 3);
+      const n3 = api.addNode(4, 3);
+      const n4 = api.addNode(4, 0);
+      api.addElement(n1, n2);
+      api.addElement(n2, n3);
+      api.addElement(n3, n4);
+      api.addSupport(n1, 'fixed');
+      api.addSupport(n4, 'fixed');
+      api.addNodalLoad(n2, 8, 0);
+    },
+    supports: [
+      { label: t('edu.ex3SupportA'), nodeIndex: 0, dofs: ['Rx', 'Ry', 'M'] },
+      { label: t('edu.ex3SupportB'), nodeIndex: 3, dofs: ['Rx', 'Ry', 'M'] },
+    ],
+    characteristics: [
+      { label: t('edu.ex3MmaxCol'), unit: 'kN·m', getCorrect: maxMomentIn([0, 2]) },
+      { label: t('edu.ex3MmaxBeam'), unit: 'kN·m', getCorrect: maxMomentIn([1]) },
+    ],
+    diagramQuestions: [
+      { question: t('edu.dq.momentAtBase'), getCorrect: f => Math.abs(f[0].mStart), unit: 'kN·m' },
+    ],
+  },
+  // ── 4. Cantilever beam — Point load at tip ─────────────────
+  {
+    id: 'cantilever-point',
+    title: t('edu.ex4Title'),
+    description: t('edu.ex4Desc'),
+    difficulty: 'easy',
+    build(api) {
+      const n1 = api.addNode(0, 0);
+      const n2 = api.addNode(4, 0);
+      api.addElement(n1, n2);
+      api.addSupport(n1, 'fixed');
+      api.addNodalLoad(n2, 0, -12);
+    },
+    supports: [
+      { label: t('edu.ex4SupportA'), nodeIndex: 0, dofs: ['Rx', 'Ry', 'M'] },
+    ],
+    characteristics: [
+      { label: 'Mmax', unit: 'kN·m', getCorrect: maxAbsMoment },
+      { label: 'Vmax', unit: 'kN', getCorrect: maxAbsShear },
+    ],
+    diagramQuestions: [
+      { question: t('edu.dq.momentAtFixed'), getCorrect: f => Math.abs(f[0].mStart), unit: 'kN·m' },
+      { question: t('edu.dq.shearConstant'), getCorrect: f => Math.abs(f[0].vStart), unit: 'kN' },
+    ],
+  },
+  // ── 5. Fixed-fixed beam — Distributed load ─────────────────
+  {
+    id: 'fixed-fixed-distributed',
+    title: t('edu.ex5Title'),
+    description: t('edu.ex5Desc'),
+    difficulty: 'medium',
+    build(api) {
+      const n1 = api.addNode(0, 0);
+      const n2 = api.addNode(6, 0);
+      const e1 = api.addElement(n1, n2);
+      api.addSupport(n1, 'fixed');
+      api.addSupport(n2, 'fixed');
+      api.addDistributedLoad(e1, -8);
+    },
+    supports: [
+      { label: t('edu.ex5SupportA'), nodeIndex: 0, dofs: ['Rx', 'Ry', 'M'] },
+      { label: t('edu.ex5SupportB'), nodeIndex: 1, dofs: ['Rx', 'Ry', 'M'] },
+    ],
+    characteristics: [
+      { label: 'Mmax', unit: 'kN·m', getCorrect: maxAbsMoment },
+      { label: 'Vmax', unit: 'kN', getCorrect: maxAbsShear },
+    ],
+    diagramQuestions: [
+      { question: t('edu.dq.momentAtEnds'), getCorrect: f => Math.abs(f[0].mStart), unit: 'kN·m' },
+      { question: t('edu.dq.shearAtSupport'), getCorrect: f => Math.abs(f[0].vStart), unit: 'kN' },
+    ],
+  },
+  // ── 6. Cantilever — Distributed load ───────────────────────
+  {
+    id: 'cantilever-distributed',
+    title: t('edu.ex6Title'),
+    description: t('edu.ex6Desc'),
+    difficulty: 'easy',
+    build(api) {
+      const n1 = api.addNode(0, 0);
+      const n2 = api.addNode(5, 0);
+      const e1 = api.addElement(n1, n2);
+      api.addSupport(n1, 'fixed');
+      api.addDistributedLoad(e1, -6);
+    },
+    supports: [
+      { label: t('edu.ex6SupportA'), nodeIndex: 0, dofs: ['Rx', 'Ry', 'M'] },
+    ],
+    characteristics: [
+      { label: 'Mmax', unit: 'kN·m', getCorrect: maxAbsMoment },
+      { label: 'Vmax', unit: 'kN', getCorrect: maxAbsShear },
+    ],
+    diagramQuestions: [
+      { question: t('edu.dq.momentAtFixed'), getCorrect: f => Math.abs(f[0].mStart), unit: 'kN·m' },
+      { question: t('edu.dq.shearAtFixed'), getCorrect: f => Math.abs(f[0].vStart), unit: 'kN' },
+    ],
+  },
+  // ── 7. Simple truss (triangle) ─────────────────────────────
+  {
+    id: 'simple-truss',
+    title: t('edu.ex7Title'),
+    description: t('edu.ex7Desc'),
+    difficulty: 'medium',
+    build(api) {
+      const n1 = api.addNode(0, 0);
+      const n2 = api.addNode(4, 0);
+      const n3 = api.addNode(2, 3);
+      api.addElement(n1, n3); // left diagonal
+      api.addElement(n2, n3); // right diagonal
+      api.addElement(n1, n2); // bottom chord
+      api.addSupport(n1, 'pinned');
+      api.addSupport(n2, 'rollerX');
+      api.addNodalLoad(n3, 0, -20);
+    },
+    supports: [
+      { label: t('edu.ex7SupportA'), nodeIndex: 0, dofs: ['Rx', 'Ry'] },
+      { label: t('edu.ex7SupportB'), nodeIndex: 1, dofs: ['Ry'] },
+    ],
+    characteristics: [
+      { label: t('edu.ex7Nmax'), unit: 'kN', getCorrect: maxAbsAxial },
+    ],
+    diagramQuestions: [
+      { question: t('edu.dq.axialBottomChord'), getCorrect: f => Math.abs(f[2]?.nStart ?? 0), unit: 'kN' },
+    ],
+  },
+  // ── 8. Portal frame — Distributed load on beam ─────────────
+  {
+    id: 'portal-distributed',
+    title: t('edu.ex8Title'),
+    description: t('edu.ex8Desc'),
+    difficulty: 'hard',
+    build(api) {
+      const n1 = api.addNode(0, 0);
+      const n2 = api.addNode(0, 4);
+      const n3 = api.addNode(5, 4);
+      const n4 = api.addNode(5, 0);
+      api.addElement(n1, n2);
+      const eBeam = api.addElement(n2, n3);
+      api.addElement(n3, n4);
+      api.addSupport(n1, 'fixed');
+      api.addSupport(n4, 'fixed');
+      api.addDistributedLoad(eBeam, -10);
+    },
+    supports: [
+      { label: t('edu.ex8SupportA'), nodeIndex: 0, dofs: ['Rx', 'Ry', 'M'] },
+      { label: t('edu.ex8SupportB'), nodeIndex: 3, dofs: ['Rx', 'Ry', 'M'] },
+    ],
+    characteristics: [
+      { label: t('edu.ex8MmaxBeam'), unit: 'kN·m', getCorrect: maxMomentIn([1]) },
+      { label: 'Vmax', unit: 'kN', getCorrect: maxAbsShear },
+    ],
+    diagramQuestions: [
+      { question: t('edu.dq.momentAtBeamEnds'), getCorrect: f => Math.abs(f[1].mStart), unit: 'kN·m' },
+    ],
+  },
+];
+}

--- a/web/src/components/pro/ProAdvancedTab.svelte
+++ b/web/src/components/pro/ProAdvancedTab.svelte
@@ -1,0 +1,2006 @@
+<script lang="ts">
+  import { modelStore, resultsStore, uiStore } from '../../lib/store';
+  import { t } from '../../lib/i18n';
+  import {
+    isSolverReady,
+    solvePDelta3D as wasmPDelta3D,
+    solveModal3D as wasmModal3D,
+    solveBuckling3D as wasmBuckling3D,
+    solveSpectral3D as wasmSpectral3D,
+    solveTimeHistory3D,
+    solvePlastic3D,
+    solveCorotational3D,
+    solveFiberNonlinear3D,
+    solveWinkler3D,
+    solveSSI3D,
+    solveContact3D,
+    solveStaged3D,
+    solveCreepShrinkage3D,
+    solveHarmonic3D,
+    solveArcLength,
+    solveDisplacementControl,
+    solveWithImperfections3D,
+    computeInfluenceLine3D,
+    solveCable2D,
+    guyanReduce2D,
+    craigBampton2D,
+    solveMultiCase2D,
+    solveMultiCase3D,
+    analyzeSection,
+    solveConstrained2D,
+    solveConstrained3D,
+  } from '../../lib/engine/wasm-solver';
+  // JS fallback solvers for when WASM is not available
+  import { solvePDelta3D as jsPDelta3D } from '../../lib/engine/pdelta-3d';
+  import { solveModal3D as jsModal3D } from '../../lib/engine/modal-3d';
+  import { solveBuckling3D as jsBuckling3D } from '../../lib/engine/buckling-3d';
+  import { solveSpectral3D as jsSpectral3D } from '../../lib/engine/spectral-3d';
+  import type { SpectralConfig3D } from '../../lib/engine/spectral-3d';
+  import { buildSolverInput3D } from '../../lib/engine/solver-service';
+  import { cirsoc103Spectrum } from '../../lib/engine/spectral';
+  import type { DesignSpectrum } from '../../lib/engine/spectral';
+  import { applyRigidDiaphragm, detectFloorLevels } from '../../lib/engine/rigid-diaphragm';
+  // Wind loads moved to ProAutoLoadsDialog
+  // enforceConstraints3D removed — WASM solvers handle quads/constraints natively
+
+  // Expose advanced results to parent via bindable props
+  interface AdvancedResults3D {
+    pdelta?: { converged: boolean; iterations: number; b2Factor?: number };
+    modal?: { modes: Array<{ frequency: number; period: number; participationX?: number; participationY?: number; participationZ?: number }>; totalMass?: number };
+    buckling?: { factors: number[] };
+    spectral?: { baseShearX?: number; baseShearY?: number; baseShearZ?: number };
+  }
+  let { advancedResults = $bindable({}) }: { advancedResults: AdvancedResults3D } = $props();
+
+  let solving = $state(false);
+  let solveError = $state<string | null>(null);
+
+  let modalElapsed = $state<number | null>(null);
+  let bucklingElapsed = $state<number | null>(null);
+  let pdeltaElapsed = $state<number | null>(null);
+  let harmonicElapsed = $state<number | null>(null);
+
+  const hasModel = $derived(modelStore.nodes.size > 0 && modelStore.elements.size > 0);
+  const wasmAvailable = $derived(isSolverReady());
+  const elementIds = $derived([...modelStore.elements.keys()]);
+  const nodeIds = $derived([...modelStore.nodes.keys()]);
+
+  function fmtNum(n: number): string {
+    if (n === 0) return '0';
+    if (Math.abs(n) < 0.001) return n.toExponential(2);
+    if (Math.abs(n) < 1) return n.toFixed(4);
+    return n.toFixed(2);
+  }
+
+  // ─── Shared helpers ────────────────────────────────────────────
+
+  let useDiaphragm = $state(false);
+
+  function buildInput() {
+    const input = buildSolverInput3D(
+      { nodes: modelStore.nodes, elements: modelStore.elements, supports: modelStore.supports,
+        loads: modelStore.loads, materials: modelStore.materials, sections: modelStore.sections,
+        quads: modelStore.quads, plates: modelStore.plates, constraints: modelStore.constraints },
+      uiStore.includeSelfWeight,
+    );
+    if (!input) throw new Error(t('advanced.emptyModel'));
+    return input;
+  }
+
+  function getMaterialDensities(input?: any): Map<number, number> {
+    // mat.rho is weight density in kN/m³; convert to mass density in kg/m³
+    const densities = new Map<number, number>();
+    for (const [id, mat] of modelStore.materials) {
+      densities.set(id, ((mat as any).rho ?? 0) * 1000 / 9.81);
+    }
+    // Also include any materials from the enforced input (penalty materials)
+    // that aren't in the store — use small density to avoid zero-mass DOFs
+    if (input?.materials) {
+      for (const [id] of input.materials) {
+        if (!densities.has(id)) {
+          densities.set(id, 1.0); // 1 kg/m³ — negligible but non-zero
+        }
+      }
+    }
+    return densities;
+  }
+
+  function maybeApplyDiaphragm(input: any) {
+    if (!useDiaphragm) return input;
+    const levels = detectFloorLevels(input.nodes);
+    if (!levels || levels.length === 0) return input;
+    return applyRigidDiaphragm(input, { levels });
+  }
+
+  // ─── 1. P-Delta ─────────────────────────────────────────────────
+
+  let pdeltaResult = $state<any | null>(null);
+
+  function handlePDelta() {
+    solveError = null;
+    solving = true;
+    pdeltaElapsed = null;
+    try {
+      let input = buildInput();
+      input = maybeApplyDiaphragm(input);
+      let res: any;
+      const t0 = performance.now();
+      try { res = wasmPDelta3D(input); } catch { res = jsPDelta3D(input); }
+      const elapsed = performance.now() - t0;
+      if (typeof res === 'string') { solveError = `P-Delta: ${res}`; solving = false; return; }
+      pdeltaElapsed = elapsed;
+      pdeltaResult = res;
+      if (res.results) {
+        resultsStore.setPDeltaResult3D(res);
+      }
+      advancedResults = { ...advancedResults, pdelta: { converged: res.converged, iterations: res.iterations, b2Factor: res.b2Factor } };
+    } catch (e: any) {
+      solveError = `P-Delta: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 2. Modal ───────────────────────────────────────────────────
+
+  let modalResult = $state<any | null>(null);
+  let numModes = $state(6);
+
+  const modalCumX = $derived.by(() => {
+    if (!modalResult?.modes) return [];
+    let sum = 0;
+    return modalResult.modes.map((m: any) => { sum += Math.abs(m.participationX ?? m.partX ?? 0); return sum; });
+  });
+  const modalCumY = $derived.by(() => {
+    if (!modalResult?.modes) return [];
+    let sum = 0;
+    return modalResult.modes.map((m: any) => { sum += Math.abs(m.participationY ?? m.partY ?? 0); return sum; });
+  });
+
+  function handleModal() {
+    solveError = null;
+    solving = true;
+    modalElapsed = null;
+    try {
+      let input = buildInput();
+      input = maybeApplyDiaphragm(input);
+      const densities = getMaterialDensities(input);
+      let res: any;
+      const t0 = performance.now();
+      try { res = wasmModal3D(input, densities, numModes); } catch { res = jsModal3D(input, densities, numModes); }
+      const elapsed = performance.now() - t0;
+      if (typeof res === 'string') { solveError = `Modal: ${res}`; solving = false; return; }
+      modalElapsed = elapsed;
+      modalResult = res;
+      if (res.modes || res.frequencies) {
+        const modes = (res.modes ?? res.frequencies ?? []).map((m: any, i: number) => ({
+          frequency: m.frequency ?? m.freq ?? (res.frequencies?.[i] ?? 0),
+          period: m.period ?? (m.frequency ? 1 / m.frequency : 0),
+          participationX: m.participationX ?? m.partX,
+          participationY: m.participationY ?? m.partY,
+          participationZ: m.participationZ ?? m.partZ,
+        }));
+        advancedResults = { ...advancedResults, modal: { modes, totalMass: res.totalMass } };
+      }
+    } catch (e: any) {
+      solveError = `Modal: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 3. Spectral ───────────────────────────────────────────────
+
+  let spectralResult = $state<any | null>(null);
+  let spectralCombination = $state<'CQC' | 'SRSS'>('CQC');
+  let seismicZone = $state<1 | 2 | 3 | 4>(3);
+  let soilType = $state<'I' | 'II' | 'III'>('II');
+
+  function handleSpectral() {
+    solveError = null;
+    solving = true;
+    try {
+      if (!modalResult) {
+        solveError = t('pro.requiresModal');
+        solving = false;
+        return;
+      }
+      let input = buildInput();
+      input = maybeApplyDiaphragm(input);
+      const densities = getMaterialDensities(input);
+      const spectrum: DesignSpectrum = cirsoc103Spectrum(seismicZone, soilType);
+      let res: any;
+      try {
+        res = wasmSpectral3D({
+          solver: input,
+          densities,
+          spectrum,
+          directions: ['X', 'Y', 'Z'],
+          combination: spectralCombination,
+          numModes,
+        });
+      } catch {
+        // JS fallback: solveSpectral3D(input, modalResult, densities, config) per direction
+        const config: SpectralConfig3D = {
+          direction: 'X',
+          spectrum,
+          rule: spectralCombination,
+        };
+        const resX = jsSpectral3D(input, modalResult, densities, { ...config, direction: 'X' });
+        const resY = jsSpectral3D(input, modalResult, densities, { ...config, direction: 'Y' });
+        if (typeof resX === 'string') { solveError = `Espectral: ${resX}`; solving = false; return; }
+        if (typeof resY === 'string') { solveError = `Espectral: ${resY}`; solving = false; return; }
+        res = {
+          baseShearX: resX.baseShear,
+          baseShearY: resY.baseShear,
+          results: resX.results,
+          perModeX: resX.perMode,
+          perModeY: resY.perMode,
+        };
+      }
+      if (typeof res === 'string') { solveError = `Espectral: ${res}`; solving = false; return; }
+      spectralResult = res;
+      advancedResults = { ...advancedResults, spectral: { baseShearX: res.baseShearX ?? res.baseShear, baseShearY: res.baseShearY, baseShearZ: res.baseShearZ } };
+    } catch (e: any) {
+      solveError = `Espectral: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 4. Buckling ───────────────────────────────────────────────
+
+  let bucklingResult = $state<any | null>(null);
+  let numBucklingModes = $state(4);
+
+  function handleBuckling() {
+    solveError = null;
+    solving = true;
+    bucklingElapsed = null;
+    try {
+      let input = buildInput();
+      input = maybeApplyDiaphragm(input);
+      let res: any;
+      const t0 = performance.now();
+      try { res = wasmBuckling3D(input, numBucklingModes); } catch { res = jsBuckling3D(input, numBucklingModes); }
+      const elapsed = performance.now() - t0;
+      if (typeof res === 'string') { solveError = `Buckling: ${res}`; solving = false; return; }
+      bucklingElapsed = elapsed;
+      bucklingResult = res;
+      const factors = res.factors ?? res.eigenvalues ?? (res.modes?.map((m: any) => m.loadFactor ?? m.factor ?? m.eigenvalue) ?? []);
+      advancedResults = { ...advancedResults, buckling: { factors } };
+    } catch (e: any) {
+      solveError = `Buckling: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 5. Time History ──────────────────────────────────────────
+
+  let thDt = $state(0.01);
+  let thNSteps = $state(200);
+  let thDir = $state<'X' | 'Y'>('X');
+  let thDamping = $state(0.05);
+  let thMethod = $state<'newmark' | 'hht'>('newmark');
+  let thAccelText = $state('');
+  let thResult = $state<any | null>(null);
+  let thUseSine = $state(false);
+  let thSineAmp = $state(0.3);
+  let thSineFreq = $state(2.0);
+
+  function generateSineAccel(): number[] {
+    const vals: number[] = [];
+    for (let i = 0; i < thNSteps; i++) {
+      vals.push(thSineAmp * Math.sin(2 * Math.PI * thSineFreq * i * thDt));
+    }
+    return vals;
+  }
+
+  function parseAccelInput(): number[] {
+    if (thUseSine) return generateSineAccel();
+    return thAccelText.split(/[,\s]+/).filter(s => s.length > 0).map(Number).filter(n => !isNaN(n));
+  }
+
+  function handleTimeHistory() {
+    solveError = null;
+    solving = true;
+    try {
+      const groundAccel = parseAccelInput();
+      if (groundAccel.length === 0) {
+        solveError = t('pro.needAccelData');
+        solving = false;
+        return;
+      }
+      let input = buildInput();
+      input = maybeApplyDiaphragm(input);
+      const densities: Record<string, number> = {};
+      for (const [id, mat] of modelStore.materials) {
+        densities[String(id)] = (mat as any).rho ?? 0;
+      }
+      const beta = 0.25;
+      const gamma = 0.5;
+      const res = solveTimeHistory3D({
+        solver: input,
+        densities,
+        timeStep: thDt,
+        nSteps: thNSteps,
+        method: thMethod,
+        beta,
+        gamma,
+        dampingXi: thDamping,
+        groundAccel,
+        groundDirection: thDir,
+      });
+      thResult = res;
+    } catch (e: any) {
+      solveError = `Time History: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 6b. Harmonic Response ───────────────────────────────────
+
+  let harmFMin = $state(0.1);
+  let harmFMax = $state(50);
+  let harmNPoints = $state(200);
+  let harmDamping = $state(0.05);
+  let harmDir = $state<'X' | 'Y' | 'Z'>('X');
+  let harmResult = $state<any | null>(null);
+
+  function handleHarmonic() {
+    solveError = null;
+    solving = true;
+    harmonicElapsed = null;
+    try {
+      let input = buildInput();
+      input = maybeApplyDiaphragm(input);
+      const densities: Record<string, number> = {};
+      for (const [id, mat] of modelStore.materials) {
+        densities[String(id)] = (mat as any).rho ?? 0;
+      }
+      const t0 = performance.now();
+      const res = solveHarmonic3D({
+        solver: input,
+        densities,
+        fMin: harmFMin,
+        fMax: harmFMax,
+        nPoints: harmNPoints,
+        dampingXi: harmDamping,
+        direction: harmDir,
+      });
+      const elapsed = performance.now() - t0;
+      harmonicElapsed = elapsed;
+      harmResult = res;
+    } catch (e: any) {
+      solveError = `Harmónico: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 7. Nonlinear ─────────────────────────────────────────────
+
+  let nlType = $state<'pushover' | 'corotational' | 'fiber'>('pushover');
+  let nlMaxHinges = $state(20);
+  let nlMaxIter = $state(50);
+  let nlTol = $state(1e-6);
+  let nlIncrements = $state(10);
+  let nlFiberIntPts = $state(5);
+  let nlResult = $state<any | null>(null);
+
+  function handleNonlinear() {
+    solveError = null;
+    solving = true;
+    try {
+      let input = buildInput();
+      input = maybeApplyDiaphragm(input);
+
+      if (nlType === 'pushover') {
+        const sections: Record<string, any> = {};
+        for (const [id, sec] of modelStore.sections) {
+          sections[String(id)] = {
+            a: (sec as any).area ?? (sec as any).a ?? 0,
+            iy: (sec as any).iy ?? (sec as any).Iy ?? 0,
+            iz: (sec as any).iz ?? (sec as any).Iz ?? 0,
+            materialId: (sec as any).materialId ?? 0,
+            b: (sec as any).b ?? (sec as any).width ?? 0,
+            h: (sec as any).h ?? (sec as any).height ?? 0,
+          };
+        }
+        const materials: Record<string, any> = {};
+        for (const [id, mat] of modelStore.materials) {
+          materials[String(id)] = { fy: (mat as any).fy ?? 250 };
+        }
+        nlResult = solvePlastic3D({
+          solver: input,
+          sections,
+          materials,
+          maxHinges: nlMaxHinges,
+        });
+      } else if (nlType === 'corotational') {
+        nlResult = solveCorotational3D(input, nlMaxIter, nlTol, nlIncrements);
+      } else {
+        const fiberSections: Record<string, any> = {};
+        for (const [id, sec] of modelStore.sections) {
+          fiberSections[String(id)] = {
+            a: (sec as any).area ?? (sec as any).a ?? 0,
+            iy: (sec as any).iy ?? (sec as any).Iy ?? 0,
+            iz: (sec as any).iz ?? (sec as any).Iz ?? 0,
+            materialId: (sec as any).materialId ?? 0,
+            b: (sec as any).b ?? (sec as any).width ?? 0,
+            h: (sec as any).h ?? (sec as any).height ?? 0,
+          };
+        }
+        nlResult = solveFiberNonlinear3D({
+          solver: input,
+          fiberSections,
+          nIntegrationPoints: nlFiberIntPts,
+          maxIter: nlMaxIter,
+          tolerance: nlTol,
+          nIncrements: nlIncrements,
+        });
+      }
+    } catch (e: any) {
+      solveError = `No lineal: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 7b. Arc-Length ──────────────────────────────────────────
+
+  let arcMaxIter = $state(50);
+  let arcTol = $state(1e-6);
+  let arcIncrements = $state(20);
+  let arcResult = $state<any | null>(null);
+
+  function handleArcLength() {
+    solveError = null;
+    solving = true;
+    try {
+      let input = buildInput();
+      input = maybeApplyDiaphragm(input);
+      arcResult = solveArcLength({
+        solver: input,
+        maxIter: arcMaxIter,
+        tolerance: arcTol,
+        nIncrements: arcIncrements,
+      });
+    } catch (e: any) {
+      solveError = `Arc-Length: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 7c. Displacement Control ──────────────────────────────
+
+  let dcNodeId = $state<number | null>(null);
+  let dcDof = $state<'ux' | 'uy' | 'uz'>('uy');
+  let dcTargetDisp = $state(-0.05);
+  let dcIncrements = $state(20);
+  let dcResult = $state<any | null>(null);
+
+  function handleDispControl() {
+    solveError = null;
+    solving = true;
+    try {
+      let input = buildInput();
+      input = maybeApplyDiaphragm(input);
+      dcResult = solveDisplacementControl({
+        solver: input,
+        controlNode: dcNodeId,
+        controlDof: dcDof,
+        targetDisplacement: dcTargetDisp,
+        nIncrements: dcIncrements,
+      });
+    } catch (e: any) {
+      solveError = `Disp. Control: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 7d. Imperfections ─────────────────────────────────────
+
+  let imperfType = $state<'global' | 'local'>('global');
+  let imperfAmplitude = $state(0.001);
+  let imperfResult = $state<any | null>(null);
+
+  function handleImperfections() {
+    solveError = null;
+    solving = true;
+    try {
+      let input = buildInput();
+      input = maybeApplyDiaphragm(input);
+      imperfResult = solveWithImperfections3D({
+        solver: input,
+        type: imperfType,
+        amplitude: imperfAmplitude,
+      });
+    } catch (e: any) {
+      solveError = `Imperfecciones: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 8. Winkler Foundation ─────────────────────────────────────
+
+  let winklerElementId = $state<number | null>(null);
+  let winklerKy = $state(1000);
+  let winklerKz = $state(0);
+  let winklerSprings = $state<{ elementId: number; ky: number; kz: number }[]>([]);
+  let winklerResult = $state<any | null>(null);
+
+  function addWinklerSpring() {
+    if (winklerElementId == null) return;
+    winklerSprings = [...winklerSprings, { elementId: winklerElementId, ky: winklerKy, kz: winklerKz }];
+  }
+
+  function removeWinklerSpring(idx: number) {
+    winklerSprings = winklerSprings.filter((_, i) => i !== idx);
+  }
+
+  function handleWinkler() {
+    solveError = null;
+    solving = true;
+    try {
+      const input = buildInput();
+      const res = solveWinkler3D({
+        solver: input,
+        foundationSprings: winklerSprings.map(s => ({
+          elementId: s.elementId,
+          ...(s.ky ? { ky: s.ky } : {}),
+          ...(s.kz ? { kz: s.kz } : {}),
+        })),
+      });
+      winklerResult = res;
+      if (res.results) resultsStore.setResults3D(res.results);
+    } catch (e: any) {
+      solveError = `Winkler: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 9. SSI ────────────────────────────────────────────────────
+
+  let ssiNodeId = $state<number | null>(null);
+  let ssiDirection = $state<'Y' | 'Z'>('Y');
+  let ssiCurveType = $state<'softClay' | 'sand' | 'stiffClay' | 'custom'>('softClay');
+  let ssiSu = $state(50);
+  let ssiGamma = $state(18);
+  let ssiDiameter = $state(0.6);
+  let ssiDepth = $state(5);
+  let ssiPhi = $state(30);
+  let ssiTribLength = $state(1);
+  let ssiMaxIter = $state(50);
+  let ssiTolerance = $state(1e-4);
+  let ssiSprings = $state<any[]>([]);
+  let ssiResult = $state<any | null>(null);
+
+  function addSsiSpring() {
+    if (ssiNodeId == null) return;
+    const params: any = { type: ssiCurveType };
+    if (ssiCurveType === 'softClay' || ssiCurveType === 'stiffClay') {
+      params.su = ssiSu; params.gamma = ssiGamma; params.d = ssiDiameter; params.depth = ssiDepth;
+    } else if (ssiCurveType === 'sand') {
+      params.phi = ssiPhi; params.gamma = ssiGamma; params.d = ssiDiameter; params.depth = ssiDepth;
+    }
+    ssiSprings = [...ssiSprings, { nodeId: ssiNodeId, direction: ssiDirection, curve: params, tributaryLength: ssiTribLength }];
+  }
+
+  function removeSsiSpring(idx: number) {
+    ssiSprings = ssiSprings.filter((_, i) => i !== idx);
+  }
+
+  function handleSSI() {
+    solveError = null;
+    solving = true;
+    try {
+      const input = buildInput();
+      const res = solveSSI3D({
+        solver: input,
+        soilSprings: ssiSprings,
+        maxIter: ssiMaxIter,
+        tolerance: ssiTolerance,
+      });
+      ssiResult = res;
+      if (res.results) resultsStore.setResults3D(res.results);
+    } catch (e: any) {
+      solveError = `SSI: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 10. Contact / Gap ─────────────────────────────────────────
+
+  let contactBehaviors = $state<Map<number, 'normal' | 'tensionOnly' | 'compressionOnly'>>(new Map());
+  let contactElementId = $state<number | null>(null);
+  let contactBehavior = $state<'normal' | 'tensionOnly' | 'compressionOnly'>('tensionOnly');
+  let contactResult = $state<any | null>(null);
+
+  function setContactBehavior() {
+    if (contactElementId == null) return;
+    const next = new Map(contactBehaviors);
+    next.set(contactElementId, contactBehavior);
+    contactBehaviors = next;
+  }
+
+  function removeContactBehavior(eid: number) {
+    const next = new Map(contactBehaviors);
+    next.delete(eid);
+    contactBehaviors = next;
+  }
+
+  const contactEntries = $derived([...contactBehaviors.entries()]);
+
+  function handleContact() {
+    solveError = null;
+    solving = true;
+    try {
+      const input = buildInput();
+      const elements: any[] = [];
+      for (const [elementId, behavior] of contactBehaviors) {
+        elements.push({ elementId, behavior });
+      }
+      const res = solveContact3D({ solver: input, contactElements: elements });
+      contactResult = res;
+      if (res.results) resultsStore.setResults3D(res.results);
+    } catch (e: any) {
+      solveError = `Contacto: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 11. Staged Construction ───────────────────────────────────
+
+  let stages = $state<{ name: string; addElements: number[]; removeElements: number[]; loadIndices: number[] }[]>([]);
+  let stagedResult = $state<any | null>(null);
+
+  function addStage() {
+    stages = [...stages, { name: t('pro.stageN').replace('{n}', String(stages.length + 1)), addElements: [], removeElements: [], loadIndices: [] }];
+  }
+
+  function removeStage(idx: number) {
+    stages = stages.filter((_, i) => i !== idx);
+  }
+
+  function handleStaged() {
+    solveError = null;
+    solving = true;
+    try {
+      const input = buildInput();
+      const res = solveStaged3D({
+        solver: input,
+        stages: stages.map(s => ({ addElements: s.addElements, removeElements: s.removeElements, loadIndices: s.loadIndices })),
+      });
+      stagedResult = res;
+      if (res.results) resultsStore.setResults3D(res.results);
+    } catch (e: any) {
+      solveError = `Etapas: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 12. Creep & Shrinkage ─────────────────────────────────────
+
+  let creepFc = $state(30);
+  let creepRH = $state(60);
+  let creepH0 = $state(200);
+  let creepAge = $state(28);
+  let creepCementClass = $state<'R' | 'N' | 'S'>('N');
+  let creepTimeSteps = $state<{ time: number; additionalLoadFactor: number }[]>([
+    { time: 365, additionalLoadFactor: 0 },
+  ]);
+  let creepResult = $state<any | null>(null);
+
+  function addCreepStep() {
+    const lastTime = creepTimeSteps.length > 0 ? creepTimeSteps[creepTimeSteps.length - 1].time : 0;
+    creepTimeSteps = [...creepTimeSteps, { time: lastTime + 365, additionalLoadFactor: 0 }];
+  }
+
+  function removeCreepStep(idx: number) {
+    creepTimeSteps = creepTimeSteps.filter((_, i) => i !== idx);
+  }
+
+  function handleCreep() {
+    solveError = null;
+    solving = true;
+    try {
+      const input = buildInput();
+      creepResult = solveCreepShrinkage3D({
+        solver: input,
+        concrete: { fc: creepFc, rh: creepRH, h0: creepH0, ageAtLoading: creepAge, cementClass: creepCementClass },
+        timeSteps: creepTimeSteps,
+      });
+    } catch (e: any) {
+      solveError = `Fluencia: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 13. Cable Analysis (2D) ──────────────────────────────────
+
+  let cableMaxIter = $state(50);
+  let cableTol = $state(1e-6);
+  let cableResult = $state<any | null>(null);
+
+  function handleCable() {
+    solveError = null;
+    solving = true;
+    try {
+      // Cable analysis is 2D-only — uses buildSolverInput from modelStore
+      const input = modelStore.buildSolverInput(true); // always include self-weight for cables
+      if (!input) { solveError = t('advanced.emptyModel'); solving = false; return; }
+      cableResult = solveCable2D(input, cableMaxIter, cableTol);
+    } catch (e: any) {
+      solveError = `Cable: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 14. Influence Lines 3D ──────────────────────────────────
+
+  let ilElementId = $state<number | null>(null);
+  let ilResponse = $state<'moment' | 'shear' | 'axial' | 'reaction'>('moment');
+  let ilResult = $state<any | null>(null);
+
+  function handleInfluenceLine3D() {
+    solveError = null;
+    solving = true;
+    try {
+      let input = buildInput();
+      input = maybeApplyDiaphragm(input);
+      ilResult = computeInfluenceLine3D({
+        solver: input,
+        elementId: ilElementId,
+        responseType: ilResponse,
+      });
+    } catch (e: any) {
+      solveError = `Influence Line 3D: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 15. Model Reduction ─────────────────────────────────────
+
+  let reductionMethod = $state<'guyan' | 'craigBampton'>('guyan');
+  let retainedDofs = $state('');   // comma-separated DOF indices
+  let numCBModes = $state(10);
+  let reductionResult = $state<any | null>(null);
+
+  function handleModelReduction() {
+    solveError = null;
+    solving = true;
+    try {
+      const retained = retainedDofs.split(/[,\s]+/).map(Number).filter(n => !isNaN(n) && n >= 0);
+      if (retained.length === 0) {
+        solveError = t('pro.noRetainedDofs');
+        solving = false;
+        return;
+      }
+      // Model reduction is 2D only
+      const input = modelStore.buildSolverInput(uiStore.includeSelfWeight);
+      if (!input) { solveError = t('advanced.emptyModel'); solving = false; return; }
+      if (reductionMethod === 'guyan') {
+        reductionResult = guyanReduce2D({ solver: input, retainedDofs: retained });
+      } else {
+        reductionResult = craigBampton2D({ solver: input, retainedDofs: retained, numModes: numCBModes });
+      }
+    } catch (e: any) {
+      solveError = `Model Reduction: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 16. Multi-Case Solver ──────────────────────────────────
+
+  let multiCaseResult = $state<any | null>(null);
+
+  function handleMultiCase() {
+    solveError = null;
+    solving = true;
+    try {
+      const cases = modelStore.model.loadCases;
+      if (cases.length < 2) {
+        solveError = t('pro.needMultipleCases');
+        solving = false;
+        return;
+      }
+      const is3DMode = modelStore.nodes.size > 0 && [...modelStore.nodes.values()].some(n => (n.z ?? 0) !== 0);
+      if (is3DMode) {
+        let input = buildInput();
+        input = maybeApplyDiaphragm(input);
+        multiCaseResult = solveMultiCase3D({ solver: input, caseIds: cases.map(c => c.id) });
+      } else {
+        const input2D = modelStore.buildSolverInput(uiStore.includeSelfWeight);
+        if (!input2D) { solveError = t('advanced.emptyModel'); solving = false; return; }
+        multiCaseResult = solveMultiCase2D({ solver: input2D, caseIds: cases.map(c => c.id) });
+      }
+    } catch (e: any) {
+      solveError = `Multi-Case: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+
+  // ─── 17. Section Analyzer ──────────────────────────────────
+
+  let secShape = $state<'rect' | 'circle' | 'I' | 'L' | 'T' | 'polygon'>('rect');
+  let secB = $state(0.3);     // m
+  let secH = $state(0.5);     // m
+  let secR = $state(0.15);    // m (circle)
+  let secTw = $state(0.01);   // m (web thickness for I/T)
+  let secTf = $state(0.015);  // m (flange thickness for I/T)
+  let secBf = $state(0.2);    // m (flange width for I/T)
+  let secPolyText = $state(''); // "x1,y1; x2,y2; ..."
+  let secResult = $state<any | null>(null);
+
+  function handleSectionAnalysis() {
+    solveError = null;
+    try {
+      let geometry: any;
+      switch (secShape) {
+        case 'rect': geometry = { shape: 'rect', b: secB, h: secH }; break;
+        case 'circle': geometry = { shape: 'circle', r: secR }; break;
+        case 'I': geometry = { shape: 'I', h: secH, b: secBf, tw: secTw, tf: secTf }; break;
+        case 'L': geometry = { shape: 'L', h: secH, b: secB, tw: secTw, tf: secTf }; break;
+        case 'T': geometry = { shape: 'T', h: secH, b: secBf, tw: secTw, tf: secTf }; break;
+        case 'polygon': {
+          const pts = secPolyText.split(';').map(p => {
+            const [x, y] = p.trim().split(',').map(Number);
+            return { x: x ?? 0, y: y ?? 0 };
+          }).filter(p => !isNaN(p.x) && !isNaN(p.y));
+          if (pts.length < 3) { solveError = t('pro.needPolygonPts'); return; }
+          geometry = { shape: 'polygon', vertices: pts };
+          break;
+        }
+      }
+      secResult = analyzeSection(geometry);
+    } catch (e: any) {
+      solveError = `Section: ${e.message ?? 'Error'}`;
+    }
+  }
+
+  // ─── 18. Constrained Solver ────────────────────────────────
+
+  let constraintType = $state<'rigid' | 'penalty'>('rigid');
+  let constraintPairs = $state('');  // "nodeA,nodeB; nodeC,nodeD; ..."
+  let constrainedResult = $state<any | null>(null);
+
+  function handleConstrained() {
+    solveError = null;
+    solving = true;
+    try {
+      const pairs = constraintPairs.split(';').map(p => {
+        const [a, b] = p.trim().split(',').map(Number);
+        return { nodeA: a, nodeB: b };
+      }).filter(p => !isNaN(p.nodeA) && !isNaN(p.nodeB));
+      if (pairs.length === 0) {
+        solveError = t('pro.needConstraintPairs');
+        solving = false;
+        return;
+      }
+      const is3DMode = modelStore.nodes.size > 0 && [...modelStore.nodes.values()].some(n => (n.z ?? 0) !== 0);
+      let res: any;
+      if (is3DMode) {
+        let input = buildInput();
+        input = maybeApplyDiaphragm(input);
+        res = solveConstrained3D({ solver: input, constraints: pairs, method: constraintType });
+      } else {
+        const input2D = modelStore.buildSolverInput(uiStore.includeSelfWeight);
+        if (!input2D) { solveError = t('advanced.emptyModel'); solving = false; return; }
+        res = solveConstrained2D({ solver: input2D, constraints: pairs, method: constraintType });
+      }
+      constrainedResult = res;
+      if (res.results) {
+        is3DMode ? resultsStore.setResults3D(res.results) : resultsStore.setResults(res.results);
+      }
+    } catch (e: any) {
+      solveError = `Constrained: ${e.message ?? 'Error'}`;
+    }
+    solving = false;
+  }
+</script>
+
+<div class="adv-tab">
+  <!-- Global options -->
+  <div class="adv-header">
+    <label class="adv-check">
+      <input type="checkbox" bind:checked={uiStore.includeSelfWeight} />
+      {t('pro.selfWeightLabel')}
+    </label>
+    <label class="adv-check">
+      <input type="checkbox" bind:checked={useDiaphragm} />
+      {t('pro.rigidDiaphragm')}
+    </label>
+    {#if !wasmAvailable}
+      <span class="adv-wasm-warn">{t('pro.wasmNotReady')}</span>
+    {/if}
+  </div>
+
+  <div class="adv-wip-banner">
+    {t('pro.advancedWip')}
+  </div>
+
+  {#if solveError}
+    <div class="adv-error">{solveError}</div>
+  {/if}
+
+  <div class="adv-scroll">
+
+    <!-- ── 1. P-Delta ── -->
+    <div class="adv-group">
+      <div class="adv-row">
+        <button class="adv-run-btn" onclick={handlePDelta} disabled={!hasModel || solving}>P-Delta</button>
+        <span class="adv-desc">{t('pro.pdeltaDesc')}</span>
+      </div>
+      {#if pdeltaResult}
+        <div class="adv-inline">
+          {pdeltaResult.converged ? t('pro.converged') : t('pro.notConverged')} — {pdeltaResult.iterations} iter.
+          {#if pdeltaResult.b2Factor != null} — B2 = {fmtNum(pdeltaResult.b2Factor)}{/if}
+          {#if pdeltaElapsed != null} — {pdeltaElapsed >= 1000 ? (pdeltaElapsed / 1000).toFixed(2) + ' s' : pdeltaElapsed.toFixed(0) + ' ms'}{/if}
+        </div>
+      {/if}
+    </div>
+
+    <!-- ── 2. Modal ── -->
+    <div class="adv-group">
+      <div class="adv-row">
+        <button class="adv-run-btn" onclick={handleModal} disabled={!hasModel || solving}>Modal</button>
+        <label class="adv-label">
+          Modos:
+          <input type="number" class="adv-num" bind:value={numModes} min={1} max={50} />
+        </label>
+      </div>
+      {#if modalResult}
+        <div class="adv-inline">
+          {#if modalResult.totalMass != null}Masa: {fmtNum(modalResult.totalMass)} kg — {/if}
+          {modalResult.modes?.length ?? 0} modos{#if modalElapsed != null} — {modalElapsed >= 1000 ? (modalElapsed / 1000).toFixed(2) + ' s' : modalElapsed.toFixed(0) + ' ms'}{#if wasmAvailable} (WASM){/if}{/if}
+        </div>
+        <div class="adv-table-scroll">
+          <table class="adv-table">
+            <thead><tr><th>Modo</th><th>f (Hz)</th><th>T (s)</th><th>Part. X</th><th>Part. Y</th><th>Part. Z</th><th>Cum. X</th><th>Cum. Y</th></tr></thead>
+            <tbody>
+              {#each modalResult.modes as mode, i}
+                <tr>
+                  <td class="col-id">{i + 1}</td>
+                  <td class="col-num">{fmtNum(mode.frequency)}</td>
+                  <td class="col-num">{fmtNum(mode.period)}</td>
+                  <td class="col-num">{fmtNum(mode.participationX ?? 0)}</td>
+                  <td class="col-num">{fmtNum(mode.participationY ?? 0)}</td>
+                  <td class="col-num">{fmtNum(mode.participationZ ?? 0)}</td>
+                  <td class="col-num" class:cum-warn={modalCumX[i] < 0.9} class:cum-ok={modalCumX[i] >= 0.9}>{(modalCumX[i] * 100).toFixed(1)}%</td>
+                  <td class="col-num" class:cum-warn={modalCumY[i] < 0.9} class:cum-ok={modalCumY[i] >= 0.9}>{(modalCumY[i] * 100).toFixed(1)}%</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      {/if}
+    </div>
+
+    <!-- ── 3. Spectral ── -->
+    <div class="adv-group">
+      <div class="adv-row">
+        <button class="adv-run-btn" onclick={handleSpectral} disabled={!hasModel || solving || !modalResult}>Espectral</button>
+        <label class="adv-label">
+          <select class="adv-sel" bind:value={spectralCombination}>
+            <option value="CQC">CQC</option>
+            <option value="SRSS">SRSS</option>
+          </select>
+        </label>
+        <label class="adv-label">
+          Zona:
+          <select class="adv-sel" bind:value={seismicZone}>
+            <option value={1}>1</option><option value={2}>2</option><option value={3}>3</option><option value={4}>4</option>
+          </select>
+        </label>
+        <label class="adv-label">
+          Suelo:
+          <select class="adv-sel" bind:value={soilType}>
+            <option value="I">I</option><option value="II">II</option><option value="III">III</option>
+          </select>
+        </label>
+      </div>
+      {#if !modalResult}
+        <div class="adv-hint">{t('pro.requiresModal')}</div>
+      {/if}
+      {#if spectralResult}
+        <div class="adv-inline">
+          Vb: X={fmtNum(spectralResult.baseShearX ?? spectralResult.baseShear?.x ?? spectralResult.baseShear ?? 0)}, Y={fmtNum(spectralResult.baseShearY ?? spectralResult.baseShear?.y ?? 0)} kN
+        </div>
+        {#if spectralResult.perMode || spectralResult.perModeX}
+          <div class="adv-table-scroll">
+            <table class="adv-table">
+              <thead><tr><th>Modo</th><th>T (s)</th><th>Sa (g)</th><th>Vb (kN)</th></tr></thead>
+              <tbody>
+                {#each (spectralResult.perMode ?? spectralResult.perModeX ?? []) as pm, i}
+                  <tr>
+                    <td class="col-id">{i + 1}</td>
+                    <td class="col-num">{fmtNum(pm.period ?? 0)}</td>
+                    <td class="col-num">{fmtNum((pm.sa ?? pm.Sa ?? 0) / 9.81)}</td>
+                    <td class="col-num">{fmtNum(pm.shear ?? pm.Vb ?? 0)}</td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          </div>
+        {/if}
+      {/if}
+    </div>
+
+    <!-- ── 4. Buckling ── -->
+    <div class="adv-group">
+      <div class="adv-row">
+        <button class="adv-run-btn" onclick={handleBuckling} disabled={!hasModel || solving}>Pandeo</button>
+        <label class="adv-label">
+          Modos:
+          <input type="number" class="adv-num" bind:value={numBucklingModes} min={1} max={20} />
+        </label>
+      </div>
+      {#if bucklingResult}
+        {#if bucklingElapsed != null}
+          <div class="adv-inline">{bucklingElapsed >= 1000 ? (bucklingElapsed / 1000).toFixed(2) + ' s' : bucklingElapsed.toFixed(0) + ' ms'}{#if wasmAvailable} (WASM){/if}</div>
+        {/if}
+        <div class="adv-table-scroll">
+          <table class="adv-table">
+            <thead><tr><th>Modo</th><th>&#x03BB;cr</th></tr></thead>
+            <tbody>
+              {#each bucklingResult.modes as mode, i}
+                <tr>
+                  <td class="col-id">{i + 1}</td>
+                  <td class="col-num">{fmtNum(mode.loadFactor)}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      {/if}
+    </div>
+
+    <!-- ── 5. Time History ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">Time History</summary>
+      <div class="adv-panel">
+        <div class="adv-form">
+          <label class="adv-label">dt (s): <input type="number" class="adv-num" bind:value={thDt} min={0.001} max={1} step={0.001} /></label>
+          <label class="adv-label">Pasos: <input type="number" class="adv-num adv-num-wide" bind:value={thNSteps} min={1} max={10000} /></label>
+          <label class="adv-label">Dir: <select class="adv-sel" bind:value={thDir}><option value="X">X</option><option value="Y">Y</option></select></label>
+          <label class="adv-label">&#x03BE;: <input type="number" class="adv-num" bind:value={thDamping} min={0} max={1} step={0.01} /></label>
+          <label class="adv-label">Método: <select class="adv-sel" bind:value={thMethod}><option value="newmark">Newmark</option><option value="hht">HHT-&#x03B1;</option></select></label>
+        </div>
+        <label class="adv-check">
+          <input type="checkbox" bind:checked={thUseSine} />
+          {t('pro.testSine')}
+        </label>
+        {#if thUseSine}
+          <div class="adv-form">
+            <label class="adv-label">Amp (g): <input type="number" class="adv-num" bind:value={thSineAmp} min={0.01} step={0.05} /></label>
+            <label class="adv-label">Freq (Hz): <input type="number" class="adv-num" bind:value={thSineFreq} min={0.1} step={0.1} /></label>
+          </div>
+        {:else}
+          <div class="adv-accel-area">
+            <label class="adv-label">{t('pro.accelInput')}:</label>
+            <textarea class="adv-textarea" bind:value={thAccelText} rows="2" placeholder="0.1, 0.25, 0.4, 0.3, -0.1, ..."></textarea>
+          </div>
+        {/if}
+        <button class="adv-run-btn" onclick={handleTimeHistory} disabled={!hasModel || solving || !wasmAvailable}>{t('pro.run')}</button>
+      </div>
+      {#if thResult}
+        <div class="adv-inline">
+          {#if thResult.peakDisplacement != null}δmax={fmtNum(thResult.peakDisplacement)} m{/if}
+          {#if thResult.peakBaseShear != null} — Vb={fmtNum(thResult.peakBaseShear)} kN{/if}
+          {#if thResult.timeAtPeak != null} — t={fmtNum(thResult.timeAtPeak)} s{/if}
+        </div>
+      {/if}
+    </details>
+
+    <!-- ── 6b. Harmonic Response ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">{t('pro.harmonicTitle')}</summary>
+      <div class="adv-panel">
+        <div class="adv-form">
+          <label class="adv-label">f min (Hz): <input type="number" class="adv-num" bind:value={harmFMin} min={0.01} max={100} step={0.1} /></label>
+          <label class="adv-label">f max (Hz): <input type="number" class="adv-num" bind:value={harmFMax} min={0.1} max={500} step={1} /></label>
+          <label class="adv-label">Puntos: <input type="number" class="adv-num" bind:value={harmNPoints} min={10} max={2000} step={10} /></label>
+          <label class="adv-label">&#x03BE;: <input type="number" class="adv-num" bind:value={harmDamping} min={0} max={1} step={0.01} /></label>
+          <label class="adv-label">Dir: <select class="adv-sel" bind:value={harmDir}><option value="X">X</option><option value="Y">Y</option><option value="Z">Z</option></select></label>
+        </div>
+        <button class="adv-run-btn" onclick={handleHarmonic} disabled={!hasModel || solving || !wasmAvailable}>{solving ? t('pro.solving') : t('pro.runHarmonic')}</button>
+      </div>
+      {#if harmResult}
+        <div class="adv-inline">
+          {#if harmResult.peakAmplitude != null}{t('pro.peakAmplitude')}: {fmtNum(harmResult.peakAmplitude)} m{/if}
+          {#if harmResult.resonanceFreq != null} — f_res={fmtNum(harmResult.resonanceFreq)} Hz{/if}
+          {#if harmResult.peakDynamicFactor != null} — DAF={fmtNum(harmResult.peakDynamicFactor)}{/if}
+          {#if harmonicElapsed != null} — {harmonicElapsed >= 1000 ? (harmonicElapsed / 1000).toFixed(2) + ' s' : harmonicElapsed.toFixed(0) + ' ms'} (WASM){/if}
+        </div>
+        {#if harmResult.frf?.length}
+          <details>
+            <summary class="adv-steps-toggle">{t('pro.frfCurve')}</summary>
+            <div class="adv-frf-table">
+              <table class="adv-table">
+                <thead><tr><th>f (Hz)</th><th>|H| (m/kN)</th></tr></thead>
+                <tbody>
+                  {#each harmResult.frf.filter((_: any, i: number) => i % Math.max(1, Math.floor(harmResult.frf.length / 20)) === 0) as pt}
+                    <tr><td class="col-num">{fmtNum(pt.frequency)}</td><td class="col-num">{pt.amplitude.toExponential(3)}</td></tr>
+                  {/each}
+                </tbody>
+              </table>
+            </div>
+          </details>
+        {/if}
+      {/if}
+    </details>
+
+    <!-- ── 7. Nonlinear ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">No lineal</summary>
+      <div class="adv-panel">
+        <div class="adv-form">
+          <label class="adv-label">Tipo: <select class="adv-sel" bind:value={nlType}><option value="pushover">Pushover</option><option value="corotational">Corotacional</option><option value="fiber">Fibra</option></select></label>
+          {#if nlType === 'pushover'}
+            <label class="adv-label">{t('pro.maxHinges')}: <input type="number" class="adv-num adv-num-wide" bind:value={nlMaxHinges} min={1} max={200} /></label>
+          {:else}
+            <label class="adv-label">Max iter: <input type="number" class="adv-num" bind:value={nlMaxIter} min={1} max={500} /></label>
+            <label class="adv-label">Tol: <input type="number" class="adv-num adv-num-wide" bind:value={nlTol} min={1e-12} max={1} step={1e-6} /></label>
+            <label class="adv-label">Incr: <input type="number" class="adv-num" bind:value={nlIncrements} min={1} max={200} /></label>
+          {/if}
+          {#if nlType === 'fiber'}
+            <label class="adv-label">Pts int: <input type="number" class="adv-num" bind:value={nlFiberIntPts} min={2} max={20} /></label>
+          {/if}
+        </div>
+        <button class="adv-run-btn" onclick={handleNonlinear} disabled={!hasModel || solving || !wasmAvailable}>{t('pro.run')}</button>
+      </div>
+      {#if nlResult}
+        <div class="adv-inline">
+          {#if nlResult.converged != null}{nlResult.converged ? t('pro.converged') : t('pro.notConverged')}{/if}
+          {#if nlResult.loadFactor != null} — λ={fmtNum(nlResult.loadFactor)}{/if}
+          {#if nlResult.maxDisplacement != null} — δmax={fmtNum(nlResult.maxDisplacement)} m{/if}
+          {#if nlResult.numHinges != null} — {nlResult.numHinges} {t('pro.hinges')}{/if}
+        </div>
+      {/if}
+    </details>
+
+    <!-- ── 7b. Arc-Length ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">{t('pro.arcLengthTitle')}</summary>
+      <div class="adv-panel">
+        <div class="adv-form">
+          <label class="adv-label">Max iter: <input type="number" class="adv-num" bind:value={arcMaxIter} min={1} max={500} /></label>
+          <label class="adv-label">Tol: <input type="number" class="adv-num adv-num-wide" bind:value={arcTol} min={1e-12} max={1} step={1e-6} /></label>
+          <label class="adv-label">Incr: <input type="number" class="adv-num" bind:value={arcIncrements} min={1} max={200} /></label>
+        </div>
+        <button class="adv-run-btn" onclick={handleArcLength} disabled={!hasModel || solving || !wasmAvailable}>{solving ? t('pro.solving') : t('pro.runArcLength')}</button>
+      </div>
+      {#if arcResult}
+        <div class="adv-inline">
+          {#if arcResult.converged != null}{arcResult.converged ? t('pro.yes') : t('pro.no')}{/if}
+          {#if arcResult.loadFactor != null} — λ={fmtNum(arcResult.loadFactor)}{/if}
+          {#if arcResult.maxDisplacement != null} — δmax={fmtNum(arcResult.maxDisplacement)} m{/if}
+          {#if arcResult.steps != null} — {arcResult.steps.length} {t('pro.steps')}{/if}
+        </div>
+      {/if}
+    </details>
+
+    <!-- ── 7c. Displacement Control ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">{t('pro.dispControlTitle')}</summary>
+      <div class="adv-panel">
+        <div class="adv-form">
+          <label class="adv-label">{t('pro.nodeLabel')}:
+            <select class="adv-sel" bind:value={dcNodeId}>
+              <option value={null}>--</option>
+              {#each nodeIds as nid}<option value={nid}>{nid}</option>{/each}
+            </select>
+          </label>
+          <label class="adv-label">DOF: <select class="adv-sel" bind:value={dcDof}><option value="ux">ux</option><option value="uy">uy</option><option value="uz">uz</option></select></label>
+          <label class="adv-label">δ (m): <input type="number" class="adv-num" bind:value={dcTargetDisp} step={0.001} /></label>
+          <label class="adv-label">Incr: <input type="number" class="adv-num" bind:value={dcIncrements} min={1} max={200} /></label>
+        </div>
+        <button class="adv-run-btn" onclick={handleDispControl} disabled={!hasModel || solving || !wasmAvailable || dcNodeId == null}>{solving ? t('pro.solving') : t('pro.runDispControl')}</button>
+      </div>
+      {#if dcResult}
+        <div class="adv-inline">
+          {#if dcResult.converged != null}{dcResult.converged ? t('pro.yes') : t('pro.no')}{/if}
+          {#if dcResult.finalLoad != null} — P={fmtNum(dcResult.finalLoad)} kN{/if}
+          {#if dcResult.maxDisplacement != null} — δmax={fmtNum(dcResult.maxDisplacement)} m{/if}
+        </div>
+      {/if}
+    </details>
+
+    <!-- ── 7d. Imperfections ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">{t('pro.imperfectionsTitle')}</summary>
+      <div class="adv-panel">
+        <div class="adv-form">
+          <label class="adv-label">{t('pro.imperfType')}:
+            <select class="adv-sel" bind:value={imperfType}>
+              <option value="global">Global (sway)</option>
+              <option value="local">Local (bow)</option>
+            </select>
+          </label>
+          <label class="adv-label">{t('pro.amplitude')} (L/...): <input type="number" class="adv-num" bind:value={imperfAmplitude} min={0.0001} max={0.1} step={0.0001} /></label>
+        </div>
+        <button class="adv-run-btn" onclick={handleImperfections} disabled={!hasModel || solving || !wasmAvailable}>{solving ? t('pro.solving') : t('pro.runImperfections')}</button>
+      </div>
+      {#if imperfResult}
+        <div class="adv-inline">
+          {#if imperfResult.maxAdditionalMoment != null}ΔM_max={fmtNum(imperfResult.maxAdditionalMoment)} kN·m{/if}
+          {#if imperfResult.maxLateralForce != null} — H_imp={fmtNum(imperfResult.maxLateralForce)} kN{/if}
+          {#if imperfResult.imperfectionShape != null} — {imperfResult.imperfectionShape.length} {t('pro.nodes')}{/if}
+        </div>
+      {/if}
+    </details>
+
+    <!-- ─── Divider: Modelado especial ─── -->
+    <div class="adv-divider">Modelado especial</div>
+
+    <!-- ── 8. Winkler Foundation ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">{t('pro.winklerFoundation')}</summary>
+      <div class="adv-panel">
+        <div class="adv-form">
+          <label class="adv-label">{t('pro.element')}:
+            <select class="adv-sel" bind:value={winklerElementId}>
+              <option value={null}>--</option>
+              {#each elementIds as eid}<option value={eid}>{eid}</option>{/each}
+            </select>
+          </label>
+          <label class="adv-label">ky (kN/m/m): <input type="number" class="adv-num" bind:value={winklerKy} min={0} step={100} /></label>
+          <label class="adv-label">kz: <input type="number" class="adv-num" bind:value={winklerKz} min={0} step={100} /></label>
+          <button class="adv-btn-sm" onclick={addWinklerSpring} disabled={winklerElementId == null}>+</button>
+        </div>
+        {#if winklerSprings.length > 0}
+          <table class="adv-table">
+            <thead><tr><th>Elem</th><th>ky</th><th>kz</th><th></th></tr></thead>
+            <tbody>
+              {#each winklerSprings as s, i}
+                <tr>
+                  <td class="col-id">{s.elementId}</td>
+                  <td class="col-num">{fmtNum(s.ky)}</td>
+                  <td class="col-num">{fmtNum(s.kz)}</td>
+                  <td><button class="adv-rm" onclick={() => removeWinklerSpring(i)}>x</button></td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        {/if}
+        <button class="adv-run-btn" onclick={handleWinkler} disabled={!hasModel || solving || !wasmAvailable || winklerSprings.length === 0}>{solving ? t('pro.solving') : t('pro.solveWinkler')}</button>
+      </div>
+      {#if winklerResult}
+        <div class="adv-result-title">{t('pro.resultWinkler')}</div>
+        <div class="adv-inline">
+          <span>{t('pro.convergence')}: {winklerResult.converged ? t('pro.yes') : t('pro.no')}</span> — <span>{t('pro.iterations')}: {winklerResult.iterations ?? '?'}</span>
+          {#if winklerResult.maxDisplacement != null} — <span>{t('pro.maxDisp')}: {fmtNum(winklerResult.maxDisplacement)} m</span>{/if}
+        </div>
+      {/if}
+    </details>
+
+    <!-- ── 9. SSI ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">{t('pro.ssiTitle')}</summary>
+      <div class="adv-panel">
+        <div class="adv-form">
+          <label class="adv-label">{t('pro.ssiNode')}:
+            <select class="adv-sel" bind:value={ssiNodeId}>
+              <option value={null}>--</option>
+              {#each nodeIds as nid}<option value={nid}>{nid}</option>{/each}
+            </select>
+          </label>
+          <label class="adv-label">Dir: <select class="adv-sel" bind:value={ssiDirection}><option value="Y">Y</option><option value="Z">Z</option></select></label>
+          <label class="adv-label">{t('pro.ssiCurve')}:
+            <select class="adv-sel" bind:value={ssiCurveType}>
+              <option value="softClay">{t('pro.softClay')}</option>
+              <option value="stiffClay">{t('pro.stiffClay')}</option>
+              <option value="sand">{t('pro.sand')}</option>
+              <option value="custom">{t('pro.customCurve')}</option>
+            </select>
+          </label>
+        </div>
+        {#if ssiCurveType === 'softClay' || ssiCurveType === 'stiffClay'}
+          <div class="adv-form">
+            <label class="adv-label">su (kPa): <input type="number" class="adv-num" bind:value={ssiSu} min={0} step={5} /></label>
+            <label class="adv-label">&#947; (kN/m3): <input type="number" class="adv-num" bind:value={ssiGamma} min={0} step={1} /></label>
+            <label class="adv-label">d (m): <input type="number" class="adv-num" bind:value={ssiDiameter} min={0.1} step={0.1} /></label>
+            <label class="adv-label">{t('pro.depth')}: <input type="number" class="adv-num" bind:value={ssiDepth} min={0} step={0.5} /></label>
+          </div>
+        {:else if ssiCurveType === 'sand'}
+          <div class="adv-form">
+            <label class="adv-label">&#966; (deg): <input type="number" class="adv-num" bind:value={ssiPhi} min={0} max={50} step={1} /></label>
+            <label class="adv-label">&#947; (kN/m3): <input type="number" class="adv-num" bind:value={ssiGamma} min={0} step={1} /></label>
+            <label class="adv-label">d (m): <input type="number" class="adv-num" bind:value={ssiDiameter} min={0.1} step={0.1} /></label>
+            <label class="adv-label">{t('pro.depth')}: <input type="number" class="adv-num" bind:value={ssiDepth} min={0} step={0.5} /></label>
+          </div>
+        {/if}
+        <div class="adv-form">
+          <label class="adv-label">{t('pro.tribLength')}: <input type="number" class="adv-num" bind:value={ssiTribLength} min={0.1} step={0.5} /></label>
+          <button class="adv-btn-sm" onclick={addSsiSpring} disabled={ssiNodeId == null}>{t('pro.addSpring')}</button>
+        </div>
+        {#if ssiSprings.length > 0}
+          <table class="adv-table">
+            <thead><tr><th>Nodo</th><th>Dir</th><th>Curva</th><th>L</th><th></th></tr></thead>
+            <tbody>
+              {#each ssiSprings as s, i}
+                <tr>
+                  <td class="col-id">{s.nodeId}</td>
+                  <td class="col-num">{s.direction}</td>
+                  <td class="col-num">{s.curve.type}</td>
+                  <td class="col-num">{fmtNum(s.tributaryLength)}</td>
+                  <td><button class="adv-rm" onclick={() => removeSsiSpring(i)}>x</button></td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        {/if}
+        <div class="adv-form">
+          <label class="adv-label">{t('pro.maxIter')}: <input type="number" class="adv-num" bind:value={ssiMaxIter} min={1} max={500} /></label>
+          <label class="adv-label">{t('pro.tolerance')}: <input type="number" class="adv-num" bind:value={ssiTolerance} min={1e-8} step={1e-5} /></label>
+        </div>
+        <button class="adv-run-btn" onclick={handleSSI} disabled={!hasModel || solving || !wasmAvailable || ssiSprings.length === 0}>{solving ? t('pro.solving') : t('pro.solveSsi')}</button>
+      </div>
+      {#if ssiResult}
+        <div class="adv-result-title">{t('pro.resultSsi')}</div>
+        <div class="adv-inline">
+          <span>{t('pro.convergence')}: {ssiResult.converged ? t('pro.yes') : t('pro.no')}</span> — <span>{t('pro.iterations')}: {ssiResult.iterations ?? '?'}</span>
+          {#if ssiResult.maxDisplacement != null} — <span>{t('pro.maxDisp')}: {fmtNum(ssiResult.maxDisplacement)} m</span>{/if}
+        </div>
+      {/if}
+    </details>
+
+    <!-- ── 10. Contact / Gap ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">{t('pro.contactGap')}</summary>
+      <div class="adv-panel">
+        <div class="adv-form">
+          <label class="adv-label">{t('pro.element')}:
+            <select class="adv-sel" bind:value={contactElementId}>
+              <option value={null}>--</option>
+              {#each elementIds as eid}<option value={eid}>{eid}</option>{/each}
+            </select>
+          </label>
+          <label class="adv-label">{t('pro.behavior')}:
+            <select class="adv-sel" bind:value={contactBehavior}>
+              <option value="normal">{t('pro.normal')}</option>
+              <option value="tensionOnly">{t('pro.tensionOnly')}</option>
+              <option value="compressionOnly">{t('pro.compressionOnly')}</option>
+            </select>
+          </label>
+          <button class="adv-btn-sm" onclick={setContactBehavior} disabled={contactElementId == null}>+</button>
+        </div>
+        {#if contactEntries.length > 0}
+          <table class="adv-table">
+            <thead><tr><th>Elem</th><th>{t('pro.behavior')}</th><th></th></tr></thead>
+            <tbody>
+              {#each contactEntries as [eid, beh]}
+                <tr>
+                  <td class="col-id">{eid}</td>
+                  <td class="col-num">{beh === 'tensionOnly' ? t('pro.tensionOnly') : beh === 'compressionOnly' ? t('pro.compressionOnly') : t('pro.normal')}</td>
+                  <td><button class="adv-rm" onclick={() => removeContactBehavior(eid)}>x</button></td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        {/if}
+        <button class="adv-run-btn" onclick={handleContact} disabled={!hasModel || solving || !wasmAvailable || contactEntries.length === 0}>{solving ? t('pro.solving') : t('pro.solveContact')}</button>
+      </div>
+      {#if contactResult}
+        <div class="adv-result-title">{t('pro.resultContact')}</div>
+        <div class="adv-inline">
+          <span>{t('pro.convergence')}: {contactResult.converged ? t('pro.yes') : t('pro.no')}</span> — <span>{t('pro.iterations')}: {contactResult.iterations ?? '?'}</span>
+          {#if contactResult.deactivated} — <span>{t('pro.deactivatedElems')}: {contactResult.deactivated.length}</span>{/if}
+        </div>
+      {/if}
+    </details>
+
+    <!-- ── 11. Staged Construction ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">{t('pro.stagedConstruction')}</summary>
+      <div class="adv-panel">
+        <button class="adv-btn-sm" onclick={addStage}>{t('pro.addStage')}</button>
+        {#each stages as stage, i}
+          <div class="adv-stage-card">
+            <div class="adv-stage-header">
+              <input type="text" class="adv-stage-name" bind:value={stage.name} />
+              <button class="adv-rm" onclick={() => removeStage(i)}>x</button>
+            </div>
+            <div class="adv-form">
+              <label class="adv-label">{t('pro.addElemIds')} <input type="text" class="adv-text" value={stage.addElements.join(',')} oninput={(e) => { stage.addElements = (e.target as HTMLInputElement).value.split(',').map(Number).filter(n => !isNaN(n) && n > 0); stages = [...stages]; }} /></label>
+            </div>
+            <div class="adv-form">
+              <label class="adv-label">{t('pro.removeElemIds')} <input type="text" class="adv-text" value={stage.removeElements.join(',')} oninput={(e) => { stage.removeElements = (e.target as HTMLInputElement).value.split(',').map(Number).filter(n => !isNaN(n) && n > 0); stages = [...stages]; }} /></label>
+            </div>
+            <div class="adv-form">
+              <label class="adv-label">{t('pro.loadIndices')}: <input type="text" class="adv-text" value={stage.loadIndices.join(',')} oninput={(e) => { stage.loadIndices = (e.target as HTMLInputElement).value.split(',').map(Number).filter(n => !isNaN(n) && n >= 0); stages = [...stages]; }} /></label>
+            </div>
+          </div>
+        {/each}
+        <button class="adv-run-btn" onclick={handleStaged} disabled={!hasModel || solving || !wasmAvailable || stages.length === 0}>{solving ? t('pro.solving') : t('pro.solveStaged')}</button>
+      </div>
+      {#if stagedResult}
+        <div class="adv-result-title">{t('pro.resultStaged')}</div>
+        <div class="adv-inline">
+          {#if stagedResult.stages}
+            {#each stagedResult.stages as sr, i}
+              <div>{t('pro.stageN').replace('{n}', String(i + 1))}: {sr.converged != null ? (sr.converged ? t('pro.ok') : t('pro.noConv')) : t('pro.solved')}</div>
+            {/each}
+          {/if}
+          {#if stagedResult.totalDisplacement != null} <span>{t('pro.totalMaxDisp')}: {fmtNum(stagedResult.totalDisplacement)} m</span>{/if}
+        </div>
+      {/if}
+    </details>
+
+    <!-- ── 12. Creep & Shrinkage ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">{t('pro.creepShrinkage')}</summary>
+      <div class="adv-panel">
+        <div class="adv-form">
+          <label class="adv-label">f'c (MPa): <input type="number" class="adv-num" bind:value={creepFc} min={10} max={100} step={5} /></label>
+          <label class="adv-label">HR (%): <input type="number" class="adv-num" bind:value={creepRH} min={20} max={100} step={5} /></label>
+          <label class="adv-label">h0 (mm): <input type="number" class="adv-num" bind:value={creepH0} min={50} max={2000} step={10} /></label>
+        </div>
+        <div class="adv-form">
+          <label class="adv-label">{t('pro.loadingAge')}: <input type="number" class="adv-num" bind:value={creepAge} min={1} max={10000} /></label>
+          <label class="adv-label">{t('pro.cementClass')}: <select class="adv-sel" bind:value={creepCementClass}><option value="R">{t('pro.cementR')}</option><option value="N">{t('pro.cementN')}</option><option value="S">{t('pro.cementS')}</option></select></label>
+        </div>
+        <div class="adv-sub-title">{t('pro.timeSteps')}</div>
+        {#each creepTimeSteps as step, i}
+          <div class="adv-form">
+            <label class="adv-label">{t('pro.timeDays')}: <input type="number" class="adv-num" bind:value={step.time} min={1} /></label>
+            <label class="adv-label">{t('pro.addLoadFactor')}: <input type="number" class="adv-num" bind:value={step.additionalLoadFactor} min={0} step={0.1} /></label>
+            <button class="adv-rm" onclick={() => removeCreepStep(i)}>x</button>
+          </div>
+        {/each}
+        <button class="adv-btn-sm" onclick={addCreepStep}>{t('pro.addStep')}</button>
+        <button class="adv-run-btn" onclick={handleCreep} disabled={!hasModel || solving || !wasmAvailable || creepTimeSteps.length === 0}>{solving ? t('pro.calculating') : t('pro.calcCreep')}</button>
+      </div>
+      {#if creepResult}
+        <div class="adv-result-title">{t('pro.resultCreep')}</div>
+        <div class="adv-inline">
+          {#if creepResult.phiCreep != null}{t('pro.creepCoeff')}: {fmtNum(creepResult.phiCreep)}{/if}
+          {#if creepResult.shrinkageStrain != null} — {t('pro.shrinkageStrain')}: {creepResult.shrinkageStrain.toExponential(2)}{/if}
+          {#if creepResult.maxDisplacement != null} — {t('pro.finalMaxDisp')}: {fmtNum(creepResult.maxDisplacement)} m{/if}
+        </div>
+      {/if}
+    </details>
+
+    <!-- ─── Divider: Herramientas avanzadas ─── -->
+    <div class="adv-divider">{t('pro.advancedTools')}</div>
+
+    <!-- ── 13. Cable (2D) ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">{t('pro.cableTitle')}</summary>
+      <div class="adv-panel">
+        <div class="adv-form">
+          <label class="adv-label">{t('pro.maxIter')}: <input type="number" class="adv-num" bind:value={cableMaxIter} min={1} max={500} /></label>
+          <label class="adv-label">{t('pro.tolerance')}: <input type="number" class="adv-num adv-num-wide" bind:value={cableTol} min={1e-12} max={1} step={1e-6} /></label>
+        </div>
+        <p class="adv-hint">{t('pro.cableHint')}</p>
+        <button class="adv-run-btn" onclick={handleCable} disabled={!hasModel || solving || !wasmAvailable}>{solving ? t('pro.solving') : t('pro.solveCable')}</button>
+      </div>
+      {#if cableResult}
+        <div class="adv-inline">
+          {#if cableResult.converged != null}{cableResult.converged ? t('pro.yes') : t('pro.no')}{/if}
+          {#if cableResult.maxSag != null} — {t('pro.maxSag')}: {fmtNum(cableResult.maxSag)} m{/if}
+          {#if cableResult.maxTension != null} — T_max={fmtNum(cableResult.maxTension)} kN{/if}
+        </div>
+      {/if}
+    </details>
+
+    <!-- ── 14. Influence Lines 3D ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">{t('pro.influenceLine3dTitle')}</summary>
+      <div class="adv-panel">
+        <div class="adv-form">
+          <label class="adv-label">{t('pro.element')}:
+            <select class="adv-sel" bind:value={ilElementId}>
+              <option value={null}>--</option>
+              {#each elementIds as eid}<option value={eid}>{eid}</option>{/each}
+            </select>
+          </label>
+          <label class="adv-label">{t('pro.response')}:
+            <select class="adv-sel" bind:value={ilResponse}>
+              <option value="moment">M</option>
+              <option value="shear">V</option>
+              <option value="axial">N</option>
+              <option value="reaction">R</option>
+            </select>
+          </label>
+        </div>
+        <button class="adv-run-btn" onclick={handleInfluenceLine3D} disabled={!hasModel || solving || !wasmAvailable || ilElementId == null}>{solving ? t('pro.solving') : t('pro.computeIL')}</button>
+      </div>
+      {#if ilResult}
+        <div class="adv-inline">
+          {#if ilResult.maxPositive != null}{t('pro.maxPos')}: {fmtNum(ilResult.maxPositive)}{/if}
+          {#if ilResult.maxNegative != null} — {t('pro.maxNeg')}: {fmtNum(ilResult.maxNegative)}{/if}
+        </div>
+        {#if ilResult.ordinates?.length}
+          <details>
+            <summary class="adv-steps-toggle">{t('pro.ilOrdinates')}</summary>
+            <div class="adv-frf-table">
+              <table class="adv-table">
+                <thead><tr><th>{t('pro.nodeLabel')}</th><th>{t('pro.ilValue')}</th></tr></thead>
+                <tbody>
+                  {#each ilResult.ordinates as pt}
+                    <tr><td class="col-id">{pt.nodeId ?? pt.position?.toFixed(2) ?? '?'}</td><td class="col-num">{fmtNum(pt.value)}</td></tr>
+                  {/each}
+                </tbody>
+              </table>
+            </div>
+          </details>
+        {/if}
+      {/if}
+    </details>
+
+    <!-- ── 15. Model Reduction ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">{t('pro.modelReductionTitle')}</summary>
+      <div class="adv-panel">
+        <div class="adv-form">
+          <label class="adv-label">{t('pro.method')}:
+            <select class="adv-sel" bind:value={reductionMethod}>
+              <option value="guyan">Guyan (estático)</option>
+              <option value="craigBampton">Craig-Bampton</option>
+            </select>
+          </label>
+        </div>
+        <div class="adv-form">
+          <label class="adv-label">{t('pro.retainedDofs')}: <input type="text" class="adv-text" bind:value={retainedDofs} placeholder="0,1,2,6,7,8..." /></label>
+        </div>
+        {#if reductionMethod === 'craigBampton'}
+          <div class="adv-form">
+            <label class="adv-label">{t('pro.numCBModes')}: <input type="number" class="adv-num" bind:value={numCBModes} min={1} max={100} /></label>
+          </div>
+        {/if}
+        <p class="adv-hint">{t('pro.reductionHint')}</p>
+        <button class="adv-run-btn" onclick={handleModelReduction} disabled={!hasModel || solving || !wasmAvailable}>{solving ? t('pro.solving') : t('pro.reduce')}</button>
+      </div>
+      {#if reductionResult}
+        <div class="adv-inline">
+          {#if reductionResult.originalSize != null}DOF orig: {reductionResult.originalSize}{/if}
+          {#if reductionResult.reducedSize != null} → red: {reductionResult.reducedSize}{/if}
+          {#if reductionResult.ratio != null} ({(reductionResult.ratio * 100).toFixed(0)}%){/if}
+        </div>
+      {/if}
+    </details>
+
+    <!-- ── 16. Multi-Case Solver ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">{t('pro.multiCaseTitle')}</summary>
+      <div class="adv-panel">
+        <p class="adv-hint">{t('pro.multiCaseHint')}</p>
+        <button class="adv-run-btn" onclick={handleMultiCase} disabled={!hasModel || solving || !wasmAvailable}>{solving ? t('pro.solving') : t('pro.solveMultiCase')}</button>
+      </div>
+      {#if multiCaseResult}
+        <div class="adv-inline">
+          {#if multiCaseResult.cases != null}{multiCaseResult.cases.length} {t('pro.casesResolved')}{/if}
+          {#if multiCaseResult.maxDisplacement != null} — δmax={fmtNum(multiCaseResult.maxDisplacement)} m{/if}
+        </div>
+      {/if}
+    </details>
+
+    <!-- ── 17. Section Analyzer ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">{t('pro.sectionAnalyzerTitle')}</summary>
+      <div class="adv-panel">
+        <div class="adv-form">
+          <label class="adv-label">{t('pro.shape')}:
+            <select class="adv-sel" bind:value={secShape}>
+              <option value="rect">{t('pro.shapeRect')}</option>
+              <option value="circle">{t('pro.shapeCircle')}</option>
+              <option value="I">I / H</option>
+              <option value="L">L</option>
+              <option value="T">T</option>
+              <option value="polygon">{t('pro.shapePolygon')}</option>
+            </select>
+          </label>
+        </div>
+        {#if secShape === 'rect'}
+          <div class="adv-form">
+            <label class="adv-label">b (m): <input type="number" class="adv-num" bind:value={secB} min={0.01} step={0.01} /></label>
+            <label class="adv-label">h (m): <input type="number" class="adv-num" bind:value={secH} min={0.01} step={0.01} /></label>
+          </div>
+        {:else if secShape === 'circle'}
+          <div class="adv-form">
+            <label class="adv-label">r (m): <input type="number" class="adv-num" bind:value={secR} min={0.01} step={0.01} /></label>
+          </div>
+        {:else if secShape === 'I' || secShape === 'T'}
+          <div class="adv-form">
+            <label class="adv-label">h (m): <input type="number" class="adv-num" bind:value={secH} min={0.01} step={0.01} /></label>
+            <label class="adv-label">bf (m): <input type="number" class="adv-num" bind:value={secBf} min={0.01} step={0.01} /></label>
+            <label class="adv-label">tw (m): <input type="number" class="adv-num" bind:value={secTw} min={0.001} step={0.001} /></label>
+            <label class="adv-label">tf (m): <input type="number" class="adv-num" bind:value={secTf} min={0.001} step={0.001} /></label>
+          </div>
+        {:else if secShape === 'L'}
+          <div class="adv-form">
+            <label class="adv-label">h (m): <input type="number" class="adv-num" bind:value={secH} min={0.01} step={0.01} /></label>
+            <label class="adv-label">b (m): <input type="number" class="adv-num" bind:value={secB} min={0.01} step={0.01} /></label>
+            <label class="adv-label">tw (m): <input type="number" class="adv-num" bind:value={secTw} min={0.001} step={0.001} /></label>
+            <label class="adv-label">tf (m): <input type="number" class="adv-num" bind:value={secTf} min={0.001} step={0.001} /></label>
+          </div>
+        {:else if secShape === 'polygon'}
+          <div class="adv-form">
+            <label class="adv-label">{t('pro.polygonVertices')}:</label>
+          </div>
+          <textarea class="adv-textarea" bind:value={secPolyText} rows="2" placeholder="0,0; 0.3,0; 0.3,0.5; 0,0.5"></textarea>
+        {/if}
+        <button class="adv-run-btn" onclick={handleSectionAnalysis} disabled={!wasmAvailable}>{t('pro.analyzeSection')}</button>
+      </div>
+      {#if secResult}
+        <div class="adv-inline">
+          {#if secResult.area != null}A={secResult.area.toExponential(3)} m²{/if}
+          {#if secResult.iy != null} — Iy={secResult.iy.toExponential(3)} m⁴{/if}
+          {#if secResult.iz != null} — Iz={secResult.iz.toExponential(3)} m⁴{/if}
+        </div>
+        {#if secResult.centroidY != null || secResult.centroidZ != null}
+          <div class="adv-inline" style="font-size:0.62rem; opacity:0.8">
+            CG: y={fmtNum(secResult.centroidY ?? 0)} m, z={fmtNum(secResult.centroidZ ?? 0)} m
+            {#if secResult.j != null} — J={secResult.j.toExponential(3)} m⁴{/if}
+            {#if secResult.wy != null} — Wy={secResult.wy.toExponential(3)} m³{/if}
+            {#if secResult.wz != null} — Wz={secResult.wz.toExponential(3)} m³{/if}
+          </div>
+        {/if}
+      {/if}
+    </details>
+
+    <!-- ── 18. Constrained Solver ── -->
+    <details class="adv-group-details">
+      <summary class="adv-title">{t('pro.constrainedTitle')}</summary>
+      <div class="adv-panel">
+        <div class="adv-form">
+          <label class="adv-label">{t('pro.constraintMethod')}:
+            <select class="adv-sel" bind:value={constraintType}>
+              <option value="rigid">{t('pro.rigidLink')}</option>
+              <option value="penalty">{t('pro.penaltyMethod')}</option>
+            </select>
+          </label>
+        </div>
+        <div class="adv-form">
+          <label class="adv-label">{t('pro.nodePairs')}:</label>
+        </div>
+        <textarea class="adv-textarea" bind:value={constraintPairs} rows="2" placeholder="1,5; 2,6; 3,7"></textarea>
+        <p class="adv-hint">{t('pro.constrainedHint')}</p>
+        <button class="adv-run-btn" onclick={handleConstrained} disabled={!hasModel || solving || !wasmAvailable}>{solving ? t('pro.solving') : t('pro.solveConstrained')}</button>
+      </div>
+      {#if constrainedResult}
+        <div class="adv-inline">
+          {#if constrainedResult.converged != null}{constrainedResult.converged ? t('pro.yes') : t('pro.no')}{/if}
+          {#if constrainedResult.maxDisplacement != null} — δmax={fmtNum(constrainedResult.maxDisplacement)} m{/if}
+          {#if constrainedResult.constraintForces?.length} — {constrainedResult.constraintForces.length} {t('pro.constraintForcesCount')}{/if}
+        </div>
+      {/if}
+    </details>
+
+  </div>
+</div>
+
+<style>
+  .adv-tab {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .adv-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 12px;
+    background: #0d1b33;
+    border-bottom: 1px solid #1a3a5a;
+    flex-shrink: 0;
+    flex-wrap: wrap;
+  }
+
+  .adv-scroll {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+  }
+
+  .adv-wip-banner {
+    padding: 7px 12px;
+    font-size: 0.72rem;
+    color: #f0c040;
+    background: rgba(240, 192, 64, 0.08);
+    border-bottom: 1px solid rgba(240, 192, 64, 0.15);
+    flex-shrink: 0;
+    text-align: center;
+  }
+
+  .adv-error {
+    padding: 6px 12px;
+    font-size: 0.72rem;
+    color: #ff8a9e;
+    background: rgba(233, 69, 96, 0.1);
+    flex-shrink: 0;
+  }
+
+  .adv-wasm-warn {
+    font-size: 0.65rem;
+    color: #ffa726;
+  }
+
+  .adv-check {
+    font-size: 0.7rem;
+    color: #aaa;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+  }
+
+  .adv-check input { cursor: pointer; }
+
+  /* Groups — each analysis type */
+  .adv-group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px 12px;
+    border-bottom: 1px solid #1a3050;
+  }
+
+  .adv-group-details {
+    border-bottom: 1px solid #1a3050;
+    padding: 6px 12px;
+  }
+
+  .adv-group-details > summary {
+    list-style: none;
+    cursor: pointer;
+  }
+
+  .adv-group-details > summary::-webkit-details-marker { display: none; }
+
+  .adv-group-details > summary::before {
+    content: '▸ ';
+    font-size: 0.55rem;
+    color: #666;
+  }
+
+  .adv-group-details[open] > summary::before {
+    content: '▾ ';
+  }
+
+  .adv-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .adv-run-btn {
+    padding: 5px 14px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #fff;
+    background: linear-gradient(135deg, #1a4a7a, #1a3860);
+    border: 1px solid #4ecdc4;
+    border-radius: 4px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .adv-run-btn:hover { background: linear-gradient(135deg, #1a5a9a, #1a4a7a); }
+  .adv-run-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+
+  .adv-btn-sm {
+    padding: 3px 10px;
+    font-size: 0.68rem;
+    font-weight: 600;
+    color: #ccc;
+    background: #1a3050;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    cursor: pointer;
+  }
+
+  .adv-btn-sm:hover { color: #fff; border-color: #4ecdc4; }
+  .adv-btn-sm:disabled { opacity: 0.35; cursor: not-allowed; }
+
+  .adv-title {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #4ecdc4;
+    user-select: none;
+  }
+
+  .adv-desc {
+    font-size: 0.62rem;
+    color: #666;
+    font-style: italic;
+  }
+
+  .adv-hint {
+    font-size: 0.6rem;
+    color: #665;
+    font-style: italic;
+  }
+
+  .adv-inline {
+    font-size: 0.68rem;
+    color: #aaa;
+    padding: 2px 0;
+    font-family: monospace;
+  }
+
+  .adv-divider {
+    padding: 6px 12px;
+    font-size: 0.6rem;
+    font-weight: 600;
+    color: #556;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    background: #0a1a30;
+    border-bottom: 1px solid #1a3050;
+  }
+
+  /* Forms */
+  .adv-form {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  .adv-label {
+    font-size: 0.68rem;
+    color: #888;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    white-space: nowrap;
+  }
+
+  .adv-num {
+    width: 55px;
+    padding: 3px 5px;
+    font-size: 0.68rem;
+    background: #0a1a30;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ccc;
+    text-align: right;
+  }
+
+  .adv-num-wide { width: 70px; }
+
+  .adv-sel {
+    padding: 3px 5px;
+    font-size: 0.68rem;
+    background: #0a1a30;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ccc;
+    cursor: pointer;
+  }
+
+  .adv-text {
+    width: 120px;
+    padding: 3px 5px;
+    font-size: 0.68rem;
+    background: #0a1a30;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ccc;
+  }
+
+  .adv-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 6px 0;
+  }
+
+  .adv-table-scroll {
+    max-height: 150px;
+    overflow-y: auto;
+  }
+
+  .adv-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.68rem;
+  }
+
+  .adv-table th {
+    padding: 3px 5px;
+    text-align: left;
+    font-size: 0.6rem;
+    font-weight: 600;
+    color: #888;
+    text-transform: uppercase;
+    background: #0a1a30;
+    border-bottom: 1px solid #1a3050;
+  }
+
+  .adv-table td {
+    padding: 3px 5px;
+    border-bottom: 1px solid #0f2030;
+    color: #ccc;
+  }
+
+  .col-id { color: #666; font-family: monospace; text-align: center; }
+  .col-num { font-family: monospace; text-align: right; font-size: 0.66rem; }
+
+  .adv-rm {
+    padding: 2px 6px;
+    font-size: 0.62rem;
+    color: #e94560;
+    background: transparent;
+    border: 1px solid #e94560;
+    border-radius: 3px;
+    cursor: pointer;
+    line-height: 1;
+  }
+
+  .adv-rm:hover { background: rgba(233, 69, 96, 0.15); }
+
+  .adv-accel-area {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .adv-textarea {
+    width: 100%;
+    padding: 4px 6px;
+    font-size: 0.64rem;
+    font-family: monospace;
+    background: #0f2030;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ccc;
+    resize: vertical;
+    min-height: 32px;
+  }
+
+  .adv-textarea::placeholder { color: #555; }
+
+  .adv-steps-toggle {
+    font-size: 0.6rem;
+    color: #8ba;
+    cursor: pointer;
+  }
+
+  .adv-step-line {
+    font-size: 0.58rem;
+    color: #9ab;
+    padding: 1px 0;
+  }
+
+  .adv-sub-title {
+    font-size: 0.66rem;
+    font-weight: 600;
+    color: #aaa;
+    margin-top: 4px;
+  }
+
+  .adv-stage-card {
+    background: #0a1a30;
+    border: 1px solid #1a3050;
+    border-radius: 4px;
+    padding: 6px 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .adv-stage-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .adv-stage-name {
+    flex: 1;
+    padding: 3px 5px;
+    font-size: 0.68rem;
+    font-weight: 600;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid #1a3050;
+    color: #ccc;
+  }
+
+  .adv-stage-name:focus { border-color: #4ecdc4; outline: none; }
+
+  .cum-ok { color: #4caf50; }
+  .cum-warn { color: #f0a500; }
+</style>

--- a/web/src/components/pro/ProAutoLoadsDialog.svelte
+++ b/web/src/components/pro/ProAutoLoadsDialog.svelte
@@ -1,0 +1,545 @@
+<script lang="ts">
+  import { modelStore, uiStore } from '../../lib/store';
+  import { t, i18n } from '../../lib/i18n';
+  import {
+    OCCUPANCY_TABLE, DEAD_LOAD_DEFAULTS,
+    getCirsoc101Combinations, computeSeismicStatic, detectFloorLevels,
+    DUCTILITY_TABLE, IMPORTANCE_FACTORS,
+    type SeismicZone, type SoilType, type ImportanceGroup,
+    type DuctilityKey, type StructureSystem, type FloorLevel,
+  } from '../../lib/engine/auto-loads';
+  import { generateWindLoads } from '../../lib/engine/wind-loads';
+  import type { WindParams } from '../../lib/engine/wind-loads';
+
+  interface Props {
+    open: boolean;
+    onclose: () => void;
+  }
+
+  let { open, onclose }: Props = $props();
+
+  // ─── Dead load config ──────────────────
+  let deadComponents = $state(DEAD_LOAD_DEFAULTS.map(d => ({ ...d })));
+  const totalDead = $derived(deadComponents.reduce((s, c) => s + c.q, 0));
+
+  // ─── Live load config ──────────────────
+  let selectedOccupancy = $state('vivienda');
+  const occupancyQ = $derived(OCCUPANCY_TABLE.find(o => o.key === selectedOccupancy)?.q ?? 2.0);
+
+  // ─── Seismic config ────────────────────
+  let enableSeismic = $state(true);
+  let seismicZone = $state<SeismicZone>(4);
+  let soilType = $state<SoilType>('SD');
+  let importanceGroup = $state<ImportanceGroup>('B');
+  let ductilityKey = $state<DuctilityKey>('HA_portico_completa');
+  let structureSystem = $state<StructureSystem>('portico_HA');
+  let seismicDirectionX = $state(true);
+  let seismicDirectionZ = $state(true);
+
+  // ─── Wind config (CIRSOC 102) ────────
+  let enableWind = $state(false);
+  let windV = $state(45);
+  let windExposure = $state<'B' | 'C' | 'D'>('B');
+  let windWidth = $state(10);
+  let windDirX = $state(true);
+  let windDirZ = $state(false);
+
+  // ─── Options ───────────────────────────
+  let generateCombinations = $state(true);
+  let clearExisting = $state(false);
+
+  const isEs = $derived(i18n.locale === 'es');
+
+  // ─── Preview computation ───────────────
+  const seismicPreview = $derived.by(() => {
+    if (!enableSeismic || seismicZone === 0) return null;
+    const allLevels = detectFloorLevels(modelStore.nodes as any);
+    if (allLevels.length < 2) return null;
+    const base = allLevels[0].elevation;
+    const top = allLevels[allLevels.length - 1].elevation;
+    const H = top - base;
+    if (H <= 0) return null;
+
+    // Estimate weight per floor from dead + live loads
+    // Use a rough tributary area estimate
+    const floorWeight = (totalDead + 0.25 * occupancyQ) * 50; // rough 50m² per floor
+    const floors: FloorLevel[] = allLevels
+      .filter(lv => lv.elevation > base + 0.01)
+      .map(lv => ({
+        elevation: lv.elevation - base,
+        weight: floorWeight,
+        nodeIds: lv.nodeIds,
+      }));
+
+    if (floors.length === 0) return null;
+    return computeSeismicStatic(
+      { zone: seismicZone, soil: soilType, importanceGroup, ductilityKey, structureSystem },
+      floors, H,
+    );
+  });
+
+  function handleGenerate() {
+    if (clearExisting) {
+      // Remove all existing loads
+      const ids = modelStore.loads.map(l => l.data.id);
+      for (const id of ids) modelStore.removeLoad(id);
+      // Remove all combinations
+      for (const c of [...modelStore.model.combinations]) modelStore.removeCombination(c.id);
+      // Remove non-default load cases
+      for (const lc of [...modelStore.model.loadCases]) {
+        if (lc.id > 4) modelStore.removeLoadCase(lc.id);
+      }
+    }
+
+    // Ensure load cases exist
+    const cases = modelStore.model.loadCases;
+    let deadCaseId = cases.find(c => c.type === 'D')?.id;
+    let liveCaseId = cases.find(c => c.type === 'L')?.id;
+    let seismicCaseIdX: number | undefined;
+    let seismicCaseIdZ: number | undefined;
+
+    if (!deadCaseId) deadCaseId = modelStore.addLoadCase(t('autoLoad.deadCase'), 'D');
+    if (!liveCaseId) liveCaseId = modelStore.addLoadCase(t('autoLoad.liveCase'), 'L');
+
+    let windCaseIdX: number | undefined;
+    let windCaseIdZ: number | undefined;
+
+    if (enableSeismic && seismicDirectionX) {
+      seismicCaseIdX = cases.find(c => c.type === 'E' && c.name.includes('X'))?.id;
+      if (!seismicCaseIdX) seismicCaseIdX = modelStore.addLoadCase(t('autoLoad.seismicX'), 'E');
+    }
+    if (enableSeismic && seismicDirectionZ) {
+      seismicCaseIdZ = cases.find(c => c.type === 'E' && c.name.includes('Z'))?.id;
+      if (!seismicCaseIdZ) seismicCaseIdZ = modelStore.addLoadCase(t('autoLoad.seismicZ'), 'E');
+    }
+
+    // Generate dead + live loads on horizontal elements (beams)
+    for (const [, elem] of modelStore.elements) {
+      const nI = modelStore.nodes.get(elem.nodeI);
+      const nJ = modelStore.nodes.get(elem.nodeJ);
+      if (!nI || !nJ) continue;
+
+      // Only apply area loads to roughly horizontal elements
+      const dx = nJ.x - nI.x;
+      const dy = nJ.y - nI.y;
+      const dz = (nJ.z ?? 0) - (nI.z ?? 0);
+      const L = Math.sqrt(dx * dx + dy * dy + dz * dz);
+      if (L < 0.01) continue;
+
+      const cosAngle = Math.abs(dy) / L;
+      // Skip if element is nearly vertical (column)
+      if (cosAngle > 0.5) continue;
+
+      // Estimate tributary width (heuristic: use section width or 1m default)
+      const sec = modelStore.sections.get(elem.sectionId);
+      // For beams, assume tributary width = spacing between beams ≈ 3m (user can adjust)
+      const tribWidth = 3.0;
+
+      // Dead load (distributed along element in local Y = gravity direction for horizontal elements)
+      const qDead = -totalDead * tribWidth; // negative Y = downward
+      if (Math.abs(qDead) > 0.001) {
+        modelStore.addDistributedLoad3D(elem.id, qDead, qDead, 0, 0, undefined, undefined, deadCaseId!);
+      }
+
+      // Live load
+      const qLive = -occupancyQ * tribWidth;
+      if (Math.abs(qLive) > 0.001) {
+        modelStore.addDistributedLoad3D(elem.id, qLive, qLive, 0, 0, undefined, undefined, liveCaseId!);
+      }
+    }
+
+    // Generate seismic forces
+    if (enableSeismic && seismicZone > 0) {
+      const allLevels = detectFloorLevels(modelStore.nodes as any);
+      if (allLevels.length >= 2) {
+        const base = allLevels[0].elevation;
+        const top = allLevels[allLevels.length - 1].elevation;
+        const H = top - base;
+
+        if (H > 0) {
+          // Compute seismic weight per floor from model
+          const floorWeight = computeFloorWeights(allLevels, base);
+          const floors: FloorLevel[] = allLevels
+            .filter(lv => lv.elevation > base + 0.01)
+            .map((lv, i) => ({
+              elevation: lv.elevation - base,
+              weight: floorWeight[i + 1] ?? 100,
+              nodeIds: lv.nodeIds,
+            }));
+
+          if (floors.length > 0) {
+            const result = computeSeismicStatic(
+              { zone: seismicZone, soil: soilType, importanceGroup, ductilityKey, structureSystem },
+              floors, H,
+            );
+
+            // Apply forces as nodal loads
+            for (const floor of result.floors) {
+              if (floor.Fk < 0.01) continue;
+              const nNodes = floor.nodeIds.length;
+              if (nNodes === 0) continue;
+              const forcePerNode = floor.Fk / nNodes;
+
+              for (const nodeId of floor.nodeIds) {
+                if (seismicDirectionX && seismicCaseIdX) {
+                  modelStore.addNodalLoad3D(nodeId, forcePerNode, 0, 0, 0, 0, 0, seismicCaseIdX);
+                }
+                if (seismicDirectionZ && seismicCaseIdZ) {
+                  modelStore.addNodalLoad3D(nodeId, 0, 0, forcePerNode, 0, 0, 0, seismicCaseIdZ);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Generate wind loads (CIRSOC 102)
+    if (enableWind) {
+      const params: WindParams = { V: windV, exposure: windExposure };
+      const nodes = modelStore.nodes as Map<number, { id: number; x: number; y: number; z?: number }>;
+
+      if (windDirX) {
+        try {
+          const res = generateWindLoads(nodes, params, 'X', windWidth);
+          if (res?.nodalForces?.length) {
+            const updCases = modelStore.model.loadCases;
+            windCaseIdX = updCases.find(c => c.type === 'W' && c.name.includes('X'))?.id;
+            if (!windCaseIdX) windCaseIdX = modelStore.addLoadCase(`${t('autoLoad.windCase')} X (V=${windV})`, 'W');
+            for (const f of res.nodalForces) {
+              modelStore.addNodalLoad3D(f.nodeId, f.Fx ?? 0, f.Fy ?? 0, f.Fz ?? 0, 0, 0, 0, windCaseIdX);
+            }
+          }
+        } catch { /* skip wind X on error */ }
+      }
+
+      if (windDirZ) {
+        try {
+          const res = generateWindLoads(nodes, params, 'Y', windWidth);
+          if (res?.nodalForces?.length) {
+            const updCases = modelStore.model.loadCases;
+            windCaseIdZ = updCases.find(c => c.type === 'W' && c.name.includes('Z'))?.id;
+            if (!windCaseIdZ) windCaseIdZ = modelStore.addLoadCase(`${t('autoLoad.windCase')} Z (V=${windV})`, 'W');
+            for (const f of res.nodalForces) {
+              modelStore.addNodalLoad3D(f.nodeId, f.Fx ?? 0, f.Fy ?? 0, f.Fz ?? 0, 0, 0, 0, windCaseIdZ);
+            }
+          }
+        } catch { /* skip wind Z on error */ }
+      }
+    }
+
+    // Generate standard combinations
+    if (generateCombinations) {
+      const hasSeismic = enableSeismic && seismicZone > 0;
+      const hasWind = enableWind && (windDirX || windDirZ);
+      const combos = getCirsoc101Combinations(hasWind, hasSeismic, false);
+
+      // Map case types to actual case IDs
+      const updatedCases = modelStore.model.loadCases;
+      for (const combo of combos) {
+        const factors: Array<{ caseId: number; factor: number }> = [];
+        for (const f of combo.factors) {
+          // Find matching case(s)
+          const matchingCases = updatedCases.filter(c => c.type === f.caseType);
+          for (const mc of matchingCases) {
+            factors.push({ caseId: mc.id, factor: f.factor });
+          }
+        }
+        if (factors.length > 0) {
+          modelStore.addCombination(combo.name, factors);
+        }
+      }
+    }
+
+    uiStore.toast(t('autoLoad.generated'), 'success');
+    onclose();
+  }
+
+  /** Estimate seismic weight per floor level from element self-weights */
+  function computeFloorWeights(
+    levels: Array<{ elevation: number; nodeIds: number[] }>,
+    baseElev: number,
+  ): number[] {
+    const weights: number[] = new Array(levels.length).fill(0);
+
+    for (const [, elem] of modelStore.elements) {
+      const nI = modelStore.nodes.get(elem.nodeI);
+      const nJ = modelStore.nodes.get(elem.nodeJ);
+      if (!nI || !nJ) continue;
+
+      const sec = modelStore.sections.get(elem.sectionId);
+      const mat = modelStore.materials.get(elem.materialId);
+      if (!sec || !mat) continue;
+
+      const dx = nJ.x - nI.x;
+      const dy = nJ.y - nI.y;
+      const dz = (nJ.z ?? 0) - (nI.z ?? 0);
+      const L = Math.sqrt(dx * dx + dy * dy + dz * dz);
+      const w = (mat.rho ?? 25) * sec.a * L; // kN
+
+      // Distribute to nearest floor levels
+      const yMid = (nI.y + nJ.y) / 2;
+      let bestIdx = 0;
+      let bestDist = Infinity;
+      for (let i = 0; i < levels.length; i++) {
+        const d = Math.abs(levels[i].elevation - yMid);
+        if (d < bestDist) { bestDist = d; bestIdx = i; }
+      }
+      weights[bestIdx] += w;
+    }
+
+    // Add superimposed dead + portion of live
+    const areaPerFloor = estimateFloorArea();
+    for (let i = 0; i < levels.length; i++) {
+      if (levels[i].elevation > baseElev + 0.01) {
+        weights[i] += (totalDead + 0.25 * occupancyQ) * areaPerFloor;
+      }
+    }
+
+    return weights;
+  }
+
+  /** Rough floor area estimate from node bounding box */
+  function estimateFloorArea(): number {
+    let minX = Infinity, maxX = -Infinity;
+    let minZ = Infinity, maxZ = -Infinity;
+    for (const [, node] of modelStore.nodes) {
+      if (node.x < minX) minX = node.x;
+      if (node.x > maxX) maxX = node.x;
+      const z = node.z ?? 0;
+      if (z < minZ) minZ = z;
+      if (z > maxZ) maxZ = z;
+    }
+    const dx = maxX - minX;
+    const dz = maxZ - minZ;
+    return Math.max(dx * dz, 10); // minimum 10m²
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onclose();
+  }
+</script>
+
+{#if open}
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<div class="al-overlay" onkeydown={handleKeydown} onclick={onclose} role="dialog" aria-modal="true">
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="al-dialog" onclick={(e) => e.stopPropagation()}>
+    <div class="al-header">
+      <h2>{t('autoLoad.title')}</h2>
+      <button class="al-close" onclick={onclose}>&times;</button>
+    </div>
+
+    <div class="al-body">
+      <!-- Dead Loads -->
+      <fieldset class="al-fieldset">
+        <legend>{t('autoLoad.deadLoads')} ({totalDead.toFixed(1)} kN/m²)</legend>
+        {#each deadComponents as comp, i}
+          <div class="al-dead-row">
+            <span class="al-dead-label">{isEs ? comp.label : comp.labelEn}</span>
+            <input type="number" step="0.1" bind:value={deadComponents[i].q} class="al-input-sm" /> kN/m²
+          </div>
+        {/each}
+      </fieldset>
+
+      <!-- Live Loads -->
+      <fieldset class="al-fieldset">
+        <legend>{t('autoLoad.liveLoads')} ({occupancyQ} kN/m²)</legend>
+        <select bind:value={selectedOccupancy} class="al-select">
+          {#each OCCUPANCY_TABLE as occ}
+            <option value={occ.key}>{isEs ? occ.label : occ.labelEn} — {occ.q} kN/m²</option>
+          {/each}
+        </select>
+      </fieldset>
+
+      <!-- Seismic -->
+      <fieldset class="al-fieldset">
+        <legend>
+          <label class="al-check-legend">
+            <input type="checkbox" bind:checked={enableSeismic} />
+            {t('autoLoad.seismic')}
+          </label>
+        </legend>
+        {#if enableSeismic}
+          <div class="al-grid">
+            <div class="al-field">
+              <label class="al-label">{t('autoLoad.zone')}</label>
+              <select bind:value={seismicZone} class="al-select-sm">
+                <option value={4}>4 — {t('autoLoad.zoneVeryHigh')}</option>
+                <option value={3}>3 — {t('autoLoad.zoneHigh')}</option>
+                <option value={2}>2 — {t('autoLoad.zoneModerate')}</option>
+                <option value={1}>1 — {t('autoLoad.zoneLow')}</option>
+              </select>
+            </div>
+            <div class="al-field">
+              <label class="al-label">{t('autoLoad.soil')}</label>
+              <select bind:value={soilType} class="al-select-sm">
+                <option value="SA">SA — {t('autoLoad.soilSA')}</option>
+                <option value="SB">SB — {t('autoLoad.soilSB')}</option>
+                <option value="SC">SC — {t('autoLoad.soilSC')}</option>
+                <option value="SD">SD — {t('autoLoad.soilSD')}</option>
+                <option value="SE">SE — {t('autoLoad.soilSE')}</option>
+              </select>
+            </div>
+            <div class="al-field">
+              <label class="al-label">{t('autoLoad.importance')}</label>
+              <select bind:value={importanceGroup} class="al-select-sm">
+                <option value="Ao">Ao (γ=1.5) — {t('autoLoad.impEssential')}</option>
+                <option value="A">A (γ=1.3) — {t('autoLoad.impImportant')}</option>
+                <option value="B">B (γ=1.0) — {t('autoLoad.impNormal')}</option>
+                <option value="C">C (γ=0.8) — {t('autoLoad.impLow')}</option>
+              </select>
+            </div>
+            <div class="al-field">
+              <label class="al-label">{t('autoLoad.ductility')}</label>
+              <select bind:value={ductilityKey} class="al-select-sm">
+                {#each DUCTILITY_TABLE as d}
+                  <option value={d.key}>{isEs ? d.label : d.labelEn} (μ={d.mu})</option>
+                {/each}
+              </select>
+            </div>
+            <div class="al-field">
+              <label class="al-label">{t('autoLoad.system')}</label>
+              <select bind:value={structureSystem} class="al-select-sm">
+                <option value="portico_HA">{t('autoLoad.sysRCFrame')}</option>
+                <option value="portico_acero">{t('autoLoad.sysSteelFrame')}</option>
+                <option value="muros">{t('autoLoad.sysWalls')}</option>
+                <option value="otro">{t('autoLoad.sysOther')}</option>
+              </select>
+            </div>
+          </div>
+          <div class="al-directions">
+            <label><input type="checkbox" bind:checked={seismicDirectionX} /> {t('autoLoad.dirX')}</label>
+            <label><input type="checkbox" bind:checked={seismicDirectionZ} /> {t('autoLoad.dirZ')}</label>
+          </div>
+
+          {#if seismicPreview}
+            <div class="al-preview">
+              <div class="al-preview-title">{t('autoLoad.preview')}</div>
+              <div class="al-preview-row">T ≈ {seismicPreview.T.toFixed(3)} s | Sa = {seismicPreview.Sa.toFixed(3)}g | R = {seismicPreview.R.toFixed(1)}</div>
+              <div class="al-preview-row">V₀ = {seismicPreview.V0.toFixed(1)} kN ({(seismicPreview.V0 / seismicPreview.W * 100).toFixed(1)}% W)</div>
+              {#each seismicPreview.floors as f}
+                <div class="al-preview-floor">h={f.elevation.toFixed(1)}m → F={f.Fk.toFixed(1)} kN</div>
+              {/each}
+            </div>
+          {/if}
+        {/if}
+      </fieldset>
+
+      <!-- Wind (CIRSOC 102) -->
+      <fieldset class="al-fieldset">
+        <legend>
+          <label class="al-check-legend">
+            <input type="checkbox" bind:checked={enableWind} />
+            {t('autoLoad.wind')}
+          </label>
+        </legend>
+        {#if enableWind}
+          <div class="al-grid">
+            <div class="al-field">
+              <label class="al-label">V (m/s)</label>
+              <input type="number" class="al-input-sm" bind:value={windV} min={10} max={120} step={1} />
+            </div>
+            <div class="al-field">
+              <label class="al-label">{t('autoLoad.windExposure')}</label>
+              <select class="al-select-sm" bind:value={windExposure}>
+                <option value="B">B — {t('autoLoad.windExpB')}</option>
+                <option value="C">C — {t('autoLoad.windExpC')}</option>
+                <option value="D">D — {t('autoLoad.windExpD')}</option>
+              </select>
+            </div>
+            <div class="al-field">
+              <label class="al-label">{t('autoLoad.windTribWidth')} (m)</label>
+              <input type="number" class="al-input-sm" bind:value={windWidth} min={0.1} step={0.5} />
+            </div>
+          </div>
+          <div class="al-directions" style="margin-top: 6px;">
+            <label><input type="checkbox" bind:checked={windDirX} /> {t('autoLoad.dirX')}</label>
+            <label><input type="checkbox" bind:checked={windDirZ} /> {t('autoLoad.dirZ')}</label>
+          </div>
+        {/if}
+      </fieldset>
+
+      <!-- Options -->
+      <fieldset class="al-fieldset">
+        <legend>{t('autoLoad.options')}</legend>
+        <label class="al-check"><input type="checkbox" bind:checked={generateCombinations} /> {t('autoLoad.genCombos')}</label>
+        <label class="al-check"><input type="checkbox" bind:checked={clearExisting} /> {t('autoLoad.clearExisting')}</label>
+      </fieldset>
+    </div>
+
+    <div class="al-footer">
+      <button class="al-btn al-btn-secondary" onclick={onclose}>{t('report.cancel')}</button>
+      <button class="al-btn al-btn-primary" onclick={handleGenerate}>{t('autoLoad.generate')}</button>
+    </div>
+  </div>
+</div>
+{/if}
+
+<style>
+  .al-overlay {
+    position: fixed; inset: 0; z-index: 9999;
+    background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center;
+  }
+  .al-dialog {
+    background: #1a1a2e; color: #e0e0e0; border-radius: 10px;
+    width: 520px; max-height: 85vh; display: flex; flex-direction: column;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.5); border: 1px solid #2a2a4a;
+  }
+  .al-header {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 14px 18px; border-bottom: 1px solid #2a2a4a;
+  }
+  .al-header h2 { margin: 0; font-size: 15px; color: #fff; }
+  .al-close { background: none; border: none; color: #888; font-size: 22px; cursor: pointer; }
+  .al-close:hover { color: #fff; }
+  .al-body { padding: 14px 18px; overflow-y: auto; flex: 1; }
+  .al-fieldset {
+    border: 1px solid #2a2a4a; border-radius: 6px; padding: 10px 12px; margin-bottom: 12px;
+  }
+  .al-fieldset legend { color: #4ecdc4; font-size: 11px; font-weight: 600; padding: 0 6px; text-transform: uppercase; }
+  .al-dead-row {
+    display: flex; align-items: center; gap: 8px; margin-bottom: 4px; font-size: 11px;
+  }
+  .al-dead-label { flex: 1; color: #bbb; }
+  .al-input-sm {
+    width: 55px; padding: 3px 5px; background: #12122a; border: 1px solid #333;
+    border-radius: 3px; color: #e0e0e0; font-size: 11px; text-align: right;
+  }
+  .al-input-sm:focus { border-color: #4ecdc4; outline: none; }
+  .al-select, .al-select-sm {
+    width: 100%; padding: 5px 6px; background: #12122a; border: 1px solid #333;
+    border-radius: 4px; color: #e0e0e0; font-size: 11px;
+  }
+  .al-select-sm { width: 100%; }
+  .al-select:focus, .al-select-sm:focus { border-color: #4ecdc4; outline: none; }
+  .al-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+  .al-field { display: flex; flex-direction: column; gap: 3px; }
+  .al-label { font-size: 10px; color: #888; }
+  .al-directions { display: flex; gap: 16px; margin-top: 8px; font-size: 11px; }
+  .al-directions label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .al-directions input { accent-color: #4ecdc4; }
+  .al-check { display: flex; align-items: center; gap: 6px; font-size: 11px; cursor: pointer; margin-bottom: 4px; }
+  .al-check input { accent-color: #4ecdc4; }
+  .al-check-legend { display: flex; align-items: center; gap: 6px; cursor: pointer; }
+  .al-check-legend input { accent-color: #4ecdc4; }
+  .al-preview {
+    margin-top: 8px; padding: 8px; background: #12122a; border-radius: 4px; font-size: 10px;
+    font-family: monospace;
+  }
+  .al-preview-title { color: #4ecdc4; font-weight: 600; margin-bottom: 4px; }
+  .al-preview-row { color: #ccc; margin-bottom: 2px; }
+  .al-preview-floor { color: #999; padding-left: 8px; }
+  .al-footer {
+    display: flex; justify-content: flex-end; gap: 8px;
+    padding: 12px 18px; border-top: 1px solid #2a2a4a;
+  }
+  .al-btn {
+    padding: 8px 20px; border-radius: 6px; font-size: 12px; font-weight: 600;
+    cursor: pointer; border: none; transition: background 0.15s;
+  }
+  .al-btn-primary { background: #4ecdc4; color: #111; }
+  .al-btn-primary:hover { background: #3dbdb4; }
+  .al-btn-secondary { background: #2a2a4a; color: #ccc; }
+  .al-btn-secondary:hover { background: #3a3a5a; }
+</style>

--- a/web/src/components/pro/ProConnectionsTab.svelte
+++ b/web/src/components/pro/ProConnectionsTab.svelte
@@ -1,0 +1,342 @@
+<script lang="ts">
+  import { modelStore, resultsStore, uiStore } from '../../lib/store';
+  import { t } from '../../lib/i18n';
+  import {
+    detectJoints, getJointForces, checkBoltGroup, checkFilletWeld,
+    BOLT_TABLE, type BoltGrade, type BoltResult, type WeldResult,
+    type JointInfo, type JointForces,
+  } from '../../lib/engine/connection-design';
+
+  // ─── Joint detection (reactive) ──────────────
+  const joints = $derived.by(() => {
+    void(modelStore.nodes.size + modelStore.elements.size + modelStore.supports.size);
+    return detectJoints(modelStore.nodes, modelStore.elements as any, modelStore.supports as any);
+  });
+
+  let selectedJointId = $state<number | null>(null);
+
+  const selectedJoint = $derived(joints.find(j => j.nodeId === selectedJointId) ?? null);
+
+  // ─── Forces at selected joint ────────────────
+  const jointForces = $derived.by((): JointForces | null => {
+    if (!selectedJoint) return null;
+    const r3d = resultsStore.results3D;
+    if (!r3d?.elementForces) return null;
+    return getJointForces(
+      selectedJoint.nodeId,
+      selectedJoint.elementIds,
+      modelStore.elements as any,
+      r3d.elementForces,
+    );
+  });
+
+  // ─── Bolt config ─────────────────────────────
+  let boltDia = $state(20);
+  let boltGrade = $state<BoltGrade>('8.8');
+  let boltCount = $state(4);
+  let boltShearPlanes = $state(1);
+  let boltThreadsInShear = $state(true);
+  let boltPlateThickness = $state(10);
+  let boltPlateFu = $state(440);
+  let boltEdgeDist = $state(35);
+  let boltVu = $state(0);
+  let boltTu = $state(0);
+  let boltResult = $state<BoltResult | null>(null);
+
+  // ─── Weld config ─────────────────────────────
+  let weldLeg = $state(6);
+  let weldLength = $state(200);
+  let weldFexx = $state(490);
+  let weldPlateThickness = $state(10);
+  let weldVu = $state(0);
+  let weldResult = $state<WeldResult | null>(null);
+
+  function selectJoint(nodeId: number) {
+    selectedJointId = selectedJointId === nodeId ? null : nodeId;
+    boltResult = null;
+    weldResult = null;
+  }
+
+  function highlightJoint(j: JointInfo) {
+    uiStore.selectedNodes = new Set([j.nodeId]);
+    uiStore.selectedElements = new Set(j.elementIds);
+  }
+
+  /** Auto-fill bolt forces from joint max shear */
+  function autoFillBoltForces() {
+    if (!jointForces) return;
+    boltVu = Math.round(jointForces.maxV * 10) / 10;
+    boltTu = 0;
+  }
+
+  /** Auto-fill weld forces from joint max shear */
+  function autoFillWeldForces() {
+    if (!jointForces) return;
+    weldVu = Math.round(jointForces.maxV * 10) / 10;
+  }
+
+  function runBoltCheck() {
+    boltResult = checkBoltGroup({
+      diameter: boltDia,
+      grade: boltGrade,
+      count: boltCount,
+      shearPlanes: boltShearPlanes,
+      threadsInShear: boltThreadsInShear,
+      plateThickness: boltPlateThickness,
+      plateFu: boltPlateFu,
+      edgeDistance: boltEdgeDist,
+      Vu: boltVu,
+      Tu: boltTu,
+    });
+  }
+
+  function runWeldCheck() {
+    weldResult = checkFilletWeld({
+      legSize: weldLeg,
+      length: weldLength,
+      Fexx: weldFexx,
+      Vu: weldVu,
+      plateThickness: weldPlateThickness,
+    });
+  }
+
+  function fmtN(n: number): string {
+    if (Math.abs(n) < 0.01) return '0';
+    return n.toFixed(1);
+  }
+
+  function statusClass(s: 'ok' | 'warn' | 'fail'): string {
+    return `st-${s}`;
+  }
+</script>
+
+<div class="conn-tab">
+  <!-- Joint list -->
+  <div class="conn-section">
+    <div class="conn-section-header">
+      <span class="conn-label-title">{t('conn.joints')} ({joints.length})</span>
+    </div>
+    {#if joints.length === 0}
+      <div class="conn-empty">{t('conn.noJoints')}</div>
+    {:else}
+      <div class="conn-joint-list">
+        {#each joints as j}
+          <button
+            class="conn-joint-row"
+            class:active={selectedJointId === j.nodeId}
+            onclick={() => { selectJoint(j.nodeId); highlightJoint(j); }}
+          >
+            <span class="conn-node-id">N{j.nodeId}</span>
+            <span class="conn-elem-count">{j.elementCount} {t('conn.elementsShort')}</span>
+            {#if j.hasSupport}<span class="conn-support-badge">{t('conn.support')}</span>{/if}
+            <span class="conn-coords">({fmtN(j.x)}, {fmtN(j.y)}, {fmtN(j.z)})</span>
+          </button>
+        {/each}
+      </div>
+    {/if}
+  </div>
+
+  {#if selectedJoint}
+    <!-- Forces at joint -->
+    <div class="conn-section">
+      <div class="conn-section-header">
+        <span class="conn-label-title">{t('conn.forcesAt')} N{selectedJoint.nodeId}</span>
+      </div>
+      {#if jointForces}
+        <div class="conn-forces-table">
+          <table>
+            <thead><tr><th>Elem</th><th>End</th><th>N</th><th>Vy</th><th>Vz</th><th>My</th><th>Mz</th></tr></thead>
+            <tbody>
+              {#each jointForces.elements as ef}
+                <tr>
+                  <td class="mono">E{ef.elementId}</td>
+                  <td class="mono">{ef.end}</td>
+                  <td class="mono">{fmtN(ef.N)}</td>
+                  <td class="mono">{fmtN(ef.Vy)}</td>
+                  <td class="mono">{fmtN(ef.Vz)}</td>
+                  <td class="mono">{fmtN(ef.My)}</td>
+                  <td class="mono">{fmtN(ef.Mz)}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+          <div class="conn-force-summary">
+            V<sub>max</sub>={fmtN(jointForces.maxV)} kN &nbsp;|&nbsp;
+            N<sub>max</sub>={fmtN(jointForces.maxN)} kN &nbsp;|&nbsp;
+            M<sub>max</sub>={fmtN(jointForces.maxM)} kN·m
+          </div>
+        </div>
+      {:else}
+        <div class="conn-no-results">{t('conn.noResults')}</div>
+      {/if}
+    </div>
+
+    <!-- Bolt check -->
+    <details class="conn-check-details">
+      <summary class="conn-check-summary">
+        {t('conn.boltCheck')}
+        {#if boltResult}
+          <span class="conn-ratio-badge {statusClass(boltResult.status)}">{(boltResult.governingRatio * 100).toFixed(0)}%</span>
+        {/if}
+      </summary>
+      <div class="conn-check-body">
+        <div class="conn-form-grid">
+          <label>∅ (mm) <input type="number" class="conn-inp" bind:value={boltDia} min={6} max={36} step={2} /></label>
+          <label>{t('conn.grade')} <select class="conn-sel" bind:value={boltGrade}><option value="4.6">4.6</option><option value="5.6">5.6</option><option value="8.8">8.8</option><option value="10.9">10.9</option></select></label>
+          <label>n <input type="number" class="conn-inp" bind:value={boltCount} min={1} max={50} /></label>
+          <label>{t('conn.shearPlanes')} <input type="number" class="conn-inp" bind:value={boltShearPlanes} min={1} max={2} /></label>
+          <label>t (mm) <input type="number" class="conn-inp" bind:value={boltPlateThickness} min={3} max={50} /></label>
+          <label>Fu (MPa) <input type="number" class="conn-inp" bind:value={boltPlateFu} min={300} max={700} step={10} /></label>
+          <label>Le (mm) <input type="number" class="conn-inp" bind:value={boltEdgeDist} min={15} max={100} /></label>
+          <label class="conn-check-label"><input type="checkbox" bind:checked={boltThreadsInShear} /> {t('conn.threadsInShear')}</label>
+        </div>
+        <div class="conn-force-inputs">
+          <label>Vu (kN) <input type="number" class="conn-inp" bind:value={boltVu} step={1} /></label>
+          <label>Tu (kN) <input type="number" class="conn-inp" bind:value={boltTu} min={0} step={1} /></label>
+          {#if jointForces}
+            <button class="conn-btn-auto" onclick={autoFillBoltForces}>{t('conn.autoFill')}</button>
+          {/if}
+          <button class="conn-btn-verify" onclick={runBoltCheck}>{t('conn.verify')}</button>
+        </div>
+        {#if boltResult}
+          <div class="conn-result-card {statusClass(boltResult.status)}">
+            <div class="conn-result-row"><span>{t('conn.shear')}</span><span>φRn={fmtN(boltResult.phiRnShear)} kN — {(boltResult.ratioShear * 100).toFixed(0)}%</span></div>
+            <div class="conn-result-row"><span>{t('conn.tension')}</span><span>φRn={fmtN(boltResult.phiRnTension)} kN — {(boltResult.ratioTension * 100).toFixed(0)}%</span></div>
+            <div class="conn-result-row"><span>{t('conn.bearing')}</span><span>φRn={fmtN(boltResult.phiRnBearing)} kN — {(boltResult.ratioBearing * 100).toFixed(0)}%</span></div>
+            <div class="conn-result-row"><span>{t('conn.interaction')}</span><span>{(boltResult.ratioInteraction * 100).toFixed(0)}%</span></div>
+            <div class="conn-result-governing">
+              {t('conn.governing')}: {(boltResult.governingRatio * 100).toFixed(0)}%
+              <span class="conn-status-icon {statusClass(boltResult.status)}">
+                {boltResult.status === 'ok' ? '✓' : boltResult.status === 'warn' ? '⚠' : '✗'}
+              </span>
+            </div>
+          </div>
+        {/if}
+      </div>
+    </details>
+
+    <!-- Weld check -->
+    <details class="conn-check-details">
+      <summary class="conn-check-summary">
+        {t('conn.weldCheck')}
+        {#if weldResult}
+          <span class="conn-ratio-badge {statusClass(weldResult.status)}">{(weldResult.ratio * 100).toFixed(0)}%</span>
+        {/if}
+      </summary>
+      <div class="conn-check-body">
+        <div class="conn-form-grid">
+          <label>a (mm) <input type="number" class="conn-inp" bind:value={weldLeg} min={3} max={25} /></label>
+          <label>L (mm) <input type="number" class="conn-inp" bind:value={weldLength} min={20} max={3000} /></label>
+          <label>Fexx (MPa) <input type="number" class="conn-inp" bind:value={weldFexx} min={350} max={700} step={10} /></label>
+          <label>t (mm) <input type="number" class="conn-inp" bind:value={weldPlateThickness} min={3} max={50} /></label>
+        </div>
+        <div class="conn-force-inputs">
+          <label>Vu (kN) <input type="number" class="conn-inp" bind:value={weldVu} step={1} /></label>
+          {#if jointForces}
+            <button class="conn-btn-auto" onclick={autoFillWeldForces}>{t('conn.autoFill')}</button>
+          {/if}
+          <button class="conn-btn-verify" onclick={runWeldCheck}>{t('conn.verify')}</button>
+        </div>
+        {#if weldResult}
+          <div class="conn-result-card {statusClass(weldResult.status)}">
+            <div class="conn-result-row"><span>{t('conn.throat')}</span><span>te={weldResult.throatEff.toFixed(1)} mm</span></div>
+            <div class="conn-result-row"><span>{t('conn.capacity')}</span><span>φRn={fmtN(weldResult.phiRn)} kN</span></div>
+            <div class="conn-result-row"><span>{t('conn.sizeRange')}</span><span>{weldResult.minSize}–{weldResult.maxSize} mm {weldResult.sizeOk ? '✓' : '✗'}</span></div>
+            <div class="conn-result-row"><span>L ≥ 4a</span><span>{weldResult.lengthOk ? '✓' : '✗'}</span></div>
+            <div class="conn-result-governing">
+              {t('conn.utilization')}: {(weldResult.ratio * 100).toFixed(0)}%
+              <span class="conn-status-icon {statusClass(weldResult.status)}">
+                {weldResult.status === 'ok' ? '✓' : weldResult.status === 'warn' ? '⚠' : '✗'}
+              </span>
+            </div>
+          </div>
+        {/if}
+      </div>
+    </details>
+  {/if}
+</div>
+
+<style>
+  .conn-tab { display: flex; flex-direction: column; height: 100%; overflow-y: auto; }
+  .conn-section { border-bottom: 1px solid #1a3050; }
+  .conn-section-header { padding: 8px 10px; }
+  .conn-label-title { font-size: 0.78rem; color: #4ecdc4; font-weight: 600; }
+  .conn-empty { text-align: center; color: #555; font-style: italic; padding: 20px 10px; font-size: 0.78rem; }
+
+  .conn-joint-list { max-height: 180px; overflow-y: auto; }
+  .conn-joint-row {
+    display: flex; align-items: center; gap: 8px; width: 100%;
+    padding: 5px 10px; font-size: 0.72rem; color: #bbb; background: transparent;
+    border: none; border-bottom: 1px solid #0f2030; cursor: pointer; text-align: left;
+  }
+  .conn-joint-row:hover { background: rgba(78, 205, 196, 0.05); }
+  .conn-joint-row.active { background: rgba(78, 205, 196, 0.1); color: #fff; }
+  .conn-node-id { font-weight: 600; color: #4ecdc4; min-width: 35px; }
+  .conn-elem-count { color: #888; }
+  .conn-support-badge { font-size: 0.6rem; padding: 1px 5px; background: rgba(240, 165, 0, 0.2); color: #f0a500; border-radius: 3px; }
+  .conn-coords { color: #555; font-family: monospace; font-size: 0.65rem; margin-left: auto; }
+
+  .conn-forces-table { padding: 6px 10px; }
+  .conn-forces-table table { width: 100%; border-collapse: collapse; font-size: 0.7rem; }
+  .conn-forces-table th { font-size: 0.62rem; color: #888; text-transform: uppercase; font-weight: 600; text-align: right; padding: 3px 4px; border-bottom: 1px solid #1a3050; }
+  .conn-forces-table td { padding: 3px 4px; border-bottom: 1px solid #0f2030; color: #ccc; }
+  .mono { font-family: monospace; text-align: right; font-size: 0.7rem; }
+  .conn-force-summary { font-size: 0.68rem; color: #888; padding: 4px 0; font-family: monospace; }
+  .conn-no-results { font-size: 0.72rem; color: #555; font-style: italic; padding: 10px; }
+
+  .conn-check-details { border-bottom: 1px solid #1a3050; }
+  .conn-check-summary {
+    padding: 8px 10px; font-size: 0.75rem; color: #ccc; cursor: pointer;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .conn-check-summary:hover { color: #fff; }
+  .conn-check-body { padding: 6px 10px 10px; }
+
+  .conn-form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 5px; margin-bottom: 6px; }
+  .conn-form-grid label { font-size: 0.68rem; color: #888; display: flex; align-items: center; gap: 4px; }
+  .conn-inp {
+    width: 60px; padding: 3px 5px; background: #0f2840; border: 1px solid #1a3050;
+    border-radius: 3px; color: #ddd; font-size: 0.72rem; font-family: monospace; text-align: right;
+  }
+  .conn-inp:focus { border-color: #4ecdc4; outline: none; }
+  .conn-sel {
+    padding: 3px 5px; background: #0f2840; border: 1px solid #1a3050;
+    border-radius: 3px; color: #ddd; font-size: 0.72rem;
+  }
+  .conn-sel:focus { border-color: #4ecdc4; outline: none; }
+  .conn-check-label { font-size: 0.68rem; color: #888; display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .conn-check-label input { accent-color: #4ecdc4; }
+
+  .conn-force-inputs { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin-bottom: 6px; }
+  .conn-force-inputs label { font-size: 0.68rem; color: #888; display: flex; align-items: center; gap: 4px; }
+  .conn-btn-auto {
+    padding: 3px 8px; font-size: 0.65rem; color: #4ecdc4; background: transparent;
+    border: 1px solid #4ecdc4; border-radius: 3px; cursor: pointer;
+  }
+  .conn-btn-auto:hover { background: rgba(78, 205, 196, 0.1); }
+  .conn-btn-verify {
+    padding: 4px 12px; font-size: 0.72rem; font-weight: 600; color: #111;
+    background: #4ecdc4; border: none; border-radius: 4px; cursor: pointer;
+  }
+  .conn-btn-verify:hover { background: #3dbdb4; }
+
+  .conn-ratio-badge {
+    font-size: 0.62rem; font-weight: 700; padding: 1px 6px; border-radius: 8px; margin-left: auto;
+  }
+  .conn-ratio-badge.st-ok { background: rgba(34, 204, 102, 0.2); color: #22cc66; }
+  .conn-ratio-badge.st-warn { background: rgba(240, 165, 0, 0.2); color: #f0a500; }
+  .conn-ratio-badge.st-fail { background: rgba(233, 69, 96, 0.2); color: #e94560; }
+
+  .conn-result-card {
+    padding: 6px 8px; border-radius: 4px; font-size: 0.7rem;
+    background: rgba(78, 205, 196, 0.05); border: 1px solid #1a3050;
+  }
+  .conn-result-card.st-fail { border-color: rgba(233, 69, 96, 0.3); background: rgba(233, 69, 96, 0.05); }
+  .conn-result-card.st-warn { border-color: rgba(240, 165, 0, 0.3); background: rgba(240, 165, 0, 0.05); }
+  .conn-result-row { display: flex; justify-content: space-between; padding: 2px 0; color: #bbb; }
+  .conn-result-governing { display: flex; justify-content: space-between; padding: 4px 0 0; font-weight: 600; color: #fff; border-top: 1px solid #1a3050; margin-top: 4px; }
+  .conn-status-icon { font-size: 0.85rem; }
+  .conn-status-icon.st-ok { color: #22cc66; }
+  .conn-status-icon.st-warn { color: #f0a500; }
+  .conn-status-icon.st-fail { color: #e94560; }
+</style>

--- a/web/src/components/pro/ProConstraintsTab.svelte
+++ b/web/src/components/pro/ProConstraintsTab.svelte
@@ -1,0 +1,449 @@
+<script lang="ts">
+  import { modelStore } from '../../lib/store';
+  import { detectFloorLevels } from '../../lib/engine/rigid-diaphragm';
+  import { t } from '../../lib/i18n';
+
+  type ConstraintKind = 'rigidLink' | 'diaphragm' | 'equalDof' | 'linearMpc';
+
+  const constraintKinds = $derived([
+    { value: 'rigidLink' as ConstraintKind, label: t('pro.rigidLink') },
+    { value: 'diaphragm' as ConstraintKind, label: t('pro.diaphragm') },
+    { value: 'equalDof' as ConstraintKind, label: t('pro.equalDof') },
+    { value: 'linearMpc' as ConstraintKind, label: t('pro.linearMpc') },
+  ]);
+
+  const dofLabels = ['ux', 'uy', 'uz', 'rx', 'ry', 'rz'] as const;
+  const planeOptions = ['XY', 'XZ', 'YZ'] as const;
+
+  let selectedKind = $state<ConstraintKind>('rigidLink');
+
+  // Rigid Link state
+  let rlMaster = $state('');
+  let rlSlave = $state('');
+  let rlDofs = $state([true, true, true, true, true, true]);
+
+  // Diaphragm state
+  let dMaster = $state('');
+  let dSlaves = $state('');
+  let dPlane = $state<'XY' | 'XZ' | 'YZ'>('XY');
+
+  // Equal DOF state
+  let eqMaster = $state('');
+  let eqSlave = $state('');
+  let eqDofs = $state([true, true, true, false, false, false]);
+
+  // Linear MPC state
+  let mpcTerms = $state('');
+  let mpcRhs = $state('0');
+
+  const constraints = $derived(modelStore.model.constraints ?? []);
+
+  function validateNode(idStr: string): number | null {
+    const id = parseInt(idStr);
+    if (isNaN(id) || !modelStore.nodes.has(id)) return null;
+    return id;
+  }
+
+  function addRigidLink() {
+    const master = validateNode(rlMaster);
+    const slave = validateNode(rlSlave);
+    if (master === null || slave === null || master === slave) return;
+    const activeDofs = dofLabels.filter((_, i) => rlDofs[i]) as string[];
+    if (activeDofs.length === 0) return;
+    modelStore.addConstraint({
+      type: 'rigidLink',
+      masterNode: master,
+      slaveNode: slave,
+      dofs: activeDofs,
+    });
+    rlMaster = '';
+    rlSlave = '';
+  }
+
+  function addDiaphragm() {
+    const master = validateNode(dMaster);
+    if (master === null) return;
+    const slaveIds = dSlaves.split(',').map(s => parseInt(s.trim())).filter(id => !isNaN(id) && modelStore.nodes.has(id) && id !== master);
+    if (slaveIds.length === 0) return;
+    modelStore.addConstraint({
+      type: 'diaphragm',
+      masterNode: master,
+      slaveNodes: slaveIds,
+      plane: dPlane,
+    });
+    dMaster = '';
+    dSlaves = '';
+  }
+
+  function addEqualDof() {
+    const master = validateNode(eqMaster);
+    const slave = validateNode(eqSlave);
+    if (master === null || slave === null || master === slave) return;
+    const activeDofs = dofLabels.filter((_, i) => eqDofs[i]) as string[];
+    if (activeDofs.length === 0) return;
+    modelStore.addConstraint({
+      type: 'equalDof',
+      masterNode: master,
+      slaveNode: slave,
+      dofs: activeDofs,
+    });
+    eqMaster = '';
+    eqSlave = '';
+  }
+
+  function addLinearMpc() {
+    const rhs = parseFloat(mpcRhs);
+    if (isNaN(rhs)) return;
+    // Parse terms: "nodeId:dof:coeff, ..." e.g. "1:ux:1.0, 2:ux:-1.0"
+    const parsed = mpcTerms.split(',').map(t => {
+      const parts = t.trim().split(':');
+      if (parts.length !== 3) return null;
+      const nodeId = parseInt(parts[0]);
+      const dof = parts[1].trim();
+      const coeff = parseFloat(parts[2]);
+      if (isNaN(nodeId) || isNaN(coeff) || !dofLabels.includes(dof as any)) return null;
+      return { nodeId, dof, coeff };
+    }).filter(Boolean) as { nodeId: number; dof: string; coeff: number }[];
+    if (parsed.length === 0) return;
+    modelStore.addConstraint({
+      type: 'linearMpc',
+      terms: parsed,
+      rhs,
+    });
+    mpcTerms = '';
+    mpcRhs = '0';
+  }
+
+  function addConstraint() {
+    if (selectedKind === 'rigidLink') addRigidLink();
+    else if (selectedKind === 'diaphragm') addDiaphragm();
+    else if (selectedKind === 'equalDof') addEqualDof();
+    else if (selectedKind === 'linearMpc') addLinearMpc();
+  }
+
+  function removeConstraint(index: number) {
+    modelStore.removeConstraint(index);
+  }
+
+  function autoDetectDiaphragms() {
+    const tolerance = 0.05;
+    const levels = detectFloorLevels(modelStore.nodes, tolerance);
+    if (levels.length === 0) return;
+
+    for (const z of levels) {
+      // Collect nodes at this level
+      const nodeIds: number[] = [];
+      for (const [id, n] of modelStore.nodes) {
+        if (Math.abs((n.z ?? 0) - z) < tolerance) {
+          nodeIds.push(id);
+        }
+      }
+      if (nodeIds.length < 2) continue;
+
+      // Find centroid to pick master node
+      let sx = 0, sy = 0;
+      for (const id of nodeIds) {
+        const n = modelStore.nodes.get(id)!;
+        sx += n.x;
+        sy += n.y;
+      }
+      const cx = sx / nodeIds.length;
+      const cy = sy / nodeIds.length;
+
+      // Master = node closest to centroid
+      let masterId = nodeIds[0];
+      let minDist = Infinity;
+      for (const id of nodeIds) {
+        const n = modelStore.nodes.get(id)!;
+        const dist = Math.sqrt((n.x - cx) ** 2 + (n.y - cy) ** 2);
+        if (dist < minDist) {
+          minDist = dist;
+          masterId = id;
+        }
+      }
+
+      const slaveIds = nodeIds.filter(id => id !== masterId);
+      modelStore.addConstraint({
+        type: 'diaphragm',
+        masterNode: masterId,
+        slaveNodes: slaveIds,
+        plane: 'XY',
+      });
+    }
+  }
+
+  function constraintLabel(c: any): string {
+    if (c.type === 'rigidLink') return t('pro.constraintRigid').replace('{master}', c.masterNode).replace('{slave}', c.slaveNode).replace('{dofs}', c.dofs ? c.dofs.join(',') : t('pro.allDofs'));
+    if (c.type === 'diaphragm') return t('pro.constraintDiaph').replace('{plane}', c.plane ?? 'XZ').replace('{master}', c.masterNode).replace('{n}', String(c.slaveNodes?.length ?? 0));
+    if (c.type === 'equalDof') return t('pro.constraintEqDof').replace('{master}', c.masterNode).replace('{slave}', c.slaveNode).replace('{dofs}', c.dofs ? c.dofs.join(',') : t('pro.allDofs'));
+    if (c.type === 'linearMpc') return t('pro.constraintMpc').replace('{n}', String(c.terms?.length ?? 0)).replace('{rhs}', String(c.rhs ?? 0));
+    return t('pro.unknown');
+  }
+
+  function constraintTypeLabel(type: string): string {
+    return constraintKinds.find(k => k.value === type)?.label ?? type;
+  }
+</script>
+
+<div class="pro-cst">
+  <div class="pro-cst-header">
+    <span class="pro-cst-count">{t('pro.nConstraints').replace('{n}', String(constraints.length))}</span>
+    {#if constraints.length > 0}
+      <button class="pro-btn pro-btn-clear" onclick={() => modelStore.clearConstraints()}>{t('pro.clear')}</button>
+    {/if}
+  </div>
+
+  <div class="pro-cst-form">
+    <div class="pro-cst-row">
+      <label>Tipo:
+        <select bind:value={selectedKind} class="pro-select-sm">
+          {#each constraintKinds as ck}
+            <option value={ck.value}>{ck.label}</option>
+          {/each}
+        </select>
+      </label>
+    </div>
+
+    {#if selectedKind === 'rigidLink'}
+      <div class="pro-cst-row">
+        <label>Master: <input type="text" bind:value={rlMaster} placeholder="ID" class="pro-input-sm" /></label>
+        <label>{t('pro.slave')}: <input type="text" bind:value={rlSlave} placeholder="ID" class="pro-input-sm" /></label>
+      </div>
+      <div class="pro-cst-dofs">
+        {#each dofLabels as dof, i}
+          <label class="pro-dof-check">
+            <input type="checkbox" bind:checked={rlDofs[i]} />
+            <span>{dof}</span>
+          </label>
+        {/each}
+      </div>
+
+    {:else if selectedKind === 'diaphragm'}
+      <div class="pro-cst-row">
+        <label>Master: <input type="text" bind:value={dMaster} placeholder="ID" class="pro-input-sm" /></label>
+        <label>{t('pro.plane')}:
+          <select bind:value={dPlane} class="pro-select-sm">
+            {#each planeOptions as p}
+              <option value={p}>{p}</option>
+            {/each}
+          </select>
+        </label>
+      </div>
+      <div class="pro-cst-row">
+        <label class="pro-label-wide">{t('pro.slaves')}: <input type="text" bind:value={dSlaves} placeholder="1, 2, 3..." class="pro-input-wide" /></label>
+      </div>
+
+    {:else if selectedKind === 'equalDof'}
+      <div class="pro-cst-row">
+        <label>Master: <input type="text" bind:value={eqMaster} placeholder="ID" class="pro-input-sm" /></label>
+        <label>{t('pro.slave')}: <input type="text" bind:value={eqSlave} placeholder="ID" class="pro-input-sm" /></label>
+      </div>
+      <div class="pro-cst-dofs">
+        {#each dofLabels as dof, i}
+          <label class="pro-dof-check">
+            <input type="checkbox" bind:checked={eqDofs[i]} />
+            <span>{dof}</span>
+          </label>
+        {/each}
+      </div>
+
+    {:else if selectedKind === 'linearMpc'}
+      <div class="pro-cst-row">
+        <label class="pro-label-wide">{t('pro.terms')}: <input type="text" bind:value={mpcTerms} placeholder="nodo:dof:coeff, ..." class="pro-input-wide" /></label>
+      </div>
+      <div class="pro-cst-row">
+        <label>RHS: <input type="text" bind:value={mpcRhs} placeholder="0" class="pro-input-sm" /></label>
+      </div>
+      <div class="pro-cst-hint">{t('pro.formatHint')}</div>
+    {/if}
+
+    <div class="pro-cst-actions">
+      <button class="pro-btn" onclick={addConstraint}>{t('pro.add')}</button>
+      <button class="pro-btn pro-btn-auto" onclick={autoDetectDiaphragms} title={t('pro.autoDetectTitle')}>
+        {t('pro.autoDetect')}
+      </button>
+    </div>
+  </div>
+
+  <div class="pro-cst-table-wrap">
+    <table class="pro-cst-table">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>{t('pro.thType')}</th>
+          <th>{t('pro.thDescription')}</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each constraints as c, i}
+          <tr>
+            <td class="col-id">{i + 1}</td>
+            <td class="col-type">{constraintTypeLabel(c.type)}</td>
+            <td class="col-desc">{constraintLabel(c)}</td>
+            <td><button class="pro-delete-btn" onclick={() => removeConstraint(i)}>×</button></td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<style>
+  .pro-cst { display: flex; flex-direction: column; height: 100%; }
+
+  .pro-cst-header {
+    padding: 8px 10px;
+    border-bottom: 1px solid #1a3050;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .pro-cst-count { font-size: 0.82rem; color: #4ecdc4; font-weight: 600; }
+
+  .pro-cst-form {
+    padding: 10px 12px;
+    border-bottom: 1px solid #1a3050;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .pro-cst-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .pro-cst-row label {
+    font-size: 0.75rem;
+    color: #888;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
+
+  .pro-label-wide {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .pro-input-sm {
+    width: 55px;
+    padding: 4px 6px;
+    background: #0f2840;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ddd;
+    font-size: 0.78rem;
+    font-family: monospace;
+  }
+
+  .pro-input-sm:focus { border-color: #1a4a7a; outline: none; }
+
+  .pro-input-wide {
+    flex: 1;
+    min-width: 100px;
+    padding: 4px 6px;
+    background: #0f2840;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ddd;
+    font-size: 0.78rem;
+    font-family: monospace;
+  }
+
+  .pro-input-wide:focus { border-color: #1a4a7a; outline: none; }
+
+  .pro-select-sm {
+    padding: 4px 6px;
+    background: #0f2840;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ccc;
+    font-size: 0.75rem;
+    cursor: pointer;
+  }
+
+  .pro-cst-dofs {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    padding: 4px 0;
+  }
+
+  .pro-dof-check {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    font-size: 0.72rem;
+    color: #aaa;
+    cursor: pointer;
+  }
+
+  .pro-dof-check input[type="checkbox"] {
+    width: 14px;
+    height: 14px;
+    accent-color: #4ecdc4;
+    cursor: pointer;
+  }
+
+  .pro-cst-hint {
+    font-size: 0.7rem;
+    color: #668;
+    font-style: italic;
+  }
+
+  .pro-cst-actions {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+
+  .pro-btn {
+    padding: 5px 12px;
+    font-size: 0.75rem;
+    color: #ccc;
+    background: #0f3460;
+    border: 1px solid #1a4a7a;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  .pro-btn:hover { background: #1a4a7a; color: #fff; }
+
+  .pro-btn-auto {
+    font-size: 0.72rem;
+    color: #4ecdc4;
+    border-color: #2a5a6a;
+  }
+
+  .pro-btn-auto:hover { background: #1a4a6a; }
+
+  .pro-btn-clear {
+    font-size: 0.68rem;
+    color: #ff6b6b;
+    border-color: #5a2a2a;
+    background: transparent;
+    padding: 4px 8px;
+  }
+
+  .pro-btn-clear:hover { background: #3a1a1a; }
+
+  .pro-cst-table-wrap { flex: 1; overflow: auto; }
+
+  .pro-cst-table { width: 100%; border-collapse: collapse; font-size: 0.78rem; }
+  .pro-cst-table thead { position: sticky; top: 0; z-index: 1; }
+  .pro-cst-table th {
+    padding: 6px 8px; text-align: left; font-size: 0.7rem; font-weight: 600;
+    color: #888; text-transform: uppercase; background: #0a1a30; border-bottom: 1px solid #1a4a7a;
+  }
+  .pro-cst-table td { padding: 5px 8px; border-bottom: 1px solid #0f2030; color: #ccc; }
+  .col-id { width: 34px; color: #666; font-family: monospace; text-align: center; }
+  .col-type { font-size: 0.72rem; color: #4ecdc4; white-space: nowrap; }
+  .col-desc { font-size: 0.72rem; color: #aaa; }
+  .pro-delete-btn { background: none; border: none; color: #555; font-size: 1rem; cursor: pointer; padding: 0; }
+  .pro-delete-btn:hover { color: #ff6b6b; }
+</style>

--- a/web/src/components/pro/ProDiagnosticsTab.svelte
+++ b/web/src/components/pro/ProDiagnosticsTab.svelte
@@ -1,0 +1,353 @@
+<script lang="ts">
+  import { modelStore, resultsStore, uiStore } from '../../lib/store';
+  import { t } from '../../lib/i18n';
+  import type { SolverDiagnostic } from '../../lib/engine/types';
+  import { checkModel } from '../../lib/engine/model-diagnostics';
+
+  type SeverityFilter = 'all' | 'error' | 'warning' | 'info';
+
+  let severityFilter = $state<SeverityFilter>('all');
+  let modelDiags = $state<SolverDiagnostic[]>([]);
+
+  const is3D = $derived(uiStore.analysisMode === '3d' || uiStore.analysisMode === 'pro');
+
+  // Auto-run model check reactively when model changes
+  const autoModelDiags = $derived.by(() => {
+    // Touch reactive dependencies so this re-runs on model changes
+    const _n = modelStore.nodes.size;
+    const _e = modelStore.elements.size;
+    const _s = modelStore.supports.size;
+    const _l = modelStore.loads.length;
+    const _m = modelStore.materials.size;
+    const _sec = modelStore.sections.size;
+    const _lc = modelStore.model.loadCases.length;
+    const _p = modelStore.model.plates?.size ?? 0;
+    const _q = modelStore.model.quads?.size ?? 0;
+    // Avoid unused var warnings
+    void(_n + _e + _s + _l + _m + _sec + _lc + _p + _q);
+
+    return checkModel({
+      nodes: modelStore.nodes,
+      elements: modelStore.elements,
+      materials: modelStore.materials,
+      sections: modelStore.sections,
+      supports: modelStore.supports,
+      loads: modelStore.loads as any,
+      loadCases: modelStore.model.loadCases,
+      plates: modelStore.model.plates,
+      quads: modelStore.model.quads,
+    });
+  });
+
+  // Merge: model checks + general diagnostics + solver diagnostics
+  const allDiagnostics = $derived.by(() => {
+    const general = is3D ? resultsStore.diagnostics3D : resultsStore.diagnostics;
+    const solver = is3D ? resultsStore.solverDiagnostics3D : resultsStore.solverDiagnostics;
+    const merged = [...autoModelDiags];
+    // Add post-solve diagnostics, deduplicating
+    for (const sd of [...general, ...solver]) {
+      const isDupe = merged.some(
+        d => d.code === sd.code && d.message === sd.message &&
+             JSON.stringify(d.elementIds) === JSON.stringify(sd.elementIds) &&
+             JSON.stringify(d.nodeIds) === JSON.stringify(sd.nodeIds)
+      );
+      if (!isDupe) merged.push(sd);
+    }
+    return merged;
+  });
+
+  // Apply severity filter
+  const diagnostics = $derived(
+    severityFilter === 'all'
+      ? allDiagnostics
+      : allDiagnostics.filter(d => d.severity === severityFilter)
+  );
+
+  const errors = $derived(allDiagnostics.filter(d => d.severity === 'error'));
+  const warnings = $derived(allDiagnostics.filter(d => d.severity === 'warning'));
+  const infos = $derived(allDiagnostics.filter(d => d.severity === 'info'));
+  const hasAny = $derived(allDiagnostics.length > 0);
+
+  const modelCount = $derived(autoModelDiags.length);
+  const solverCount = $derived(allDiagnostics.length - autoModelDiags.length);
+
+  function severityIcon(s: SolverDiagnostic['severity']): string {
+    if (s === 'error') return '\u2717';
+    if (s === 'warning') return '\u26A0';
+    return '\u2139';
+  }
+
+  function severityClass(s: SolverDiagnostic['severity']): string {
+    if (s === 'error') return 'sev-error';
+    if (s === 'warning') return 'sev-warning';
+    return 'sev-info';
+  }
+
+  function sourceLabel(s: SolverDiagnostic['source']): string {
+    return t(`diag.source.${s}`);
+  }
+
+  function codeTooltip(code: string): string {
+    const key = `diag.tooltip.${code}`;
+    const translated = t(key);
+    return translated !== key ? translated : '';
+  }
+
+  function handleClick(diag: SolverDiagnostic) {
+    if (diag.elementIds && diag.elementIds.length > 0) {
+      uiStore.selectedElements = new Set(diag.elementIds);
+      uiStore.selectedNodes = new Set();
+      window.dispatchEvent(new Event('dedaliano-zoom-to-fit'));
+    } else if (diag.nodeIds && diag.nodeIds.length > 0) {
+      uiStore.selectedNodes = new Set(diag.nodeIds);
+      uiStore.selectedElements = new Set();
+      window.dispatchEvent(new Event('dedaliano-zoom-to-fit'));
+    }
+  }
+
+  function formatDetails(details: Record<string, unknown>): string {
+    return Object.entries(details)
+      .map(([k, v]) => `${k}: ${typeof v === 'number' ? (v as number).toFixed(3) : v}`)
+      .join(' | ');
+  }
+</script>
+
+<div class="diag-panel" data-tour="diagnostics-panel">
+  <!-- Action bar -->
+  <div class="diag-action-bar">
+    <span class="diag-auto-label">
+      {t('diag.modelChecks')}: {modelCount}
+      {#if solverCount > 0}
+        &nbsp;|&nbsp;{t('diag.solverChecks')}: {solverCount}
+      {/if}
+    </span>
+  </div>
+
+  {#if !hasAny}
+    <div class="diag-empty">
+      <span class="diag-check">&#10003;</span>
+      <div>{t('diag.noIssues')}</div>
+    </div>
+  {:else}
+    <!-- Summary bar -->
+    <div class="diag-summary">
+      {#if errors.length > 0}
+        <button
+          class="diag-badge sev-error"
+          class:active={severityFilter === 'error'}
+          onclick={() => severityFilter = severityFilter === 'error' ? 'all' : 'error'}
+        >
+          {errors.length} {t('diag.errors')}
+        </button>
+      {/if}
+      {#if warnings.length > 0}
+        <button
+          class="diag-badge sev-warning"
+          class:active={severityFilter === 'warning'}
+          onclick={() => severityFilter = severityFilter === 'warning' ? 'all' : 'warning'}
+        >
+          {warnings.length} {t('diag.warnings')}
+        </button>
+      {/if}
+      {#if infos.length > 0}
+        <button
+          class="diag-badge sev-info"
+          class:active={severityFilter === 'info'}
+          onclick={() => severityFilter = severityFilter === 'info' ? 'all' : 'info'}
+        >
+          {infos.length} {t('diag.info')}
+        </button>
+      {/if}
+      {#if severityFilter !== 'all'}
+        <button
+          class="diag-badge sev-all"
+          onclick={() => severityFilter = 'all'}
+        >
+          {t('diag.showAll')}
+        </button>
+      {/if}
+    </div>
+
+    <!-- Diagnostic list -->
+    <div class="diag-list">
+      {#each diagnostics as diag}
+        {@const tooltip = codeTooltip(diag.code)}
+        <button
+          class="diag-item {severityClass(diag.severity)}"
+          onclick={() => handleClick(diag)}
+          title={tooltip || undefined}
+          data-tour="diagnostic-item"
+        >
+          <span class="diag-icon {severityClass(diag.severity)}">{severityIcon(diag.severity)}</span>
+          <span class="diag-source">{sourceLabel(diag.source)}</span>
+          <div class="diag-content">
+            <span class="diag-msg">{t(diag.message) !== diag.message ? t(diag.message) : diag.message}</span>
+            {#if tooltip}
+              <span class="diag-tooltip-text">{tooltip}</span>
+            {/if}
+          </div>
+          {#if diag.elementIds && diag.elementIds.length > 0}
+            <span class="diag-refs">{t('diag.elements')}: {diag.elementIds.join(', ')}</span>
+          {/if}
+          {#if diag.nodeIds && diag.nodeIds.length > 0}
+            <span class="diag-refs">{t('diag.nodes')}: {diag.nodeIds.join(', ')}</span>
+          {/if}
+          {#if diag.details}
+            <span class="diag-details">{formatDetails(diag.details)}</span>
+          {/if}
+        </button>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .diag-panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow-y: auto;
+  }
+
+  .diag-action-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 10px;
+    border-bottom: 1px solid #1a3050;
+    flex-shrink: 0;
+  }
+
+  .diag-auto-label {
+    font-size: 0.68rem;
+    color: #888;
+  }
+
+  .diag-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 40px 10px;
+    color: #4ecdc4;
+    font-size: 0.8rem;
+  }
+
+  .diag-check {
+    font-size: 2rem;
+    color: #4ecdc4;
+  }
+
+  .diag-summary {
+    display: flex;
+    gap: 8px;
+    padding: 8px 10px;
+    border-bottom: 1px solid #1a3050;
+    flex-shrink: 0;
+    flex-wrap: wrap;
+  }
+
+  .diag-badge {
+    padding: 4px 12px;
+    border-radius: 10px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: border-color 0.15s, opacity 0.15s;
+  }
+
+  .diag-badge:hover {
+    opacity: 0.85;
+  }
+
+  .diag-badge.active {
+    border-color: currentColor;
+  }
+
+  .diag-badge.sev-error { background: rgba(233, 69, 96, 0.2); color: #e94560; }
+  .diag-badge.sev-warning { background: rgba(240, 165, 0, 0.2); color: #f0a500; }
+  .diag-badge.sev-info { background: rgba(78, 205, 196, 0.2); color: #4ecdc4; }
+  .diag-badge.sev-all { background: rgba(255, 255, 255, 0.08); color: #888; }
+
+  .diag-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  .diag-item {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    border: none;
+    background: transparent;
+    text-align: left;
+    cursor: pointer;
+    color: #ccc;
+    font-size: 0.75rem;
+    border-bottom: 1px solid #0f2030;
+    width: 100%;
+  }
+
+  .diag-item:hover {
+    background: rgba(78, 205, 196, 0.05);
+  }
+
+  .diag-icon {
+    font-size: 0.85rem;
+    flex-shrink: 0;
+    width: 18px;
+    text-align: center;
+  }
+
+  .diag-icon.sev-error { color: #e94560; }
+  .diag-icon.sev-warning { color: #f0a500; }
+  .diag-icon.sev-info { color: #4ecdc4; }
+
+  .diag-source {
+    padding: 2px 8px;
+    border-radius: 3px;
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    background: rgba(255, 255, 255, 0.05);
+    color: #888;
+    flex-shrink: 0;
+  }
+
+  .diag-content {
+    flex: 1;
+    min-width: 100px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .diag-msg {
+    /* inherits from parent */
+  }
+
+  .diag-tooltip-text {
+    font-size: 0.65rem;
+    color: #777;
+    font-style: italic;
+  }
+
+  .diag-refs {
+    font-family: monospace;
+    font-size: 0.68rem;
+    color: #666;
+  }
+
+  .diag-details {
+    width: 100%;
+    font-family: monospace;
+    font-size: 0.65rem;
+    color: #555;
+    padding-left: 26px;
+  }
+</style>

--- a/web/src/components/pro/ProElementsTab.svelte
+++ b/web/src/components/pro/ProElementsTab.svelte
@@ -1,0 +1,497 @@
+<script lang="ts">
+  import { modelStore, uiStore } from '../../lib/store';
+  import { t } from '../../lib/i18n';
+
+  interface ElemRow {
+    id: number | null;
+    nodeI: string;
+    nodeJ: string;
+    materialId: number;
+    sectionId: number;
+    hingeI: boolean;
+    hingeJ: boolean;
+  }
+
+  let rows = $state<ElemRow[]>([]);
+  let pasteError = $state<string | null>(null);
+  let selectedRowIdx = $state<number | null>(null);
+  let drawMode = $state(false);
+  let drawNodeI = $state<number | null>(null);
+
+  // Sync rows from store on mount
+  $effect(() => {
+    const storeElems = [...modelStore.elements.values()];
+    if (storeElems.length > 0 && rows.length === 0) {
+      rows = storeElems.map(e => ({
+        id: e.id,
+        nodeI: String(e.nodeI),
+        nodeJ: String(e.nodeJ),
+        materialId: e.materialId,
+        sectionId: e.sectionId,
+        hingeI: e.hingeStart ?? false,
+        hingeJ: e.hingeEnd ?? false,
+      }));
+    }
+  });
+
+  // Listen for node clicks in draw mode
+  $effect(() => {
+    if (!drawMode) {
+      drawNodeI = null;
+      return;
+    }
+    // When a node is selected in the viewport, use it for drawing
+    if (uiStore.selectedNodes.size === 1) {
+      const nodeId = [...uiStore.selectedNodes][0];
+      if (drawNodeI === null) {
+        drawNodeI = nodeId;
+      } else if (nodeId !== drawNodeI) {
+        // Create element
+        const eid = modelStore.addElement(drawNodeI, nodeId);
+        rows = [...rows, {
+          id: eid,
+          nodeI: String(drawNodeI),
+          nodeJ: String(nodeId),
+          materialId: 1,
+          sectionId: 1,
+          hingeI: false,
+          hingeJ: false,
+        }];
+        // Chain: nodeJ becomes next nodeI
+        drawNodeI = nodeId;
+        uiStore.selectedNodes = new Set();
+      }
+    }
+  });
+
+  // Listen for element selection from viewport
+  $effect(() => {
+    if (uiStore.selectedElements.size === 1) {
+      const elemId = [...uiStore.selectedElements][0];
+      const idx = rows.findIndex(r => r.id === elemId);
+      if (idx >= 0) selectedRowIdx = idx;
+    }
+  });
+
+  function addEmptyRow() {
+    rows = [...rows, { id: null, nodeI: '', nodeJ: '', materialId: 1, sectionId: 1, hingeI: false, hingeJ: false }];
+  }
+
+  function commitRow(idx: number) {
+    const row = rows[idx];
+    const ni = parseInt(row.nodeI);
+    const nj = parseInt(row.nodeJ);
+    if (isNaN(ni) || isNaN(nj) || ni === nj) return;
+    if (!modelStore.nodes.has(ni) || !modelStore.nodes.has(nj)) return;
+
+    if (row.id === null) {
+      const eid = modelStore.addElement(ni, nj);
+      modelStore.updateElementMaterial(eid, row.materialId);
+      modelStore.updateElementSection(eid, row.sectionId);
+      if (row.hingeI) modelStore.toggleHinge(eid, 'start');
+      if (row.hingeJ) modelStore.toggleHinge(eid, 'end');
+      rows[idx] = { ...rows[idx], id: eid };
+    } else {
+      // Update existing element properties
+      const elem = modelStore.elements.get(row.id);
+      if (!elem) return;
+      modelStore.updateElementMaterial(row.id, row.materialId);
+      modelStore.updateElementSection(row.id, row.sectionId);
+      // Sync hinges
+      if ((elem.hingeStart ?? false) !== row.hingeI) modelStore.toggleHinge(row.id, 'start');
+      if ((elem.hingeEnd ?? false) !== row.hingeJ) modelStore.toggleHinge(row.id, 'end');
+    }
+  }
+
+  function deleteRow(idx: number) {
+    const row = rows[idx];
+    if (row.id !== null) modelStore.removeElement(row.id);
+    rows = rows.filter((_, i) => i !== idx);
+  }
+
+  function handleKeydown(e: KeyboardEvent, idx: number) {
+    if (e.key === 'Enter') {
+      commitRow(idx);
+      if (idx === rows.length - 1) {
+        addEmptyRow();
+        setTimeout(() => {
+          const inputs = document.querySelectorAll('.pro-elems-table input[data-col="ni"]');
+          const lastInput = inputs[inputs.length - 1] as HTMLInputElement;
+          lastInput?.focus();
+        }, 10);
+      }
+    }
+  }
+
+  function handlePaste(e: ClipboardEvent) {
+    const text = e.clipboardData?.getData('text');
+    if (!text) return;
+    if (!text.includes('\t') && !text.includes('\n')) return;
+
+    e.preventDefault();
+    pasteError = null;
+
+    const lines = text.trim().split('\n').filter(l => l.trim());
+    for (let i = 0; i < lines.length; i++) {
+      const parts = lines[i].split('\t').map(s => s.trim());
+      if (parts.length < 2) {
+        pasteError = t('pro.pasteRowError').replace('{n}', String(i + 1)).replace('{cols}', '2').replace('{names}', t('pro.thNodeI') + ', ' + t('pro.thNodeJ'));
+        return;
+      }
+      const ni = parseInt(parts[0]);
+      const nj = parseInt(parts[1]);
+      if (isNaN(ni) || isNaN(nj)) {
+        pasteError = t('pro.pasteInvalidNodeIds').replace('{n}', String(i + 1));
+        return;
+      }
+      if (!modelStore.nodes.has(ni) || !modelStore.nodes.has(nj)) {
+        pasteError = t('pro.pasteNodeNotExist').replace('{n}', String(i + 1)).replace('{ni}', String(ni)).replace('{nj}', String(nj));
+        return;
+      }
+      const eid = modelStore.addElement(ni, nj);
+      rows = [...rows, {
+        id: eid,
+        nodeI: String(ni),
+        nodeJ: String(nj),
+        materialId: 1,
+        sectionId: 1,
+        hingeI: false,
+        hingeJ: false,
+      }];
+    }
+  }
+
+  function handleRowClick(idx: number) {
+    selectedRowIdx = idx;
+    const row = rows[idx];
+    if (row.id !== null) {
+      uiStore.selectedElements = new Set([row.id]);
+      uiStore.selectedNodes = new Set();
+    }
+  }
+
+  function toggleDrawMode() {
+    drawMode = !drawMode;
+    if (drawMode) {
+      drawNodeI = null;
+      uiStore.selectedNodes = new Set();
+      uiStore.selectedElements = new Set();
+    }
+  }
+
+  // Available materials and sections
+  const materials = $derived([...modelStore.materials.values()]);
+  const sections = $derived([...modelStore.sections.values()]);
+  const elemCount = $derived(rows.filter(r => r.id !== null).length);
+</script>
+
+<div class="pro-elems">
+  <div class="pro-elems-header">
+    <span class="pro-elems-count">{t('pro.nElements').replace('{n}', String(elemCount))}</span>
+    <div class="pro-elems-actions">
+      <button class="pro-btn" onclick={addEmptyRow}>{t('pro.addElement')}</button>
+      <button class="pro-btn" class:pro-btn-active={drawMode} onclick={toggleDrawMode}>
+        {drawMode ? t('pro.stopDrawing') : t('pro.draw')}
+      </button>
+    </div>
+  </div>
+
+  {#if drawMode}
+    <div class="pro-draw-status">
+      {#if drawNodeI === null}
+        {t('pro.drawClickNodeI')}
+      {:else}
+        {@html t('pro.drawNodeISelected').replace('{id}', String(drawNodeI))}
+      {/if}
+    </div>
+  {/if}
+
+  {#if pasteError}
+    <div class="pro-paste-error">{pasteError}</div>
+  {/if}
+
+  <div class="pro-paste-hint">
+    {t('pro.pasteHintElems')}
+  </div>
+
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="pro-elems-table-wrap" onpaste={handlePaste}>
+    <table class="pro-elems-table">
+      <thead>
+        <tr>
+          <th class="col-id">ID</th>
+          <th class="col-node">{t('pro.thNodeI')}</th>
+          <th class="col-node">{t('pro.thNodeJ')}</th>
+          <th class="col-mat">{t('pro.thMaterial')}</th>
+          <th class="col-sec">{t('pro.thSection')}</th>
+          <th class="col-hinge">{t('pro.thHingeI')}</th>
+          <th class="col-hinge">{t('pro.thHingeJ')}</th>
+          <th class="col-actions"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each rows as row, idx}
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <tr
+            class:selected={selectedRowIdx === idx}
+            class:unsaved={row.id === null}
+            onclick={() => handleRowClick(idx)}
+          >
+            <td class="col-id">{row.id ?? '—'}</td>
+            <td class="col-node">
+              <input type="text" data-col="ni" bind:value={row.nodeI}
+                onkeydown={(e) => handleKeydown(e, idx)}
+                onblur={() => commitRow(idx)} placeholder="—" />
+            </td>
+            <td class="col-node">
+              <input type="text" data-col="nj" bind:value={row.nodeJ}
+                onkeydown={(e) => handleKeydown(e, idx)}
+                onblur={() => commitRow(idx)} placeholder="—" />
+            </td>
+            <td class="col-mat">
+              <select value={String(row.materialId)} onchange={(e) => {
+                row.materialId = parseInt(e.currentTarget.value);
+                if (row.id !== null) commitRow(idx);
+              }}>
+                {#each materials as m}
+                  <option value={String(m.id)}>{m.name}</option>
+                {/each}
+              </select>
+            </td>
+            <td class="col-sec">
+              <select value={String(row.sectionId)} onchange={(e) => {
+                row.sectionId = parseInt(e.currentTarget.value);
+                if (row.id !== null) commitRow(idx);
+              }}>
+                {#each sections as s}
+                  <option value={String(s.id)}>{s.name}</option>
+                {/each}
+              </select>
+            </td>
+            <td class="col-hinge">
+              <button class="hinge-btn" class:hinged={row.hingeI} onclick={() => {
+                row.hingeI = !row.hingeI;
+                if (row.id !== null) commitRow(idx);
+              }}>{row.hingeI ? t('pro.hingeArt') : t('pro.hingeEmp')}</button>
+            </td>
+            <td class="col-hinge">
+              <button class="hinge-btn" class:hinged={row.hingeJ} onclick={() => {
+                row.hingeJ = !row.hingeJ;
+                if (row.id !== null) commitRow(idx);
+              }}>{row.hingeJ ? t('pro.hingeArt') : t('pro.hingeEmp')}</button>
+            </td>
+            <td class="col-actions">
+              <button class="pro-delete-btn" onclick={() => deleteRow(idx)}>×</button>
+            </td>
+          </tr>
+        {/each}
+        {#if rows.length === 0}
+          <tr>
+            <td colspan="8" class="pro-empty">{t('pro.emptyElements')}</td>
+          </tr>
+        {/if}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<style>
+  .pro-elems {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .pro-elems-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 10px;
+    border-bottom: 1px solid #1a3050;
+    flex-shrink: 0;
+  }
+
+  .pro-elems-count {
+    font-size: 0.82rem;
+    color: #4ecdc4;
+    font-weight: 600;
+  }
+
+  .pro-elems-actions {
+    display: flex;
+    gap: 6px;
+  }
+
+  .pro-btn {
+    padding: 5px 12px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: #ccc;
+    background: #0f3460;
+    border: 1px solid #1a4a7a;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  .pro-btn:hover { background: #1a4a7a; color: #fff; }
+
+  .pro-btn-active {
+    background: #e94560 !important;
+    border-color: #ff6b6b !important;
+    color: #fff !important;
+  }
+
+  .pro-draw-status {
+    padding: 8px 12px;
+    font-size: 0.78rem;
+    color: #4ecdc4;
+    background: rgba(78, 205, 196, 0.08);
+    border-bottom: 1px solid #1a3050;
+  }
+
+  .pro-draw-status strong {
+    color: #fff;
+  }
+
+  .pro-paste-error {
+    padding: 4px 10px;
+    font-size: 0.7rem;
+    color: #ff8a9e;
+    background: rgba(233, 69, 96, 0.1);
+    border-bottom: 1px solid #5a2030;
+  }
+
+  .pro-paste-hint {
+    padding: 6px 12px;
+    font-size: 0.72rem;
+    color: #668;
+    font-style: italic;
+    border-bottom: 1px solid #1a2540;
+    flex-shrink: 0;
+  }
+
+  .pro-elems-table-wrap {
+    flex: 1;
+    overflow: auto;
+  }
+
+  .pro-elems-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.78rem;
+    table-layout: fixed;
+  }
+
+  .pro-elems-table thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+
+  .pro-elems-table th {
+    padding: 6px 4px;
+    text-align: left;
+    font-size: 0.68rem;
+    font-weight: 600;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    background: #0a1a30;
+    border-bottom: 1px solid #1a4a7a;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .pro-elems-table td {
+    padding: 3px 3px;
+    border-bottom: 1px solid #0f2030;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .pro-elems-table tr:hover { background: rgba(78, 205, 196, 0.04); }
+  .pro-elems-table tr.selected { background: rgba(78, 205, 196, 0.1); }
+  .pro-elems-table tr.unsaved td { opacity: 0.6; }
+
+  .col-id {
+    width: 32px;
+    color: #666;
+    font-family: monospace;
+    font-size: 0.75rem;
+    text-align: center;
+  }
+
+  .col-node { width: 50px; }
+  .col-node input {
+    width: 100%;
+    padding: 4px 5px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    color: #ddd;
+    font-size: 0.78rem;
+    font-family: monospace;
+  }
+  .col-node input:focus {
+    background: #0f2840;
+    border-color: #1a4a7a;
+    outline: none;
+  }
+
+  .col-mat, .col-sec { width: auto; }
+  .col-mat select, .col-sec select {
+    width: 100%;
+    padding: 3px 3px;
+    background: #0f2840;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    color: #ccc;
+    font-size: 0.72rem;
+    cursor: pointer;
+  }
+  .col-mat select:focus, .col-sec select:focus {
+    border-color: #1a4a7a;
+    outline: none;
+  }
+
+  .col-hinge { width: 40px; text-align: center; }
+
+  .hinge-btn {
+    padding: 3px 6px;
+    font-size: 0.68rem;
+    font-weight: 600;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    cursor: pointer;
+    background: #0f2840;
+    color: #888;
+    min-width: 34px;
+  }
+
+  .hinge-btn.hinged {
+    background: #4a3010;
+    border-color: #8a6020;
+    color: #f0a500;
+  }
+
+  .col-actions { width: 20px; text-align: center; }
+
+  .pro-delete-btn {
+    background: none;
+    border: none;
+    color: #555;
+    font-size: 1rem;
+    cursor: pointer;
+    padding: 0;
+    line-height: 1;
+  }
+  .pro-delete-btn:hover { color: #ff6b6b; }
+
+  .pro-empty {
+    text-align: center;
+    color: #555;
+    font-style: italic;
+    padding: 20px 10px !important;
+  }
+</style>

--- a/web/src/components/pro/ProLoadsTab.svelte
+++ b/web/src/components/pro/ProLoadsTab.svelte
@@ -1,0 +1,628 @@
+<script lang="ts">
+  import { modelStore, uiStore, resultsStore } from '../../lib/store';
+  import type { LoadCaseType } from '../../lib/store/model.svelte';
+  import { t } from '../../lib/i18n';
+  import ProAutoLoadsDialog from './ProAutoLoadsDialog.svelte';
+
+  let showAutoLoadsDialog = $state(false);
+
+  type LoadKind = 'nodal' | 'distributed' | 'point' | 'surface' | 'thermalQuad';
+
+  let loadKind = $state<LoadKind>('nodal');
+  let activeCaseId = $state(1); // default to first load case
+
+  // Load visibility toggle per case
+  function isCaseVisible(caseId: number): boolean {
+    const vis = uiStore.visibleLoadCases3D;
+    return vis === null || vis.includes(caseId);
+  }
+
+  function toggleCaseVisibility(caseId: number) {
+    const current = uiStore.visibleLoadCases3D;
+    if (current === null) {
+      // Currently showing all → hide this one (show all except this)
+      uiStore.visibleLoadCases3D = loadCases.map(lc => lc.id).filter(id => id !== caseId);
+    } else {
+      if (current.includes(caseId)) {
+        const next = current.filter(id => id !== caseId);
+        uiStore.visibleLoadCases3D = next;
+      } else {
+        const next = [...current, caseId];
+        // If all cases are visible, reset to null (show all)
+        uiStore.visibleLoadCases3D = next.length >= loadCases.length ? null : next;
+      }
+    }
+    // Ensure loads are shown
+    uiStore.showLoads3D = true;
+  }
+
+  function showAllCases() {
+    uiStore.visibleLoadCases3D = null;
+    uiStore.showLoads3D = true;
+    uiStore.hideLoadsWithDiagram = false;
+  }
+
+  function hideAllCases() {
+    uiStore.visibleLoadCases3D = [];
+  }
+
+  // Nodal load fields
+  let nlNodeId = $state('');
+  let nlFx = $state('');
+  let nlFy = $state('');
+  let nlFz = $state('');
+  let nlMx = $state('');
+  let nlMy = $state('');
+  let nlMz = $state('');
+
+  // Distributed load fields
+  let dlElemId = $state('');
+  let dlQyI = $state('');
+  let dlQyJ = $state('');
+  let dlQzI = $state('');
+  let dlQzJ = $state('');
+
+  // Point load on element fields
+  let plElemId = $state('');
+  let plA = $state('');
+  let plPy = $state('');
+  let plPz = $state('');
+
+  // Surface load fields
+  let slQuadId = $state('');
+  let slQ = $state('');
+
+  // Thermal quad load fields
+  let tqQuadId = $state('');
+  let tqDtUniform = $state('');
+  let tqDtGradient = $state('');
+
+  // New load case fields
+  let newCaseName = $state('');
+  let newCaseType = $state<LoadCaseType>('');
+
+  // New combination fields
+  let newComboName = $state('');
+
+  const loads = $derived(modelStore.loads);
+  const loadCases = $derived(modelStore.model.loadCases);
+  const combinations = $derived(modelStore.model.combinations);
+
+  // Filter loads by active case
+  const caseLoads = $derived(loads.filter(l => (l.data.caseId ?? 1) === activeCaseId));
+  const nodalLoads = $derived(caseLoads.filter(l => l.type === 'nodal3d'));
+  const distLoads = $derived(caseLoads.filter(l => l.type === 'distributed3d'));
+  const pointLoads = $derived(caseLoads.filter(l => l.type === 'pointOnElement3d'));
+  const surfaceLoads = $derived(caseLoads.filter(l => l.type === 'surface3d'));
+  const thermalQuadLoads = $derived(caseLoads.filter(l => l.type === 'thermalQuad3d'));
+
+  const caseTypeLabels = $derived<Record<string, string>>({
+    'D': t('pro.caseTypeD'),
+    'L': t('pro.caseTypeL'),
+    'W': t('pro.caseTypeW'),
+    'E': t('pro.caseTypeE'),
+    'S': t('pro.caseTypeS'),
+    'T': t('pro.caseTypeT'),
+    '': t('pro.caseTypeOther'),
+  });
+
+  function addNodalLoad() {
+    const nodeId = parseInt(nlNodeId);
+    if (isNaN(nodeId) || !modelStore.nodes.has(nodeId)) return;
+    const fx = parseFloat(nlFx) || 0;
+    const fy = parseFloat(nlFy) || 0;
+    const fz = parseFloat(nlFz) || 0;
+    const mx = parseFloat(nlMx) || 0;
+    const my = parseFloat(nlMy) || 0;
+    const mz = parseFloat(nlMz) || 0;
+    if (fx === 0 && fy === 0 && fz === 0 && mx === 0 && my === 0 && mz === 0) return;
+    modelStore.addNodalLoad3D(nodeId, fx, fy, fz, mx, my, mz, activeCaseId);
+    nlNodeId = ''; nlFx = ''; nlFy = ''; nlFz = ''; nlMx = ''; nlMy = ''; nlMz = '';
+  }
+
+  function addDistLoad() {
+    const elemId = parseInt(dlElemId);
+    if (isNaN(elemId) || !modelStore.elements.has(elemId)) return;
+    const qyI = parseFloat(dlQyI) || 0;
+    const qyJ = parseFloat(dlQyJ) || qyI;
+    const qzI = parseFloat(dlQzI) || 0;
+    const qzJ = parseFloat(dlQzJ) || qzI;
+    if (qyI === 0 && qyJ === 0 && qzI === 0 && qzJ === 0) return;
+    modelStore.addDistributedLoad3D(elemId, qyI, qyJ, qzI, qzJ, undefined, undefined, activeCaseId);
+    dlElemId = ''; dlQyI = ''; dlQyJ = ''; dlQzI = ''; dlQzJ = '';
+  }
+
+  function addPointLoad() {
+    const elemId = parseInt(plElemId);
+    if (isNaN(elemId) || !modelStore.elements.has(elemId)) return;
+    const a = parseFloat(plA);
+    const py = parseFloat(plPy) || 0;
+    const pz = parseFloat(plPz) || 0;
+    if (isNaN(a) || a < 0 || (py === 0 && pz === 0)) return;
+    modelStore.addPointLoadOnElement3D(elemId, a, py, pz, activeCaseId);
+    plElemId = ''; plA = ''; plPy = ''; plPz = '';
+  }
+
+  function addSurfaceLoad() {
+    const quadId = parseInt(slQuadId);
+    if (isNaN(quadId)) return;
+    if (!modelStore.model.quads.has(quadId)) {
+      uiStore.toast(t('pro.noQuadFound'), 'error');
+      return;
+    }
+    const q = parseFloat(slQ) || 0;
+    if (q === 0) return;
+    modelStore.addSurfaceLoad3D(quadId, q, activeCaseId);
+    slQuadId = ''; slQ = '';
+  }
+
+  function addThermalQuadLoad() {
+    const quadId = parseInt(tqQuadId);
+    if (isNaN(quadId) || !modelStore.model.quads.has(quadId)) return;
+    const dtU = parseFloat(tqDtUniform) || 0;
+    const dtG = parseFloat(tqDtGradient) || 0;
+    if (dtU === 0 && dtG === 0) return;
+    modelStore.addThermalLoadQuad3D(quadId, dtU, dtG, activeCaseId);
+    tqQuadId = ''; tqDtUniform = ''; tqDtGradient = '';
+  }
+
+  function removeLoad(loadId: number) {
+    modelStore.removeLoad(loadId);
+  }
+
+  function addLoadCase() {
+    if (!newCaseName.trim()) return;
+    const id = modelStore.addLoadCase(newCaseName.trim(), newCaseType);
+    activeCaseId = id;
+    newCaseName = '';
+    newCaseType = '';
+  }
+
+  function removeLoadCase(id: number) {
+    modelStore.removeLoadCase(id);
+    if (activeCaseId === id) {
+      activeCaseId = loadCases[0]?.id ?? 1;
+    }
+  }
+
+  function addCombination() {
+    if (!newComboName.trim()) return;
+    // Default: all cases ×1.0
+    const factors = loadCases.map(lc => ({ caseId: lc.id, factor: 1.0 }));
+    modelStore.addCombination(newComboName.trim(), factors);
+    newComboName = '';
+  }
+
+  function removeCombination(id: number) {
+    modelStore.removeCombination(id);
+  }
+
+  function updateComboFactor(comboId: number, caseId: number, value: string) {
+    const f = parseFloat(value);
+    if (isNaN(f)) return;
+    const combo = combinations.find(c => c.id === comboId);
+    if (!combo) return;
+    const existing = combo.factors.find(ff => ff.caseId === caseId);
+    if (existing) {
+      existing.factor = f;
+    } else {
+      combo.factors.push({ caseId, factor: f });
+    }
+    // Trigger reactivity
+    modelStore.updateCombination(comboId, combo.name, combo.factors);
+  }
+
+  function fmtNum(n: number): string {
+    if (n === 0) return '0';
+    return n.toFixed(2);
+  }
+</script>
+
+<div class="pro-loads">
+  <!-- Auto-generate button -->
+  <div class="pro-autogen-bar">
+    <button class="pro-btn-autogen" onclick={() => showAutoLoadsDialog = true}>{t('autoLoad.autoGenBtn')}</button>
+  </div>
+
+  <ProAutoLoadsDialog open={showAutoLoadsDialog} onclose={() => showAutoLoadsDialog = false} />
+
+  <!-- Load visibility bar -->
+  <div class="pro-vis-bar">
+    <label class="pro-vis-toggle">
+      <input type="checkbox" checked={uiStore.showLoads3D} onchange={(e) => { uiStore.showLoads3D = e.currentTarget.checked; if (e.currentTarget.checked) uiStore.hideLoadsWithDiagram = false; }} />
+      {t('pro.showLoads')}
+    </label>
+    {#if !uiStore.showLoads3D}
+      <span class="pro-vis-status pro-vis-off">OFF</span>
+    {:else if uiStore.hideLoadsWithDiagram && resultsStore.diagramType !== 'none'}
+      <button class="pro-vis-btn pro-vis-btn-warn" onclick={() => { uiStore.hideLoadsWithDiagram = false; uiStore.showLoads3D = true; }}>
+        {t('pro.loadsHiddenByDiagram')}
+      </button>
+    {:else}
+      <span class="pro-vis-status pro-vis-on">{loads.length} cargas</span>
+    {/if}
+    <button class="pro-vis-btn" onclick={showAllCases} title={t('pro.showAll')}>{t('pro.showAll')}</button>
+    <button class="pro-vis-btn" onclick={hideAllCases} title={t('pro.hideAll')}>{t('pro.hideAll')}</button>
+  </div>
+
+  <!-- Load Cases Management -->
+  <div class="pro-cases-section">
+    <div class="pro-cases-header">
+      <span class="pro-section-label">{t('pro.loadCases')}</span>
+    </div>
+    <div class="pro-cases-tabs">
+      {#each loadCases as lc}
+        <button
+          class="pro-case-tab"
+          class:active={activeCaseId === lc.id}
+          onclick={() => activeCaseId = lc.id}
+          title={caseTypeLabels[lc.type] ?? lc.type}
+        >
+          <span class="case-type-dot" class:type-d={lc.type === 'D'} class:type-l={lc.type === 'L'} class:type-w={lc.type === 'W'} class:type-e={lc.type === 'E'}></span>
+          {lc.name}
+          <span class="case-eye" class:visible={isCaseVisible(lc.id)} role="button" tabindex="-1" onclick={(e) => { e.stopPropagation(); toggleCaseVisibility(lc.id); }} onkeydown={() => {}} title={isCaseVisible(lc.id) ? t('pro.hideCase') : t('pro.showCase')}>
+            {isCaseVisible(lc.id) ? '👁' : '·'}
+          </span>
+          {#if loadCases.length > 1}
+            <span class="case-x" role="button" tabindex="-1" onclick={(e) => { e.stopPropagation(); removeLoadCase(lc.id); }} onkeydown={() => {}}>×</span>
+          {/if}
+        </button>
+      {/each}
+    </div>
+    <div class="pro-case-add">
+      <input type="text" bind:value={newCaseName} placeholder={t('pro.newCase')} class="inp-case" />
+      <select bind:value={newCaseType} class="pro-sel-sm">
+        <option value="D">D</option>
+        <option value="L">L</option>
+        <option value="W">W</option>
+        <option value="E">E</option>
+        <option value="S">S</option>
+        <option value="">{t('pro.caseTypeOther')}</option>
+      </select>
+      <button class="pro-btn-sm" onclick={addLoadCase}>+</button>
+    </div>
+  </div>
+
+  <!-- Combinations -->
+  <div class="pro-combos-section">
+    <details>
+      <summary class="pro-section-label">{t('pro.combos')} ({combinations.length})</summary>
+      <div class="pro-combos-list">
+        {#each combinations as combo}
+          <div class="pro-combo-row">
+            <span class="combo-name">{combo.name}</span>
+            <div class="combo-factors">
+              {#each loadCases as lc}
+                {@const factor = combo.factors.find(f => f.caseId === lc.id)?.factor ?? 0}
+                <label class="combo-factor-label">
+                  {lc.name}:
+                  <input type="text" value={factor} class="inp-factor"
+                    onchange={(e) => updateComboFactor(combo.id, lc.id, e.currentTarget.value)} />
+                </label>
+              {/each}
+            </div>
+            <button class="pro-delete-btn" onclick={() => removeCombination(combo.id)}>×</button>
+          </div>
+        {/each}
+        <div class="pro-combo-add">
+          <input type="text" bind:value={newComboName} placeholder={t('pro.comboPlaceholder')} class="inp-case" />
+          <button class="pro-btn-sm" onclick={addCombination}>{t('pro.addCombo')}</button>
+        </div>
+      </div>
+    </details>
+  </div>
+
+  <div class="pro-loads-header">
+    <span class="pro-loads-count">{t('pro.loadsInCase').replace('{n}', String(caseLoads.length)).replace('{name}', loadCases.find(c => c.id === activeCaseId)?.name ?? '?').replace('{total}', String(loads.length))}</span>
+  </div>
+
+  <!-- Load kind selector -->
+  <div class="pro-loads-form">
+    <div class="pro-kind-row">
+      <button class="pro-type-btn" class:active={loadKind === 'nodal'} onclick={() => loadKind = 'nodal'}>{t('pro.nodal')}</button>
+      <button class="pro-type-btn" class:active={loadKind === 'distributed'} onclick={() => loadKind = 'distributed'}>{t('pro.distributed')}</button>
+      <button class="pro-type-btn" class:active={loadKind === 'point'} onclick={() => loadKind = 'point'}>{t('pro.pointLoad')}</button>
+      <button class="pro-type-btn" class:active={loadKind === 'surface'} onclick={() => loadKind = 'surface'}>{t('pro.surfaceLoad')}</button>
+      <button class="pro-type-btn" class:active={loadKind === 'thermalQuad'} onclick={() => loadKind = 'thermalQuad'}>{t('pro.thermalQuadLoad')}</button>
+    </div>
+
+    {#if loadKind === 'nodal'}
+      <div class="pro-load-inputs">
+        <div class="pro-load-row">
+          <label>Nodo: <input type="text" bind:value={nlNodeId} placeholder="ID" class="inp-sm" /></label>
+        </div>
+        <div class="pro-load-row">
+          <label>Fx: <input type="text" bind:value={nlFx} placeholder="kN" class="inp-num" /></label>
+          <label>Fy: <input type="text" bind:value={nlFy} placeholder="kN" class="inp-num" /></label>
+          <label>Fz: <input type="text" bind:value={nlFz} placeholder="kN" class="inp-num" /></label>
+        </div>
+        <div class="pro-load-row">
+          <label>Mx: <input type="text" bind:value={nlMx} placeholder="kN·m" class="inp-num" /></label>
+          <label>My: <input type="text" bind:value={nlMy} placeholder="kN·m" class="inp-num" /></label>
+          <label>Mz: <input type="text" bind:value={nlMz} placeholder="kN·m" class="inp-num" /></label>
+        </div>
+        <button class="pro-btn" onclick={addNodalLoad}>{t('pro.addNodalLoad')}</button>
+      </div>
+    {:else if loadKind === 'distributed'}
+      <div class="pro-load-inputs">
+        <div class="pro-load-row">
+          <label>Elemento: <input type="text" bind:value={dlElemId} placeholder="ID" class="inp-sm" /></label>
+        </div>
+        <div class="pro-load-row">
+          <label>qY_i: <input type="text" bind:value={dlQyI} placeholder="kN/m" class="inp-num" /></label>
+          <label>qY_j: <input type="text" bind:value={dlQyJ} placeholder="kN/m" class="inp-num" /></label>
+        </div>
+        <div class="pro-load-row">
+          <label>qZ_i: <input type="text" bind:value={dlQzI} placeholder="kN/m" class="inp-num" /></label>
+          <label>qZ_j: <input type="text" bind:value={dlQzJ} placeholder="kN/m" class="inp-num" /></label>
+        </div>
+        <button class="pro-btn" onclick={addDistLoad}>{t('pro.addDistLoad')}</button>
+      </div>
+    {:else if loadKind === 'point'}
+      <div class="pro-load-inputs">
+        <div class="pro-load-row">
+          <label>Elemento: <input type="text" bind:value={plElemId} placeholder="ID" class="inp-sm" /></label>
+          <label>a (m): <input type="text" bind:value={plA} placeholder="dist." class="inp-num" /></label>
+        </div>
+        <div class="pro-load-row">
+          <label>Py: <input type="text" bind:value={plPy} placeholder="kN" class="inp-num" /></label>
+          <label>Pz: <input type="text" bind:value={plPz} placeholder="kN" class="inp-num" /></label>
+        </div>
+        <button class="pro-btn" onclick={addPointLoad}>{t('pro.addPointLoad')}</button>
+      </div>
+    {:else if loadKind === 'surface'}
+      <div class="pro-load-inputs">
+        <div class="pro-load-row">
+          <label>{t('pro.slab')}: <input type="text" bind:value={slQuadId} placeholder="ID" class="inp-sm" /></label>
+          <label>q: <input type="text" bind:value={slQ} placeholder="kN/m²" class="inp-num" /></label>
+        </div>
+        <button class="pro-btn" onclick={addSurfaceLoad}>{t('pro.addSurfaceLoad')}</button>
+      </div>
+    {:else}
+      <div class="pro-load-inputs">
+        <div class="pro-load-row">
+          <label>{t('pro.slab')}: <input type="text" bind:value={tqQuadId} placeholder="ID" class="inp-sm" /></label>
+        </div>
+        <div class="pro-load-row">
+          <label>{t('pro.dtUniform')}: <input type="text" bind:value={tqDtUniform} placeholder="°C" class="inp-num" /></label>
+          <label>{t('pro.dtGradient')}: <input type="text" bind:value={tqDtGradient} placeholder="°C" class="inp-num" /></label>
+        </div>
+        <button class="pro-btn" onclick={addThermalQuadLoad}>{t('pro.addThermalQuadLoad')}</button>
+      </div>
+    {/if}
+  </div>
+
+  <!-- Loads table for active case -->
+  <div class="pro-loads-table-wrap">
+    {#if nodalLoads.length > 0}
+      <div class="pro-load-section-title">{t('pro.nodalLoads')}</div>
+      <table class="pro-loads-table">
+        <thead><tr><th>ID</th><th>Nodo</th><th>Fx</th><th>Fy</th><th>Fz</th><th>Mx</th><th>My</th><th>Mz</th><th></th></tr></thead>
+        <tbody>
+          {#each nodalLoads as l}
+            <tr>
+              <td class="col-id">{l.data.id}</td>
+              <td class="col-num">{l.data.nodeId}</td>
+              <td class="col-num">{fmtNum(l.data.fx)}</td>
+              <td class="col-num">{fmtNum(l.data.fy)}</td>
+              <td class="col-num">{fmtNum(l.data.fz ?? 0)}</td>
+              <td class="col-num">{fmtNum(l.data.mx ?? 0)}</td>
+              <td class="col-num">{fmtNum(l.data.my ?? 0)}</td>
+              <td class="col-num">{fmtNum(l.data.mz ?? 0)}</td>
+              <td><button class="pro-delete-btn" onclick={() => removeLoad(l.data.id)}>×</button></td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+
+    {#if distLoads.length > 0}
+      <div class="pro-load-section-title">{t('pro.distLoads')}</div>
+      <table class="pro-loads-table">
+        <thead><tr><th>ID</th><th>Elem</th><th>qY_i</th><th>qY_j</th><th>qZ_i</th><th>qZ_j</th><th></th></tr></thead>
+        <tbody>
+          {#each distLoads as l}
+            <tr>
+              <td class="col-id">{l.data.id}</td>
+              <td class="col-num">{l.data.elementId}</td>
+              <td class="col-num">{fmtNum(l.data.qYI ?? 0)}</td>
+              <td class="col-num">{fmtNum(l.data.qYJ ?? 0)}</td>
+              <td class="col-num">{fmtNum(l.data.qZI ?? 0)}</td>
+              <td class="col-num">{fmtNum(l.data.qZJ ?? 0)}</td>
+              <td><button class="pro-delete-btn" onclick={() => removeLoad(l.data.id)}>×</button></td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+
+    {#if pointLoads.length > 0}
+      <div class="pro-load-section-title">{t('pro.pointLoads')}</div>
+      <table class="pro-loads-table">
+        <thead><tr><th>ID</th><th>Elem</th><th>a (m)</th><th>Py</th><th>Pz</th><th></th></tr></thead>
+        <tbody>
+          {#each pointLoads as l}
+            <tr>
+              <td class="col-id">{l.data.id}</td>
+              <td class="col-num">{l.data.elementId}</td>
+              <td class="col-num">{fmtNum(l.data.a)}</td>
+              <td class="col-num">{fmtNum(l.data.py ?? 0)}</td>
+              <td class="col-num">{fmtNum(l.data.pz ?? 0)}</td>
+              <td><button class="pro-delete-btn" onclick={() => removeLoad(l.data.id)}>×</button></td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+
+    {#if surfaceLoads.length > 0}
+      <div class="pro-load-section-title">{t('pro.surfaceLoads')}</div>
+      <table class="pro-loads-table">
+        <thead><tr><th>ID</th><th>{t('pro.slab')}</th><th>q (kN/m²)</th><th></th></tr></thead>
+        <tbody>
+          {#each surfaceLoads as l}
+            <tr>
+              <td class="col-id">{l.data.id}</td>
+              <td class="col-num">{l.data.quadId}</td>
+              <td class="col-num">{fmtNum(l.data.q)}</td>
+              <td><button class="pro-delete-btn" onclick={() => removeLoad(l.data.id)}>×</button></td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+
+    {#if thermalQuadLoads.length > 0}
+      <div class="pro-load-section-title">{t('pro.thermalQuadLoads')}</div>
+      <table class="pro-loads-table">
+        <thead><tr><th>ID</th><th>{t('pro.slab')}</th><th>{t('pro.dtUniform')}</th><th>{t('pro.dtGradient')}</th><th></th></tr></thead>
+        <tbody>
+          {#each thermalQuadLoads as l}
+            <tr>
+              <td class="col-id">{l.data.id}</td>
+              <td class="col-num">{l.data.quadId}</td>
+              <td class="col-num">{fmtNum(l.data.dtUniform)}</td>
+              <td class="col-num">{fmtNum(l.data.dtGradient)}</td>
+              <td><button class="pro-delete-btn" onclick={() => removeLoad(l.data.id)}>x</button></td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+
+    {#if caseLoads.length === 0}
+      <div class="pro-empty">{t('pro.noLoads')}</div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .pro-loads { display: flex; flex-direction: column; }
+  .pro-vis-bar {
+    display: flex; align-items: center; gap: 8px; padding: 6px 10px;
+    border-bottom: 1px solid #1a3050; background: #0a1a30;
+  }
+  .pro-vis-toggle {
+    display: flex; align-items: center; gap: 4px;
+    font-size: 0.72rem; color: #aaa; cursor: pointer; margin-right: auto;
+  }
+  .pro-vis-toggle input { accent-color: #4ecdc4; cursor: pointer; }
+  .pro-vis-btn {
+    padding: 2px 8px; font-size: 0.65rem; color: #888;
+    background: transparent; border: 1px solid #1a3050; border-radius: 3px; cursor: pointer;
+  }
+  .pro-vis-btn:hover { color: #ccc; border-color: #4ecdc4; }
+  .pro-vis-status { font-size: 0.62rem; font-weight: 600; }
+  .pro-vis-on { color: #4ecdc4; }
+  .pro-vis-off { color: #e94560; }
+  .pro-vis-btn-warn {
+    color: #f0a500; border-color: #5a4a2a; font-weight: 600;
+    animation: pulse-warn 1.5s ease-in-out infinite;
+  }
+  @keyframes pulse-warn { 0%, 100% { opacity: 0.7; } 50% { opacity: 1; } }
+  .pro-autogen-bar { padding: 8px 10px; border-bottom: 1px solid #1a3050; }
+  .pro-btn-autogen {
+    width: 100%; padding: 7px 12px; font-size: 0.75rem; font-weight: 600;
+    color: #1a1a2e; background: #4ecdc4; border: none; border-radius: 5px;
+    cursor: pointer; transition: background 0.15s;
+  }
+  .pro-btn-autogen:hover { background: #3dbdb4; }
+
+  /* Load Cases */
+  .pro-cases-section { border-bottom: 1px solid #1a3050; }
+  .pro-cases-header { padding: 8px 12px; }
+  .pro-section-label { font-size: 0.78rem; color: #4ecdc4; font-weight: 600; cursor: pointer; }
+
+  .pro-cases-tabs {
+    display: flex; flex-wrap: wrap; gap: 4px; padding: 0 10px 8px;
+  }
+  .pro-case-tab {
+    padding: 5px 12px; font-size: 0.72rem; color: #888; background: #0f2840;
+    border: 1px solid #1a3050; border-radius: 4px; cursor: pointer;
+    display: flex; align-items: center; gap: 5px;
+  }
+  .pro-case-tab:hover { color: #ccc; background: #1a3860; }
+  .pro-case-tab.active { color: #fff; background: #1a4a7a; border-color: #4ecdc4; }
+  .case-eye {
+    background: none; border: none; font-size: 0.7rem; cursor: pointer;
+    padding: 0 2px; line-height: 1; opacity: 0.4; transition: opacity 0.15s;
+  }
+  .case-eye.visible { opacity: 0.9; }
+  .case-eye:hover { opacity: 1; }
+  .case-x { background: none; border: none; color: #555; font-size: 0.8rem; cursor: pointer; padding: 0 0 0 4px; line-height: 1; }
+  .case-x:hover { color: #ff6b6b; }
+
+  .case-type-dot { width: 6px; height: 6px; border-radius: 50%; background: #555; flex-shrink: 0; }
+  .case-type-dot.type-d { background: #4ecdc4; }
+  .case-type-dot.type-l { background: #f0a500; }
+  .case-type-dot.type-w { background: #6bbaff; }
+  .case-type-dot.type-e { background: #e94560; }
+
+  .pro-case-add {
+    display: flex; gap: 6px; padding: 6px 10px 8px; align-items: center;
+  }
+  .inp-case {
+    width: 110px; padding: 4px 6px; background: #0f2840; border: 1px solid #1a3050;
+    border-radius: 3px; color: #ddd; font-size: 0.72rem;
+  }
+  .inp-case:focus { border-color: #1a4a7a; outline: none; }
+  .pro-sel-sm {
+    padding: 4px 5px; background: #0f2840; border: 1px solid #1a3050;
+    border-radius: 3px; color: #ccc; font-size: 0.72rem; cursor: pointer;
+  }
+  .pro-btn-sm {
+    padding: 4px 10px; font-size: 0.72rem; color: #4ecdc4; background: #0f3460;
+    border: 1px solid #1a4a7a; border-radius: 4px; cursor: pointer;
+  }
+  .pro-btn-sm:hover { background: #1a4a7a; color: #fff; }
+
+  /* Combinations */
+  .pro-combos-section { border-bottom: 1px solid #1a3050; padding: 6px 10px; }
+  .pro-combos-list { padding: 6px 0; display: flex; flex-direction: column; gap: 6px; }
+  .pro-combo-row {
+    display: flex; align-items: center; gap: 8px; padding: 4px 0;
+    border-bottom: 1px solid #0f2030; flex-wrap: wrap;
+  }
+  .combo-name { font-size: 0.72rem; color: #ccc; font-weight: 500; min-width: 90px; }
+  .combo-factors { display: flex; flex-wrap: wrap; gap: 6px; }
+  .combo-factor-label { font-size: 0.68rem; color: #888; display: flex; align-items: center; gap: 3px; }
+  .inp-factor {
+    width: 40px; padding: 3px 4px; background: #0f2840; border: 1px solid #1a3050;
+    border-radius: 3px; color: #ddd; font-size: 0.72rem; font-family: monospace; text-align: center;
+  }
+  .inp-factor:focus { border-color: #1a4a7a; outline: none; }
+  .pro-combo-add { display: flex; gap: 6px; align-items: center; padding-top: 6px; }
+
+  .pro-loads-header { padding: 8px 12px; border-bottom: 1px solid #1a3050; }
+  .pro-loads-count { font-size: 0.78rem; color: #4ecdc4; font-weight: 600; }
+
+  .pro-loads-form { padding: 10px 12px; border-bottom: 1px solid #1a3050; }
+  .pro-kind-row { display: flex; gap: 5px; margin-bottom: 10px; }
+  .pro-type-btn {
+    padding: 5px 10px; font-size: 0.75rem; font-weight: 500; color: #888;
+    background: #0f2840; border: 1px solid #1a3050; border-radius: 4px; cursor: pointer;
+  }
+  .pro-type-btn:hover { color: #ccc; background: #1a3860; }
+  .pro-type-btn.active { color: #fff; background: #1a4a7a; border-color: #4ecdc4; }
+
+  .pro-load-inputs { display: flex; flex-direction: column; gap: 8px; }
+  .pro-load-row { display: flex; flex-wrap: wrap; gap: 8px; }
+  .pro-load-row label { font-size: 0.75rem; color: #888; display: flex; align-items: center; gap: 4px; }
+  .inp-sm { width: 55px; padding: 4px 6px; background: #0f2840; border: 1px solid #1a3050; border-radius: 3px; color: #ddd; font-size: 0.78rem; font-family: monospace; }
+  .inp-num { width: 65px; padding: 4px 6px; background: #0f2840; border: 1px solid #1a3050; border-radius: 3px; color: #ddd; font-size: 0.78rem; font-family: monospace; }
+  .inp-sm:focus, .inp-num:focus { border-color: #1a4a7a; outline: none; }
+  .pro-btn { align-self: flex-start; padding: 5px 14px; font-size: 0.75rem; color: #ccc; background: #0f3460; border: 1px solid #1a4a7a; border-radius: 4px; cursor: pointer; }
+  .pro-btn:hover { background: #1a4a7a; color: #fff; }
+
+  .pro-loads-table-wrap { }
+  .pro-load-section-title { padding: 6px 12px; font-size: 0.72rem; font-weight: 600; color: #4ecdc4; text-transform: uppercase; background: #0a1a30; border-bottom: 1px solid #1a3050; }
+  .pro-loads-table { width: 100%; border-collapse: collapse; font-size: 0.78rem; }
+  .pro-loads-table thead { position: sticky; top: 0; z-index: 1; }
+  .pro-loads-table th { padding: 6px 6px; text-align: left; font-size: 0.68rem; font-weight: 600; color: #888; text-transform: uppercase; background: #0a1a30; border-bottom: 1px solid #1a4a7a; }
+  .pro-loads-table td { padding: 4px 6px; border-bottom: 1px solid #0f2030; color: #ccc; }
+  .col-id { width: 32px; color: #666; font-family: monospace; text-align: center; }
+  .col-num { font-family: monospace; text-align: right; font-size: 0.75rem; }
+  .pro-delete-btn { background: none; border: none; color: #555; font-size: 1rem; cursor: pointer; padding: 0; }
+  .pro-delete-btn:hover { color: #ff6b6b; }
+  .pro-empty { text-align: center; color: #555; font-style: italic; padding: 30px 10px; font-size: 0.78rem; }
+</style>

--- a/web/src/components/pro/ProMaterialsTab.svelte
+++ b/web/src/components/pro/ProMaterialsTab.svelte
@@ -1,0 +1,401 @@
+<script lang="ts">
+  import { modelStore } from '../../lib/store';
+  import { t } from '../../lib/i18n';
+  import {
+    getMaterialPresets, MATERIAL_CATEGORIES, searchPresets,
+    type MaterialPreset,
+  } from '../../lib/data/material-presets';
+
+  let activeCategory = $state<string>('hormigon');
+  let searchQuery = $state('');
+  let filtered = $derived(searchPresets(searchQuery, activeCategory));
+
+  // Custom material form
+  let showCustom = $state(false);
+  let newName = $state('');
+  let newE = $state('');
+  let newNu = $state('');
+  let newRho = $state('');
+  let newFy = $state('');
+
+  const materials = $derived([...modelStore.materials.values()]);
+
+  function addPreset(p: MaterialPreset) {
+    modelStore.addMaterial({
+      name: p.name,
+      e: p.e,
+      nu: p.nu,
+      rho: p.rho,
+      fy: p.fy,
+    });
+  }
+
+  function addCustom() {
+    const e = parseFloat(newE);
+    const nu = parseFloat(newNu);
+    const rho = parseFloat(newRho);
+    const fy = parseFloat(newFy);
+    if (!newName.trim() || isNaN(e) || isNaN(nu) || isNaN(rho)) return;
+    modelStore.addMaterial({
+      name: newName.trim(),
+      e,
+      nu,
+      rho,
+      fy: isNaN(fy) ? undefined : fy,
+    });
+    newName = ''; newE = ''; newNu = ''; newRho = ''; newFy = '';
+    showCustom = false;
+  }
+
+  function removeMat(id: number) {
+    modelStore.removeMaterial(id);
+  }
+</script>
+
+<div class="pro-mat">
+  <!-- Collapsible add-material panel -->
+  <details class="add-panel">
+    <summary class="add-panel-summary">{t('pro.addMaterialPanel')}</summary>
+    <div class="add-panel-body">
+
+  <!-- Category tabs -->
+  <div class="cat-tabs">
+    {#each MATERIAL_CATEGORIES as cat}
+      <button
+        class:active={activeCategory === cat.id}
+        onclick={() => { activeCategory = cat.id; searchQuery = ''; }}
+      >{t(cat.label)}</button>
+    {/each}
+  </div>
+
+  <!-- Search -->
+  <div class="search-wrap">
+    <input type="text" placeholder={t('search.material')} bind:value={searchQuery} />
+  </div>
+
+  <!-- Preset list -->
+  <div class="preset-list">
+    {#each filtered as p}
+      <button class="preset-item" onclick={() => addPreset(p)}>
+        <span class="preset-name">{p.name}</span>
+        <span class="preset-props">
+          E={p.e >= 1000 ? `${(p.e/1000).toFixed(0)}GPa` : `${p.e}MPa`}
+          {#if p.fy}&nbsp; fy={p.fy}MPa{/if}
+          &nbsp; {t('field.density')}={p.rho}
+        </span>
+      </button>
+    {/each}
+    {#if filtered.length === 0}
+      <p class="no-results">{t('search.noResults')}</p>
+    {/if}
+  </div>
+
+  <!-- Custom material toggle -->
+  <div class="custom-section">
+    <button class="custom-toggle" onclick={() => showCustom = !showCustom}>
+      {showCustom ? '−' : '+'} {t('pro.customMaterial')}
+    </button>
+    {#if showCustom}
+      <div class="custom-form">
+        <div class="custom-row">
+          <label><span>{t('pro.thName')}</span>
+            <input type="text" bind:value={newName} placeholder="Ej: Acero S275" /></label>
+        </div>
+        <div class="custom-row">
+          <label><span>E (MPa)</span>
+            <input type="number" bind:value={newE} placeholder="200000" /></label>
+          <label><span>{t('field.poisson')}</span>
+            <input type="number" step="0.01" bind:value={newNu} placeholder="0.3" /></label>
+        </div>
+        <div class="custom-row">
+          <label><span>{t('field.density')} (kN/m³)</span>
+            <input type="number" step="0.1" bind:value={newRho} placeholder="78.5" /></label>
+          <label><span>fy (MPa)</span>
+            <input type="number" bind:value={newFy} placeholder={t('pro.optional')} /></label>
+        </div>
+        <button class="add-btn" onclick={addCustom}>{t('pro.addMaterial')}</button>
+      </div>
+    {/if}
+  </div>
+
+    </div>
+  </details>
+
+  <!-- Materials table -->
+  <div class="mat-list">
+    <div class="mat-list-header">
+      <span class="mat-count">{t('pro.nMaterials').replace('{n}', String(materials.length))}</span>
+    </div>
+    <div class="mat-table-wrap">
+      <table class="mat-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>{t('pro.thName')}</th>
+            <th>E (MPa)</th>
+            <th>{t('field.poisson')}</th>
+            <th>{t('field.density')}</th>
+            <th>fy</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each materials as m}
+            <tr>
+              <td class="col-id">{m.id}</td>
+              <td class="col-name">{m.name}</td>
+              <td class="col-num">{m.e.toLocaleString()}</td>
+              <td class="col-num">{m.nu}</td>
+              <td class="col-num">{m.rho}</td>
+              <td class="col-num">{m.fy ?? '—'}</td>
+              <td><button class="del-btn" onclick={() => removeMat(m.id)}>×</button></td>
+            </tr>
+          {/each}
+          {#if materials.length === 0}
+            <tr><td colspan="7" class="no-results">{t('pro.noMaterials')}</td></tr>
+          {/if}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<style>
+  .pro-mat {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  /* ─── Add Panel (collapsible) ─── */
+  .add-panel {
+    flex-shrink: 0;
+    border-bottom: 2px solid #0f3460;
+  }
+  .add-panel[open] {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .add-panel-summary {
+    padding: 8px 12px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #4ecdc4;
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+  }
+  .add-panel-summary::-webkit-details-marker { display: none; }
+  .add-panel-summary::before {
+    content: '+ ';
+  }
+  .add-panel[open] > .add-panel-summary::before {
+    content: '− ';
+  }
+  .add-panel-summary:hover { color: #6eede4; }
+  .add-panel-body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  /* ─── Category Tabs ─── */
+  .cat-tabs {
+    display: flex;
+    border-bottom: 2px solid #0f3460;
+    flex-shrink: 0;
+  }
+  .cat-tabs button {
+    flex: 1;
+    padding: 0.45rem 0.4rem;
+    border: none;
+    background: transparent;
+    color: #888;
+    cursor: pointer;
+    font-size: 0.72rem;
+    font-weight: 500;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -2px;
+    transition: all 0.15s;
+  }
+  .cat-tabs button:hover { color: #ccc; }
+  .cat-tabs button.active { color: #4ecdc4; border-bottom-color: #4ecdc4; }
+
+  /* ─── Search ─── */
+  .search-wrap {
+    padding: 6px 8px;
+    flex-shrink: 0;
+  }
+  .search-wrap input {
+    width: 100%;
+    padding: 5px 8px;
+    background: #0f2840;
+    border: 1px solid #1a3050;
+    border-radius: 4px;
+    color: #eee;
+    font-size: 0.78rem;
+  }
+  .search-wrap input::placeholder { color: #555; }
+  .search-wrap input:focus { outline: none; border-color: #4ecdc4; }
+
+  /* ─── Preset List ─── */
+  .preset-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0 6px;
+    min-height: 0;
+  }
+  .preset-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    padding: 6px 8px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    color: #ccc;
+    cursor: pointer;
+    font-size: 0.78rem;
+    text-align: left;
+    transition: all 0.12s;
+  }
+  .preset-item:hover {
+    background: #1a4a7a;
+    border-color: #4ecdc4;
+    color: white;
+  }
+  .preset-name { font-weight: 600; white-space: nowrap; }
+  .preset-props { font-size: 0.65rem; color: #777; white-space: nowrap; }
+  .preset-item:hover .preset-props { color: #aaa; }
+
+  .no-results {
+    text-align: center;
+    color: #555;
+    font-size: 0.75rem;
+    padding: 1rem;
+  }
+
+  /* ─── Custom Material ─── */
+  .custom-section {
+    flex-shrink: 0;
+    border-top: 1px solid #1a3050;
+    padding: 4px 8px 6px;
+  }
+  .custom-toggle {
+    background: none;
+    border: none;
+    color: #888;
+    font-size: 0.75rem;
+    cursor: pointer;
+    padding: 4px 0;
+    width: 100%;
+    text-align: left;
+  }
+  .custom-toggle:hover { color: #4ecdc4; }
+
+  .custom-form {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    padding-top: 4px;
+  }
+  .custom-row {
+    display: flex;
+    gap: 8px;
+  }
+  .custom-row label {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 0.7rem;
+    color: #888;
+  }
+  .custom-row input {
+    padding: 4px 6px;
+    background: #0f2840;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ddd;
+    font-size: 0.75rem;
+    font-family: monospace;
+  }
+  .custom-row input:focus { outline: none; border-color: #4ecdc4; }
+
+  .add-btn {
+    margin-top: 4px;
+    padding: 5px 12px;
+    background: #0f4a3a;
+    border: 1px solid #1a7a5a;
+    border-radius: 4px;
+    color: #4ecdc4;
+    cursor: pointer;
+    font-size: 0.75rem;
+    font-weight: 600;
+    align-self: flex-start;
+    transition: all 0.15s;
+  }
+  .add-btn:hover { background: #1a7a5a; color: white; }
+
+  /* ─── Materials Table ─── */
+  .mat-list {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .add-panel[open] ~ .mat-list {
+    flex: 0 0 auto;
+    max-height: 160px;
+  }
+  .mat-list-header {
+    padding: 5px 10px;
+    flex-shrink: 0;
+  }
+  .mat-count {
+    font-size: 0.78rem;
+    color: #4ecdc4;
+    font-weight: 600;
+  }
+  .mat-table-wrap {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+  }
+  .mat-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.72rem;
+  }
+  .mat-table thead { position: sticky; top: 0; z-index: 1; }
+  .mat-table th {
+    padding: 4px 5px;
+    text-align: left;
+    font-size: 0.65rem;
+    font-weight: 600;
+    color: #666;
+    text-transform: uppercase;
+    background: #0a1a30;
+    border-bottom: 1px solid #1a3050;
+  }
+  .mat-table td {
+    padding: 3px 5px;
+    border-bottom: 1px solid #0f2030;
+    color: #bbb;
+  }
+  .col-id { width: 28px; color: #555; font-family: monospace; text-align: center; }
+  .col-name { max-width: 110px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .col-num { font-family: monospace; text-align: right; font-size: 0.68rem; }
+  .del-btn {
+    background: none; border: none; color: #444; font-size: 0.9rem; cursor: pointer; padding: 0;
+  }
+  .del-btn:hover { color: #ff6b6b; }
+</style>

--- a/web/src/components/pro/ProNodesTab.svelte
+++ b/web/src/components/pro/ProNodesTab.svelte
@@ -1,0 +1,422 @@
+<script lang="ts">
+  import { modelStore, uiStore } from '../../lib/store';
+  import { t } from '../../lib/i18n';
+
+  interface NodeRow {
+    id: number | null;  // null = unsaved new row
+    x: string;
+    y: string;
+    z: string;
+  }
+
+  let rows = $state<NodeRow[]>([]);
+  let pasteError = $state<string | null>(null);
+  let selectedRowIdx = $state<number | null>(null);
+
+  // Sync rows from modelStore on mount and when nodes change
+  $effect(() => {
+    const storeNodes = [...modelStore.nodes.values()];
+    // Only sync if the store has nodes and rows are empty or stale
+    if (storeNodes.length > 0 && rows.length === 0) {
+      rows = storeNodes.map(n => ({
+        id: n.id,
+        x: String(n.x),
+        y: String(n.y),
+        z: String(n.z ?? 0),
+      }));
+    }
+  });
+
+  function parseNumber(s: string): number | null {
+    // Accept both . and , as decimal separator
+    const cleaned = s.trim().replace(',', '.');
+    const n = parseFloat(cleaned);
+    return isNaN(n) ? null : n;
+  }
+
+  function addEmptyRow() {
+    rows = [...rows, { id: null, x: '', y: '', z: '0' }];
+  }
+
+  function commitRow(idx: number) {
+    const row = rows[idx];
+    const x = parseNumber(row.x);
+    const y = parseNumber(row.y);
+    const z = parseNumber(row.z);
+    if (x === null || y === null || z === null) return;
+
+    if (row.id === null) {
+      // New node
+      const realId = modelStore.addNode(x, y, z);
+      rows[idx] = { ...rows[idx], id: realId };
+    } else {
+      // Update existing node
+      modelStore.updateNode(row.id, x, y, z);
+    }
+  }
+
+  function deleteRow(idx: number) {
+    const row = rows[idx];
+    if (row.id !== null) {
+      modelStore.removeNode(row.id);
+    }
+    rows = rows.filter((_, i) => i !== idx);
+  }
+
+  function handleKeydown(e: KeyboardEvent, idx: number) {
+    if (e.key === 'Enter') {
+      commitRow(idx);
+      // If last row, add a new one
+      if (idx === rows.length - 1) {
+        addEmptyRow();
+        // Focus the X input of the new row after a tick
+        setTimeout(() => {
+          const inputs = document.querySelectorAll('.pro-nodes-table input[data-col="x"]');
+          const lastInput = inputs[inputs.length - 1] as HTMLInputElement;
+          lastInput?.focus();
+        }, 10);
+      }
+    }
+  }
+
+  function handlePaste(e: ClipboardEvent) {
+    const text = e.clipboardData?.getData('text');
+    if (!text) return;
+
+    // Check if it looks like tabular data (has tabs or multiple lines)
+    if (!text.includes('\t') && !text.includes('\n')) return;
+
+    e.preventDefault();
+    pasteError = null;
+
+    const lines = text.trim().split('\n').filter(l => l.trim());
+    const newRows: NodeRow[] = [];
+    const newNodeIds: number[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const parts = lines[i].split('\t').map(s => s.trim());
+      if (parts.length < 2) {
+        pasteError = t('pro.pasteRowError').replace('{n}', String(i + 1)).replace('{cols}', '2').replace('{names}', 'X, Y');
+        return;
+      }
+
+      const x = parseNumber(parts[0]);
+      const y = parseNumber(parts[1]);
+      const z = parts.length >= 3 ? parseNumber(parts[2]) : 0;
+
+      if (x === null || y === null) {
+        pasteError = t('pro.pasteInvalidNum').replace('{n}', String(i + 1));
+        return;
+      }
+
+      const realId = modelStore.addNode(x, y, z ?? 0);
+      newNodeIds.push(realId);
+      newRows.push({
+        id: realId,
+        x: String(x),
+        y: String(y),
+        z: String(z ?? 0),
+      });
+    }
+
+    // Add new rows to the table
+    rows = [...rows.filter(r => r.id !== null), ...newRows];
+    pasteError = null;
+  }
+
+  function handleRowClick(idx: number) {
+    selectedRowIdx = idx;
+    const row = rows[idx];
+    if (row.id !== null) {
+      // Select node in viewport
+      uiStore.selectedNodes = new Set([row.id]);
+      uiStore.selectedElements = new Set();
+    }
+  }
+
+  // Listen for node selection from viewport → highlight row
+  $effect(() => {
+    if (uiStore.selectedNodes.size === 1) {
+      const nodeId = [...uiStore.selectedNodes][0];
+      const idx = rows.findIndex(r => r.id === nodeId);
+      if (idx >= 0) selectedRowIdx = idx;
+    }
+  });
+
+  function commitAll() {
+    for (let i = 0; i < rows.length; i++) {
+      commitRow(i);
+    }
+  }
+
+  function clearAll() {
+    for (const row of rows) {
+      if (row.id !== null) modelStore.removeNode(row.id);
+    }
+    rows = [];
+  }
+
+  const nodeCount = $derived(rows.filter(r => r.id !== null).length);
+</script>
+
+<div class="pro-nodes">
+  <div class="pro-nodes-header">
+    <span class="pro-nodes-count">{t('pro.nNodes').replace('{n}', String(nodeCount))}</span>
+    <div class="pro-nodes-actions">
+      <button class="pro-btn" onclick={addEmptyRow}>{t('pro.addNode')}</button>
+      <button class="pro-btn pro-btn-sm" onclick={commitAll} title={t('pro.apply')}>{t('pro.apply')}</button>
+      <button class="pro-btn pro-btn-sm pro-btn-danger" onclick={clearAll} title={t('pro.clear')}>{t('pro.clear')}</button>
+    </div>
+  </div>
+
+  {#if pasteError}
+    <div class="pro-paste-error">{pasteError}</div>
+  {/if}
+
+  <div class="pro-paste-hint">
+    {t('pro.pasteHintNodes')}
+  </div>
+
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="pro-nodes-table-wrap" onpaste={handlePaste}>
+    <table class="pro-nodes-table">
+      <thead>
+        <tr>
+          <th class="col-id">ID</th>
+          <th class="col-coord">X (m)</th>
+          <th class="col-coord">Y (m)</th>
+          <th class="col-coord">Z (m)</th>
+          <th class="col-actions"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each rows as row, idx}
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <tr
+            class:selected={selectedRowIdx === idx}
+            class:unsaved={row.id === null}
+            onclick={() => handleRowClick(idx)}
+          >
+            <td class="col-id">{row.id ?? '—'}</td>
+            <td class="col-coord">
+              <input
+                type="text"
+                data-col="x"
+                bind:value={row.x}
+                onkeydown={(e) => handleKeydown(e, idx)}
+                onblur={() => commitRow(idx)}
+                placeholder="0"
+              />
+            </td>
+            <td class="col-coord">
+              <input
+                type="text"
+                data-col="y"
+                bind:value={row.y}
+                onkeydown={(e) => handleKeydown(e, idx)}
+                onblur={() => commitRow(idx)}
+                placeholder="0"
+              />
+            </td>
+            <td class="col-coord">
+              <input
+                type="text"
+                data-col="z"
+                bind:value={row.z}
+                onkeydown={(e) => handleKeydown(e, idx)}
+                onblur={() => commitRow(idx)}
+                placeholder="0"
+              />
+            </td>
+            <td class="col-actions">
+              <button class="pro-delete-btn" onclick={() => deleteRow(idx)} title={t('pro.delete')}>×</button>
+            </td>
+          </tr>
+        {/each}
+        {#if rows.length === 0}
+          <tr>
+            <td colspan="5" class="pro-empty">{t('pro.emptyNodes')}</td>
+          </tr>
+        {/if}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<style>
+  .pro-nodes {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .pro-nodes-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 10px;
+    border-bottom: 1px solid #1a3050;
+    flex-shrink: 0;
+  }
+
+  .pro-nodes-count {
+    font-size: 0.82rem;
+    color: #4ecdc4;
+    font-weight: 600;
+  }
+
+  .pro-nodes-actions {
+    display: flex;
+    gap: 6px;
+  }
+
+  .pro-btn {
+    padding: 5px 12px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: #ccc;
+    background: #0f3460;
+    border: 1px solid #1a4a7a;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  .pro-btn:hover {
+    background: #1a4a7a;
+    color: #fff;
+  }
+
+  .pro-btn-sm {
+    padding: 4px 10px;
+    font-size: 0.72rem;
+  }
+
+  .pro-btn-danger {
+    color: #ff8a9e;
+    border-color: #5a2030;
+  }
+
+  .pro-btn-danger:hover {
+    background: #4a1525;
+    color: #ff6b6b;
+  }
+
+  .pro-paste-error {
+    padding: 4px 10px;
+    font-size: 0.7rem;
+    color: #ff8a9e;
+    background: rgba(233, 69, 96, 0.1);
+    border-bottom: 1px solid #5a2030;
+  }
+
+  .pro-paste-hint {
+    padding: 6px 12px;
+    font-size: 0.72rem;
+    color: #668;
+    font-style: italic;
+    border-bottom: 1px solid #1a2540;
+    flex-shrink: 0;
+  }
+
+  .pro-nodes-table-wrap {
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  .pro-nodes-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.75rem;
+  }
+
+  .pro-nodes-table thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+
+  .pro-nodes-table th {
+    padding: 6px 8px;
+    text-align: left;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    background: #0a1a30;
+    border-bottom: 1px solid #1a4a7a;
+  }
+
+  .pro-nodes-table td {
+    padding: 3px 4px;
+    border-bottom: 1px solid #0f2030;
+  }
+
+  .pro-nodes-table tr:hover {
+    background: rgba(78, 205, 196, 0.04);
+  }
+
+  .pro-nodes-table tr.selected {
+    background: rgba(78, 205, 196, 0.1);
+  }
+
+  .pro-nodes-table tr.unsaved td {
+    opacity: 0.6;
+  }
+
+  .col-id {
+    width: 36px;
+    color: #666;
+    font-family: monospace;
+    font-size: 0.7rem;
+    text-align: center;
+  }
+
+  .col-coord {
+    width: auto;
+  }
+
+  .col-coord input {
+    width: 100%;
+    padding: 4px 6px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    color: #ddd;
+    font-size: 0.78rem;
+    font-family: monospace;
+  }
+
+  .col-coord input:focus {
+    background: #0f2840;
+    border-color: #1a4a7a;
+    outline: none;
+  }
+
+  .col-actions {
+    width: 24px;
+    text-align: center;
+  }
+
+  .pro-delete-btn {
+    background: none;
+    border: none;
+    color: #555;
+    font-size: 1rem;
+    cursor: pointer;
+    padding: 0 2px;
+    line-height: 1;
+  }
+
+  .pro-delete-btn:hover {
+    color: #ff6b6b;
+  }
+
+  .pro-empty {
+    text-align: center;
+    color: #555;
+    font-style: italic;
+    padding: 20px 10px !important;
+  }
+</style>

--- a/web/src/components/pro/ProPanel.svelte
+++ b/web/src/components/pro/ProPanel.svelte
@@ -1,0 +1,609 @@
+<script lang="ts">
+  import { t } from '../../lib/i18n';
+  import { modelStore, resultsStore, uiStore, verificationStore } from '../../lib/store';
+  import { openReport } from '../../lib/engine/pro-report';
+  import type { ReportData, ReportConfig } from '../../lib/engine/pro-report';
+  import { verifyElement, classifyElement, computeJointPsiFromModel } from '../../lib/engine/codes/argentina/cirsoc201';
+  import type { ElementVerification, VerificationInput } from '../../lib/engine/codes/argentina/cirsoc201';
+  import { computeQuantities } from '../../lib/engine/quantity-takeoff';
+  import { runGlobalSolve } from '../../lib/engine/live-calc';
+  import ProReportDialog from './ProReportDialog.svelte';
+  import ProNodesTab from './ProNodesTab.svelte';
+  import ProElementsTab from './ProElementsTab.svelte';
+  import ProMaterialsTab from './ProMaterialsTab.svelte';
+  import ProSectionsTab from './ProSectionsTab.svelte';
+  import ProSupportsTab from './ProSupportsTab.svelte';
+  import ProLoadsTab from './ProLoadsTab.svelte';
+  import ProResultsTab from './ProResultsTab.svelte';
+  import ProVerificationTab from './ProVerificationTab.svelte';
+  import ProShellTab from './ProShellTab.svelte';
+  import ProConstraintsTab from './ProConstraintsTab.svelte';
+  import ProAdvancedTab from './ProAdvancedTab.svelte';
+  import ProDiagnosticsTab from './ProDiagnosticsTab.svelte';
+  import ProConnectionsTab from './ProConnectionsTab.svelte';
+  import type { SolverDiagnostic } from '../../lib/engine/types';
+  import { checkModel } from '../../lib/engine/model-diagnostics';
+
+  type ProTab = 'nodes' | 'elements' | 'shells' | 'materials' | 'sections' | 'supports' | 'constraints' | 'loads' | 'advanced' | 'results' | 'verification' | 'connections' | 'diagnostics';
+
+  // Group tabs into logical categories
+  interface TabGroup {
+    label: string;
+    tabs: { id: ProTab; label: string; badge?: () => number }[];
+  }
+
+  const tabGroups: TabGroup[] = $derived([
+    {
+      label: t('pro.groupGeometry'),
+      tabs: [
+        { id: 'nodes' as ProTab, label: t('pro.tabNodes') },
+        { id: 'elements' as ProTab, label: t('pro.tabElements') },
+        { id: 'shells' as ProTab, label: t('pro.tabShells') },
+      ],
+    },
+    {
+      label: t('pro.groupProperties'),
+      tabs: [
+        { id: 'materials' as ProTab, label: t('pro.tabMaterials') },
+        { id: 'sections' as ProTab, label: t('pro.tabSections') },
+      ],
+    },
+    {
+      label: t('pro.groupConditions'),
+      tabs: [
+        { id: 'supports' as ProTab, label: t('pro.tabSupports') },
+        { id: 'constraints' as ProTab, label: t('pro.tabConstraints') },
+        { id: 'loads' as ProTab, label: t('pro.tabLoads') },
+      ],
+    },
+    {
+      label: t('pro.groupAnalysis'),
+      tabs: [
+        { id: 'advanced' as ProTab, label: t('pro.tabAdvanced') },
+        { id: 'results' as ProTab, label: t('pro.tabResults') },
+        { id: 'verification' as ProTab, label: t('pro.tabVerification') },
+        { id: 'connections' as ProTab, label: t('pro.tabConnections') },
+        { id: 'diagnostics' as ProTab, label: t('pro.tabDiagnostics') },
+      ],
+    },
+  ]);
+
+  let activeTab = $state<ProTab>('nodes');
+  let verificationsRef = $state<ElementVerification[]>([]);
+  let advancedResultsRef = $state<Record<string, any>>({});
+  let tabError = $state<string | null>(null);
+  let showReportDialog = $state(false);
+  let solving = $state(false);
+  let solveError = $state<string | null>(null);
+  const hasModel = $derived(modelStore.nodes.size > 0 && modelStore.elements.size > 0);
+
+  async function handleSolve() {
+    solveError = null;
+    solving = true;
+    try {
+      await runGlobalSolve();
+      if (!resultsStore.results3D) {
+        solveError = t('pro.noResults');
+        solving = false;
+        return;
+      }
+      // Combinations are already solved inside runGlobalSolve for PRO mode
+      activeTab = 'results';
+    } catch (e: any) {
+      console.error('PRO solve error:', e);
+      solveError = e?.message || String(e) || t('pro.unknownError');
+    }
+    solving = false;
+  }
+
+  // Merge model + assembly + solver diagnostics with dedup (mirrors ProDiagnosticsTab logic)
+  const diagCount = $derived.by(() => {
+    const is3D = uiStore.analysisMode === '3d' || uiStore.analysisMode === 'pro';
+    const general = is3D ? resultsStore.diagnostics3D : resultsStore.diagnostics;
+    const solver = is3D ? resultsStore.solverDiagnostics3D : resultsStore.solverDiagnostics;
+    const modelDiags = checkModel({
+      nodes: modelStore.nodes,
+      elements: modelStore.elements,
+      materials: modelStore.materials,
+      sections: modelStore.sections,
+      supports: modelStore.supports,
+      loads: modelStore.loads as any,
+      loadCases: modelStore.model.loadCases,
+      plates: modelStore.model.plates,
+      quads: modelStore.model.quads,
+    });
+    const merged = [...modelDiags];
+    for (const sd of [...general, ...solver]) {
+      const isDupe = merged.some(
+        d => d.code === sd.code && d.message === sd.message &&
+             JSON.stringify(d.elementIds) === JSON.stringify(sd.elementIds) &&
+             JSON.stringify(d.nodeIds) === JSON.stringify(sd.nodeIds)
+      );
+      if (!isDupe) merged.push(sd);
+    }
+    return merged.filter(d => d.severity === 'error' || d.severity === 'warning').length;
+  });
+
+  // Counts for badges
+  const nodeCount = $derived(modelStore.nodes.size);
+  const elemCount = $derived(modelStore.elements.size);
+  const loadCount = $derived(modelStore.loads.length);
+
+  /** Auto-run CIRSOC verification on current results */
+  function autoVerify(): ElementVerification[] {
+    const results = resultsStore.results3D;
+    if (!results) return [];
+    const verifs: ElementVerification[] = [];
+    const rebarFy = 420, cover = 0.025, stirrupDia = 8;
+
+    for (const ef of results.elementForces) {
+      const elem = modelStore.elements.get(ef.elementId);
+      if (!elem) continue;
+      const nodeI = modelStore.nodes.get(elem.nodeI);
+      const nodeJ = modelStore.nodes.get(elem.nodeJ);
+      if (!nodeI || !nodeJ) continue;
+      const section = modelStore.sections.get(elem.sectionId);
+      const material = modelStore.materials.get(elem.materialId);
+      if (!section || !material) continue;
+      if (!section.b || !section.h) continue;
+      const fc = material.fy;
+      if (!fc || fc > 80) continue;
+
+      const dx = nodeJ.x - nodeI.x, dy = nodeJ.y - nodeI.y, dz = (nodeJ.z ?? 0) - (nodeI.z ?? 0);
+      const L = Math.sqrt(dx * dx + dy * dy + dz * dz);
+      const elemType = classifyElement(nodeI.x, nodeI.y, nodeI.z ?? 0, nodeJ.x, nodeJ.y, nodeJ.z ?? 0, section.b, section.h);
+      const MuMax = Math.max(Math.abs(ef.mzStart), Math.abs(ef.mzEnd));
+      const VuMax = Math.max(Math.abs(ef.vyStart), Math.abs(ef.vyEnd));
+      const NuMax = Math.max(Math.abs(ef.nStart), Math.abs(ef.nEnd));
+      const MuyMax = Math.max(Math.abs(ef.myStart), Math.abs(ef.myEnd));
+      const VzMax = Math.max(Math.abs(ef.vzStart), Math.abs(ef.vzEnd));
+      const TuMax = Math.max(Math.abs(ef.mxStart), Math.abs(ef.mxEnd));
+      const isVertical = elemType === 'column' || elemType === 'wall';
+
+      let M1: number | undefined, M2: number | undefined;
+      if (isVertical) {
+        if (Math.abs(ef.mzStart) >= Math.abs(ef.mzEnd)) {
+          M2 = Math.abs(ef.mzStart);
+          M1 = Math.sign(ef.mzStart) === Math.sign(ef.mzEnd) ? Math.abs(ef.mzEnd) : -Math.abs(ef.mzEnd);
+        } else {
+          M2 = Math.abs(ef.mzEnd);
+          M1 = Math.sign(ef.mzStart) === Math.sign(ef.mzEnd) ? Math.abs(ef.mzStart) : -Math.abs(ef.mzStart);
+        }
+      }
+
+      let psiA: number | undefined, psiB: number | undefined;
+      if (isVertical) {
+        const psi = computeJointPsiFromModel(
+          ef.elementId,
+          modelStore.nodes as any, modelStore.elements as any,
+          modelStore.sections as any, modelStore.materials as any,
+          modelStore.supports as any,
+        );
+        psiA = psi.psiA;
+        psiB = psi.psiB;
+      }
+
+      const input: VerificationInput = {
+        elementId: ef.elementId, elementType: elemType,
+        Mu: MuMax, Vu: VuMax, Nu: NuMax,
+        b: section.b, h: section.h, fc, fy: rebarFy, cover, stirrupDia,
+        Muy: isVertical ? MuyMax : undefined,
+        Vz: VzMax > 0.01 ? VzMax : undefined,
+        Tu: TuMax > 0.001 ? TuMax : undefined,
+        Lu: isVertical ? L : undefined, M1, M2, psiA, psiB,
+      };
+      verifs.push(verifyElement(input));
+    }
+    return verifs;
+  }
+
+  /** Serialize loads for the report */
+  function serializeLoads(): ReportData['loads'] {
+    const loads: NonNullable<ReportData['loads']> = [];
+    for (const load of modelStore.model.loads) {
+      let tipo = '', destino = '', valores = '';
+      switch (load.type) {
+        case 'nodal': { const d = load.data; tipo = t('file.loadNodal'); destino = `Nodo ${d.nodeId}`; valores = `Fx=${d.fx} kN, Fy=${d.fy} kN, Mz=${d.mz} kN·m`; break; }
+        case 'distributed': { const d = load.data; tipo = t('file.loadDistributed'); destino = `Elem ${d.elementId}`; valores = d.qI === d.qJ ? `q=${d.qI} kN/m` : `qI=${d.qI}, qJ=${d.qJ} kN/m`; break; }
+        case 'pointOnElement': { const d = load.data; tipo = t('file.loadPointOnElement'); destino = `Elem ${d.elementId}`; valores = `P=${d.p} kN, a=${d.a} m`; break; }
+        case 'thermal': { const d = load.data; tipo = t('file.loadThermal'); destino = `Elem ${d.elementId}`; valores = `ΔT=${d.dtUniform} °C, ΔTg=${d.dtGradient} °C`; break; }
+      }
+      loads.push({ type: tipo, target: destino, values: valores, caseLabel: (load as any).caseLabel });
+    }
+    return loads;
+  }
+
+  async function handleOpenReportDialog() {
+    // Auto-solve if no results yet
+    if (!resultsStore.results3D) {
+      if (modelStore.nodes.size === 0) { uiStore.toast(t('pro.solveFirst'), 'error'); return; }
+      await runGlobalSolve();
+    }
+    if (!resultsStore.results3D) return;
+
+    // Auto-verify CIRSOC if not already done
+    if (verificationsRef.length === 0) {
+      verificationsRef = autoVerify();
+      verificationStore.setConcrete(verificationsRef);
+    }
+
+    showReportDialog = true;
+  }
+
+  function exportReport(config: ReportConfig) {
+    showReportDialog = false;
+
+    const results = resultsStore.results3D;
+    if (!results) return;
+
+    let screenshot: string | undefined;
+    const canvas = document.querySelector('canvas');
+    if (canvas) {
+      try { screenshot = canvas.toDataURL('image/png'); } catch { /* ignore */ }
+    }
+
+    const data: ReportData = {
+      projectName: modelStore.model.name || 'Estructura',
+      date: new Date().toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' }),
+      nodes: [...modelStore.nodes.values()],
+      elements: [...modelStore.elements.values()],
+      materials: [...modelStore.materials.values()],
+      sections: [...modelStore.sections.values()],
+      supports: [...modelStore.supports.values()],
+      quads: modelStore.model.quads.size > 0 ? [...modelStore.model.quads.values()] : undefined,
+      loadCount: modelStore.loads.length,
+      loads: serializeLoads(),
+      results,
+      verifications: verificationsRef,
+      advancedResults: Object.keys(advancedResultsRef).length > 0 ? advancedResultsRef : undefined,
+      diagnostics: resultsStore.diagnostics3D.length > 0 ? resultsStore.diagnostics3D : undefined,
+      screenshot,
+      t,
+      config,
+    };
+
+    if (verificationsRef.length > 0) {
+      const elemLengths = new Map<number, number>();
+      for (const v of verificationsRef) {
+        const elem = modelStore.elements.get(v.elementId);
+        if (elem) {
+          const nI = modelStore.nodes.get(elem.nodeI);
+          const nJ = modelStore.nodes.get(elem.nodeJ);
+          if (nI && nJ) {
+            const dx = nJ.x - nI.x, dy = nJ.y - nI.y, dz = (nJ.z ?? 0) - (nI.z ?? 0);
+            elemLengths.set(v.elementId, Math.sqrt(dx * dx + dy * dy + dz * dz));
+          }
+        }
+      }
+      data.quantities = computeQuantities(verificationsRef, elemLengths);
+      data.elementLengths = elemLengths;
+    }
+
+    // Story drift for report
+    const yTol = 0.05;
+    const yLevels: number[] = [];
+    for (const [, node] of modelStore.nodes) {
+      if (!yLevels.some(lv => Math.abs(lv - node.y) < yTol)) yLevels.push(node.y);
+    }
+    yLevels.sort((a, b) => a - b);
+    if (yLevels.length >= 2) {
+      const drifts: NonNullable<ReportData['storyDrifts']> = [];
+      const driftLimit = 0.015;
+      for (let i = 1; i < yLevels.length; i++) {
+        const level = yLevels[i], prevLevel = yLevels[i - 1];
+        const storyH = level - prevLevel;
+        if (storyH < 0.1) continue;
+        let maxUxCur = 0, maxUzCur = 0, maxUxPrev = 0, maxUzPrev = 0;
+        for (const d of results.displacements) {
+          const node = modelStore.nodes.get(d.nodeId);
+          if (!node) continue;
+          if (Math.abs(node.y - level) < yTol) {
+            maxUxCur = Math.max(maxUxCur, Math.abs(d.ux));
+            maxUzCur = Math.max(maxUzCur, Math.abs(d.uz));
+          } else if (Math.abs(node.y - prevLevel) < yTol) {
+            maxUxPrev = Math.max(maxUxPrev, Math.abs(d.ux));
+            maxUzPrev = Math.max(maxUzPrev, Math.abs(d.uz));
+          }
+        }
+        const deltaX = Math.abs(maxUxCur - maxUxPrev), deltaZ = Math.abs(maxUzCur - maxUzPrev);
+        const ratioX = deltaX / storyH, ratioZ = deltaZ / storyH;
+        const maxRatio = Math.max(ratioX, ratioZ);
+        drifts.push({
+          level, height: storyH, driftX: deltaX, driftZ: deltaZ, ratioX, ratioZ,
+          status: maxRatio > driftLimit ? 'fail' : maxRatio > driftLimit * 0.8 ? 'warn' : 'ok',
+        });
+      }
+      if (drifts.length > 0) data.storyDrifts = drifts;
+    }
+
+    openReport(data);
+  }
+
+  function getTabCount(id: ProTab): string {
+    switch (id) {
+      case 'nodes': return nodeCount > 0 ? String(nodeCount) : '';
+      case 'elements': return elemCount > 0 ? String(elemCount) : '';
+      case 'loads': return loadCount > 0 ? String(loadCount) : '';
+      default: return '';
+    }
+  }
+</script>
+
+<div class="pro-panel">
+  <!-- Action bar -->
+  <div class="pro-actions">
+    <button class="pro-example-btn" onclick={() => { modelStore.loadExample('pro-edificio-7p'); uiStore.includeSelfWeight = true; uiStore.showGrid3D = false; uiStore.showAxes3D = false; setTimeout(() => window.dispatchEvent(new Event('dedaliano-zoom-to-fit')), 100); }} title={t('pro.exampleTitle')}>
+      {t('pro.exampleBtn')}
+    </button>
+    <button class="pro-solve-btn" onclick={handleSolve} disabled={!hasModel || solving}>
+      {solving ? t('pro.solving') : t('pro.solve')}
+    </button>
+    <button class="pro-report-btn" onclick={handleOpenReportDialog} disabled={modelStore.nodes.size === 0} title={t('pro.reportTitle')}>
+      {t('pro.reportBtn')}
+    </button>
+  </div>
+  {#if solveError}
+    <div class="pro-solve-error">{solveError}</div>
+  {/if}
+
+  <!-- Grouped tab navigation -->
+  <nav class="pro-nav">
+    {#each tabGroups as group}
+      <div class="tab-group">
+        <span class="tab-group-label">{group.label}</span>
+        <div class="tab-group-buttons">
+          {#each group.tabs as tab}
+            <button
+              class="pro-tab"
+              class:active={activeTab === tab.id}
+              onclick={() => { tabError = null; activeTab = tab.id; }}
+            >
+              {tab.label}
+              {#if tab.id === 'diagnostics' && diagCount > 0}
+                <span class="badge badge-error">{diagCount}</span>
+              {:else}
+                {@const count = getTabCount(tab.id)}
+                {#if count}
+                  <span class="badge badge-count">{count}</span>
+                {/if}
+              {/if}
+            </button>
+          {/each}
+        </div>
+      </div>
+    {/each}
+  </nav>
+
+  <!-- Tab content -->
+  <div class="pro-content">
+    <svelte:boundary onerror={(e) => { tabError = String(e); console.error('ProPanel tab error:', e); }}>
+      {#if tabError}
+        <div class="pro-tab-error">
+          <p>{t('pro.errorInTab').replace('{tab}', activeTab)}</p>
+          <pre>{tabError}</pre>
+          <button onclick={() => { tabError = null; activeTab = 'nodes'; }}>{t('pro.backToNodes')}</button>
+        </div>
+      {:else if activeTab === 'nodes'}
+        <ProNodesTab />
+      {:else if activeTab === 'elements'}
+        <ProElementsTab />
+      {:else if activeTab === 'shells'}
+        <ProShellTab />
+      {:else if activeTab === 'materials'}
+        <ProMaterialsTab />
+      {:else if activeTab === 'sections'}
+        <ProSectionsTab />
+      {:else if activeTab === 'supports'}
+        <ProSupportsTab />
+      {:else if activeTab === 'constraints'}
+        <ProConstraintsTab />
+      {:else if activeTab === 'loads'}
+        <ProLoadsTab />
+      {:else if activeTab === 'advanced'}
+        <ProAdvancedTab bind:advancedResults={advancedResultsRef} />
+      {:else if activeTab === 'results'}
+        <ProResultsTab />
+      {:else if activeTab === 'verification'}
+        <ProVerificationTab bind:verifications={verificationsRef} />
+      {:else if activeTab === 'connections'}
+        <ProConnectionsTab />
+      {:else if activeTab === 'diagnostics'}
+        <ProDiagnosticsTab />
+      {/if}
+    </svelte:boundary>
+  </div>
+</div>
+
+<ProReportDialog
+  open={showReportDialog}
+  hasResults={!!resultsStore.results3D}
+  hasVerifications={verificationsRef.length > 0}
+  hasAdvanced={Object.keys(advancedResultsRef).length > 0}
+  hasDrift={false}
+  hasDiagnostics={resultsStore.diagnostics3D.length > 0}
+  hasQuantities={verificationsRef.length > 0}
+  ongenerate={exportReport}
+  onclose={() => { showReportDialog = false; }}
+/>
+
+<style>
+  .pro-panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    background: #16213e;
+    color: #ddd;
+  }
+
+  /* ─── Action bar ─── */
+  .pro-actions {
+    display: flex;
+    gap: 6px;
+    padding: 6px 10px;
+    background: #0d1b33;
+    border-bottom: 1px solid #1a3a5a;
+    flex-shrink: 0;
+    justify-content: flex-end;
+  }
+
+  .pro-example-btn {
+    padding: 5px 12px;
+    font-size: 0.72rem;
+    font-weight: 500;
+    color: #f0a500;
+    background: transparent;
+    border: 1px solid #f0a50044;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .pro-example-btn:hover { background: #f0a50018; }
+
+  .pro-solve-btn {
+    padding: 5px 18px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #fff;
+    background: linear-gradient(135deg, #4ecdc4, #36b5ad);
+    border: 1px solid #4ecdc4;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .pro-solve-btn:hover { background: linear-gradient(135deg, #5fe0d7, #4ecdc4); }
+  .pro-solve-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+  .pro-report-btn {
+    padding: 5px 16px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #fff;
+    background: linear-gradient(135deg, #e94560, #c73e54);
+    border: 1px solid #e94560;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .pro-report-btn:hover { background: linear-gradient(135deg, #ff5a75, #e94560); }
+  .pro-report-btn:disabled { opacity: 0.3; cursor: not-allowed; }
+
+  .pro-solve-error {
+    padding: 4px 10px;
+    font-size: 0.7rem;
+    color: #ff8a9e;
+    background: rgba(233, 69, 96, 0.1);
+    border-bottom: 1px solid #1a3a5a;
+  }
+
+  /* ─── Grouped tab navigation ─── */
+  .pro-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0;
+    padding: 4px 4px 0;
+    background: #0a1a30;
+    border-bottom: 1px solid #1a4a7a;
+    flex-shrink: 0;
+  }
+
+  .tab-group {
+    display: flex;
+    align-items: center;
+    gap: 1px;
+    padding: 2px 3px;
+    min-width: 0;
+  }
+
+  .tab-group-label {
+    font-size: 0.5rem;
+    font-weight: 600;
+    color: #556;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0 3px 0 1px;
+    white-space: nowrap;
+    writing-mode: horizontal-tb;
+  }
+
+  .tab-group-buttons {
+    display: flex;
+    gap: 1px;
+  }
+
+  .pro-tab {
+    padding: 4px 7px;
+    font-size: 0.7rem;
+    font-weight: 500;
+    color: #778;
+    background: #0f2840;
+    border: none;
+    border-radius: 3px 3px 0 0;
+    cursor: pointer;
+    transition: all 0.15s;
+    white-space: nowrap;
+    position: relative;
+  }
+
+  .pro-tab:hover {
+    color: #ccc;
+    background: #1a3860;
+  }
+
+  .pro-tab.active {
+    color: #fff;
+    background: #16213e;
+    border-bottom: 2px solid #e94560;
+  }
+
+  .badge {
+    display: inline-block;
+    margin-left: 3px;
+    padding: 0 4px;
+    font-size: 0.55rem;
+    font-weight: 700;
+    border-radius: 6px;
+    min-width: 12px;
+    text-align: center;
+    line-height: 13px;
+    vertical-align: middle;
+  }
+
+  .badge-error {
+    background: #e94560;
+    color: #fff;
+  }
+
+  .badge-count {
+    background: #1a4a7a;
+    color: #8ab;
+  }
+
+  /* ─── Content area ─── */
+  .pro-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0;
+  }
+
+  .pro-tab-error {
+    padding: 16px;
+    color: #ff6b6b;
+    font-size: 0.8rem;
+  }
+  .pro-tab-error pre {
+    background: #1a0a0a;
+    padding: 8px;
+    border-radius: 4px;
+    overflow-x: auto;
+    font-size: 0.7rem;
+    margin: 8px 0;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+  .pro-tab-error button {
+    padding: 6px 14px;
+    background: #0f3460;
+    border: 1px solid #1a4a7a;
+    color: #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.72rem;
+  }
+</style>

--- a/web/src/components/pro/ProReportDialog.svelte
+++ b/web/src/components/pro/ProReportDialog.svelte
@@ -1,0 +1,238 @@
+<script lang="ts">
+  import { t } from '../../lib/i18n';
+
+  /** Report configuration passed to the generator */
+  export interface ReportConfig {
+    companyName: string;
+    companyLogo: string | null; // data URL
+    projectAddress: string;
+    engineerName: string;
+    revision: string;
+    sections: {
+      modelData: boolean;
+      results: boolean;
+      verification: boolean;
+      advancedAnalysis: boolean;
+      storyDrift: boolean;
+      diagnostics: boolean;
+      quantities: boolean;
+      loads: boolean;
+    };
+  }
+
+  interface Props {
+    open: boolean;
+    hasResults: boolean;
+    hasVerifications: boolean;
+    hasAdvanced: boolean;
+    hasDrift: boolean;
+    hasDiagnostics: boolean;
+    hasQuantities: boolean;
+    ongenerate: (config: ReportConfig) => void;
+    onclose: () => void;
+  }
+
+  let { open, hasResults, hasVerifications, hasAdvanced, hasDrift, hasDiagnostics, hasQuantities, ongenerate, onclose }: Props = $props();
+
+  // ─── Persistent state (localStorage) ─────────────────────
+  const STORAGE_KEY = 'dedaliano-report-config';
+
+  function loadSaved(): Partial<ReportConfig> {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : {};
+    } catch { return {}; }
+  }
+
+  function save(cfg: Partial<ReportConfig>): void {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(cfg)); } catch { /* ignore */ }
+  }
+
+  const saved = loadSaved();
+
+  let companyName = $state(saved.companyName ?? '');
+  let companyLogo = $state<string | null>(saved.companyLogo ?? null);
+  let projectAddress = $state(saved.projectAddress ?? '');
+  let engineerName = $state(saved.engineerName ?? '');
+  let revision = $state(saved.revision ?? '1');
+
+  let secModelData = $state(true);
+  let secResults = $state(true);
+  let secVerification = $state(true);
+  let secAdvanced = $state(true);
+  let secDrift = $state(true);
+  let secDiagnostics = $state(true);
+  let secQuantities = $state(true);
+  let secLoads = $state(true);
+
+  function handleLogoUpload(e: Event) {
+    const input = e.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    if (file.size > 500_000) { alert(t('report.logoTooLarge')); return; }
+    const reader = new FileReader();
+    reader.onload = () => {
+      companyLogo = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  }
+
+  function removeLogo() {
+    companyLogo = null;
+  }
+
+  function handleGenerate() {
+    // Persist company info for next time
+    save({ companyName, companyLogo, projectAddress, engineerName, revision });
+
+    ongenerate({
+      companyName,
+      companyLogo,
+      projectAddress,
+      engineerName,
+      revision,
+      sections: {
+        modelData: secModelData,
+        results: secResults,
+        verification: secVerification,
+        advancedAnalysis: secAdvanced,
+        storyDrift: secDrift,
+        diagnostics: secDiagnostics,
+        quantities: secQuantities,
+        loads: secLoads,
+      },
+    });
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onclose();
+  }
+</script>
+
+{#if open}
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<div class="rpt-overlay" onkeydown={handleKeydown} onclick={onclose} role="dialog" aria-modal="true">
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="rpt-dialog" onclick={(e) => e.stopPropagation()}>
+    <div class="rpt-header">
+      <h2>{t('report.configTitle')}</h2>
+      <button class="rpt-close" onclick={onclose}>&times;</button>
+    </div>
+
+    <div class="rpt-body">
+      <!-- Company & project info -->
+      <fieldset class="rpt-fieldset">
+        <legend>{t('report.projectInfo')}</legend>
+
+        <div class="rpt-logo-row">
+          <label class="rpt-label">{t('report.companyLogo')}</label>
+          <div class="rpt-logo-area">
+            {#if companyLogo}
+              <img src={companyLogo} alt="Logo" class="rpt-logo-preview" />
+              <button class="rpt-btn-sm rpt-btn-danger" onclick={removeLogo}>{t('report.removeLogo')}</button>
+            {:else}
+              <input type="file" accept="image/png,image/jpeg,image/svg+xml" onchange={handleLogoUpload} class="rpt-file-input" />
+            {/if}
+          </div>
+        </div>
+
+        <div class="rpt-field">
+          <label class="rpt-label">{t('report.companyName')}</label>
+          <input type="text" bind:value={companyName} placeholder={t('report.companyNamePh')} class="rpt-input" />
+        </div>
+
+        <div class="rpt-field">
+          <label class="rpt-label">{t('report.engineerName')}</label>
+          <input type="text" bind:value={engineerName} placeholder={t('report.engineerNamePh')} class="rpt-input" />
+        </div>
+
+        <div class="rpt-field">
+          <label class="rpt-label">{t('report.projectAddress')}</label>
+          <input type="text" bind:value={projectAddress} placeholder={t('report.projectAddressPh')} class="rpt-input" />
+        </div>
+
+        <div class="rpt-field">
+          <label class="rpt-label">{t('report.revision')}</label>
+          <input type="text" bind:value={revision} placeholder="1" class="rpt-input rpt-input-sm" />
+        </div>
+      </fieldset>
+
+      <!-- Sections to include -->
+      <fieldset class="rpt-fieldset">
+        <legend>{t('report.includeSections')}</legend>
+        <div class="rpt-checks">
+          <label class="rpt-check"><input type="checkbox" bind:checked={secModelData} /> {t('report.secModelData')}</label>
+          <label class="rpt-check"><input type="checkbox" bind:checked={secLoads} /> {t('report.secLoads')}</label>
+          <label class="rpt-check"><input type="checkbox" bind:checked={secResults} disabled={!hasResults} /> {t('report.secResults')} {#if !hasResults}<span class="rpt-hint">({t('report.noData')})</span>{/if}</label>
+          <label class="rpt-check"><input type="checkbox" bind:checked={secVerification} disabled={!hasVerifications} /> {t('report.secVerification')} {#if !hasVerifications}<span class="rpt-hint">({t('report.noData')})</span>{/if}</label>
+          <label class="rpt-check"><input type="checkbox" bind:checked={secAdvanced} disabled={!hasAdvanced} /> {t('report.secAdvanced')} {#if !hasAdvanced}<span class="rpt-hint">({t('report.noData')})</span>{/if}</label>
+          <label class="rpt-check"><input type="checkbox" bind:checked={secDrift} disabled={!hasDrift} /> {t('report.secDrift')} {#if !hasDrift}<span class="rpt-hint">({t('report.noData')})</span>{/if}</label>
+          <label class="rpt-check"><input type="checkbox" bind:checked={secQuantities} disabled={!hasQuantities} /> {t('report.secQuantities')} {#if !hasQuantities}<span class="rpt-hint">({t('report.noData')})</span>{/if}</label>
+          <label class="rpt-check"><input type="checkbox" bind:checked={secDiagnostics} disabled={!hasDiagnostics} /> {t('report.secDiagnostics')} {#if !hasDiagnostics}<span class="rpt-hint">({t('report.noData')})</span>{/if}</label>
+        </div>
+      </fieldset>
+    </div>
+
+    <div class="rpt-footer">
+      <button class="rpt-btn rpt-btn-secondary" onclick={onclose}>{t('report.cancel')}</button>
+      <button class="rpt-btn rpt-btn-primary" onclick={handleGenerate}>{t('report.generate')}</button>
+    </div>
+  </div>
+</div>
+{/if}
+
+<style>
+  .rpt-overlay {
+    position: fixed; inset: 0; z-index: 9999;
+    background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center;
+  }
+  .rpt-dialog {
+    background: #1a1a2e; color: #e0e0e0; border-radius: 10px;
+    width: 480px; max-height: 85vh; display: flex; flex-direction: column;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.5); border: 1px solid #2a2a4a;
+  }
+  .rpt-header {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 16px 20px; border-bottom: 1px solid #2a2a4a;
+  }
+  .rpt-header h2 { margin: 0; font-size: 16px; color: #fff; }
+  .rpt-close { background: none; border: none; color: #888; font-size: 22px; cursor: pointer; padding: 0 4px; }
+  .rpt-close:hover { color: #fff; }
+  .rpt-body { padding: 16px 20px; overflow-y: auto; flex: 1; }
+  .rpt-fieldset {
+    border: 1px solid #2a2a4a; border-radius: 6px; padding: 12px 14px; margin-bottom: 14px;
+  }
+  .rpt-fieldset legend { color: #4ecdc4; font-size: 12px; font-weight: 600; padding: 0 6px; text-transform: uppercase; }
+  .rpt-field { margin-bottom: 10px; }
+  .rpt-label { display: block; font-size: 11px; color: #aaa; margin-bottom: 3px; }
+  .rpt-input {
+    width: 100%; padding: 6px 8px; background: #12122a; border: 1px solid #333; border-radius: 4px;
+    color: #e0e0e0; font-size: 12px;
+  }
+  .rpt-input:focus { border-color: #4ecdc4; outline: none; }
+  .rpt-input-sm { width: 80px; }
+  .rpt-logo-row { display: flex; align-items: center; gap: 12px; margin-bottom: 10px; }
+  .rpt-logo-area { display: flex; align-items: center; gap: 8px; }
+  .rpt-logo-preview { max-height: 40px; max-width: 120px; border-radius: 4px; border: 1px solid #333; }
+  .rpt-file-input { font-size: 11px; color: #aaa; }
+  .rpt-checks { display: flex; flex-direction: column; gap: 6px; }
+  .rpt-check { font-size: 12px; cursor: pointer; display: flex; align-items: center; gap: 6px; }
+  .rpt-check input[type="checkbox"] { accent-color: #4ecdc4; }
+  .rpt-check input:disabled { opacity: 0.4; }
+  .rpt-hint { color: #666; font-size: 10px; }
+  .rpt-footer {
+    display: flex; justify-content: flex-end; gap: 8px;
+    padding: 12px 20px; border-top: 1px solid #2a2a4a;
+  }
+  .rpt-btn {
+    padding: 8px 20px; border-radius: 6px; font-size: 13px; font-weight: 600;
+    cursor: pointer; border: none; transition: background 0.15s;
+  }
+  .rpt-btn-primary { background: #4ecdc4; color: #111; }
+  .rpt-btn-primary:hover { background: #3dbdb4; }
+  .rpt-btn-secondary { background: #2a2a4a; color: #ccc; }
+  .rpt-btn-secondary:hover { background: #3a3a5a; }
+  .rpt-btn-sm { padding: 3px 8px; font-size: 10px; border-radius: 3px; cursor: pointer; border: none; }
+  .rpt-btn-danger { background: #c0392b; color: #fff; }
+  .rpt-btn-danger:hover { background: #e74c3c; }
+</style>

--- a/web/src/components/pro/ProResultsTab.svelte
+++ b/web/src/components/pro/ProResultsTab.svelte
@@ -1,0 +1,707 @@
+<script lang="ts">
+  import { modelStore, uiStore, resultsStore } from '../../lib/store';
+  import { t } from '../../lib/i18n';
+  import { runGlobalSolve } from '../../lib/engine/live-calc';
+
+  let solveError = $state<string | null>(null);
+  let includeSelfWeight = $state(false);
+  let solving = $state(false);
+
+  const results = $derived(resultsStore.results3D);
+  const hasModel = $derived(modelStore.nodes.size > 0 && modelStore.elements.size > 0);
+  const hasCombinations = $derived(resultsStore.hasCombinations3D);
+
+  // View mode
+  type ViewMode = 'single' | 'combo' | 'envelope';
+  let viewMode = $state<ViewMode>('single');
+  let selectedCaseId = $state<number | null>(null);
+  let selectedComboId = $state<number | null>(null);
+
+  function handleSolve() {
+    solveError = null;
+    solving = true;
+    uiStore.includeSelfWeight = includeSelfWeight;
+    try {
+      // First solve single (all loads)
+      runGlobalSolve();
+      if (!resultsStore.results3D) {
+        solveError = t('pro.noResults');
+        solving = false;
+        return;
+      }
+
+      // Now solve combinations if load cases exist
+      if (modelStore.loadCases.length > 0 && modelStore.combinations.length > 0) {
+        try {
+          const comboResult = modelStore.solveCombinations3D(includeSelfWeight, false, true);
+          if (typeof comboResult === 'string') {
+            console.warn('Combinations warning:', comboResult);
+          } else if (comboResult) {
+            resultsStore.setCombinationResults3D(comboResult.perCase, comboResult.perCombo, comboResult.envelope);
+            viewMode = 'envelope';
+          }
+        } catch (comboErr: any) {
+          console.warn('Combinations 3D failed (results still available):', comboErr);
+        }
+      }
+    } catch (e: any) {
+      console.error('PRO solve error:', e);
+      solveError = e?.message || String(e) || t('pro.unknownError');
+    }
+    solving = false;
+  }
+
+  function switchView(mode: ViewMode) {
+    viewMode = mode;
+    if (mode === 'envelope') {
+      resultsStore.activeView = 'envelope';
+    } else if (mode === 'combo' && selectedComboId !== null) {
+      resultsStore.activeComboId = selectedComboId;
+      resultsStore.activeView = 'combo';
+    } else if (mode === 'single') {
+      if (selectedCaseId !== null) {
+        resultsStore.activeCaseId = selectedCaseId;
+      } else {
+        resultsStore.activeView = 'single';
+      }
+    }
+  }
+
+  function onCaseChange(e: Event) {
+    const id = Number((e.target as HTMLSelectElement).value);
+    selectedCaseId = id;
+    resultsStore.activeCaseId = id;
+  }
+
+  function onComboChange(e: Event) {
+    const id = Number((e.target as HTMLSelectElement).value);
+    selectedComboId = id;
+    resultsStore.activeComboId = id;
+    resultsStore.activeView = 'combo';
+  }
+
+  function fmtNum(n: number): string {
+    if (n === 0) return '0';
+    if (Math.abs(n) < 0.001) return n.toExponential(2);
+    if (Math.abs(n) < 1) return n.toFixed(4);
+    return n.toFixed(2);
+  }
+
+  const caseKeys = $derived([...resultsStore.perCase3D.keys()]);
+  const comboKeys = $derived([...resultsStore.perCombo3D.keys()]);
+
+</script>
+
+<div class="pro-res">
+  <div class="pro-res-header">
+    <div class="pro-res-solve-row">
+      <button class="pro-solve-btn" onclick={handleSolve} disabled={!hasModel || solving}>
+        {solving ? t('pro.solving') : t('pro.solve')}
+      </button>
+      <label class="pro-sw-label">
+        <input type="checkbox" bind:checked={includeSelfWeight} />
+        {t('pro.selfWeight')}
+      </label>
+    </div>
+    {#if solveError}
+      <div class="pro-solve-error">{solveError}</div>
+    {/if}
+    {#if results}
+      <span class="pro-res-status">{t('pro.solvedStatus').replace('{reactions}', String(results.reactions.length)).replace('{elements}', String(results.elementForces.length))}</span>
+    {/if}
+  </div>
+
+  {#if results}
+    <!-- 3D Visualization controls -->
+    <div class="pro-viz-section">
+      <div class="pro-viz-row">
+        <label class="pro-viz-label">{t('pro.diagramLabel')}</label>
+        <select class="pro-viz-sel" bind:value={resultsStore.diagramType}>
+          <option value="none">{t('pro.diagNone')}</option>
+          <option value="deformed">{t('pro.diagDeformed')}</option>
+          <option value="momentY">My</option>
+          <option value="momentZ">Mz</option>
+          <option value="shearY">Vy</option>
+          <option value="shearZ">Vz</option>
+          <option value="axial">N</option>
+          <option value="torsion">T</option>
+          <option value="axialColor">{t('pro.diagAxialColor')}</option>
+          <option value="colorMap">{t('pro.diagColorMap')}</option>
+          <option value="verification">{t('pro.diagVerification')}</option>
+        </select>
+      </div>
+
+      {#if resultsStore.diagramType === 'colorMap'}
+        <div class="pro-viz-row">
+          <label class="pro-viz-label">{t('pro.variableLabel')}</label>
+          <select class="pro-viz-sel" bind:value={resultsStore.colorMapKind}>
+            <option value="moment">{t('pro.varMoment')}</option>
+            <option value="shear">{t('pro.varShear')}</option>
+            <option value="axial">{t('pro.varAxial')}</option>
+            <option value="stressRatio">{t('pro.varStressRatio')}</option>
+            <option value="vonMises">Von Mises (σ)</option>
+            <option value="shellVonMises">Shell σ Von Mises</option>
+          </select>
+        </div>
+      {/if}
+
+      {#if resultsStore.diagramType === 'deformed'}
+        <div class="pro-viz-row">
+          <label class="pro-viz-label">{t('pro.scaleLabel')}</label>
+          <input type="range" class="pro-viz-range" min={1} max={500} bind:value={resultsStore.deformedScale} />
+          <span class="pro-viz-val">{resultsStore.deformedScale}×</span>
+        </div>
+      {/if}
+
+      <div class="pro-viz-row">
+        <label class="pro-viz-check">
+          <input type="checkbox" bind:checked={resultsStore.showReactions} />
+          {t('pro.showReactions3D')}
+        </label>
+      </div>
+      <div class="pro-viz-row">
+        <label class="pro-viz-check">
+          <input type="checkbox" bind:checked={resultsStore.showConstraintForces} />
+          {t('config.showConstraintForces')}
+        </label>
+      </div>
+    </div>
+
+    <!-- View mode selector -->
+    {#if hasCombinations}
+      <div class="pro-view-selector">
+        <button class="pro-view-btn" class:active={viewMode === 'single'} onclick={() => switchView('single')}>{t('pro.viewCase')}</button>
+        <button class="pro-view-btn" class:active={viewMode === 'combo'} onclick={() => switchView('combo')}>{t('pro.viewCombo')}</button>
+        <button class="pro-view-btn" class:active={viewMode === 'envelope'} onclick={() => switchView('envelope')}>{t('pro.viewEnvelope')}</button>
+
+        {#if viewMode === 'single' && caseKeys.length > 0}
+          <select class="pro-view-sel" onchange={onCaseChange}>
+            {#each caseKeys as cid}
+              {@const lc = modelStore.loadCases.find(c => c.id === cid)}
+              <option value={cid}>{lc ? lc.name : `${t('pro.caseN')}${cid}`}</option>
+            {/each}
+          </select>
+        {/if}
+
+        {#if viewMode === 'combo' && comboKeys.length > 0}
+          <select class="pro-view-sel" onchange={onComboChange}>
+            {#each comboKeys as cid}
+              {@const cb = modelStore.combinations.find(c => c.id === cid)}
+              <option value={cid}>{cb ? cb.name : `${t('pro.comboN')}${cid}`}</option>
+            {/each}
+          </select>
+        {/if}
+      </div>
+    {/if}
+
+    <!-- Results tables — each collapsible -->
+    <div class="pro-res-scroll">
+
+      <details class="res-detail" open>
+        <summary class="pro-res-section-title">{t('pro.reactionsTitle')} <span class="res-count">({results.reactions.length})</span></summary>
+        <div class="pro-res-table-wrap">
+          <table class="pro-res-table">
+            <thead>
+              <tr>
+                <th>{t('pro.nodeLabel')}</th>
+                <th>Fx (kN)</th>
+                <th>Fy (kN)</th>
+                <th>Fz (kN)</th>
+                <th>Mx (kN·m)</th>
+                <th>My (kN·m)</th>
+                <th>Mz (kN·m)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each results.reactions as r}
+                <tr>
+                  <td class="col-id">{r.nodeId}</td>
+                  <td class="col-num">{fmtNum(r.fx)}</td>
+                  <td class="col-num">{fmtNum(r.fy)}</td>
+                  <td class="col-num">{fmtNum(r.fz)}</td>
+                  <td class="col-num">{fmtNum(r.mx)}</td>
+                  <td class="col-num">{fmtNum(r.my)}</td>
+                  <td class="col-num">{fmtNum(r.mz)}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      </details>
+
+      <details class="res-detail" open>
+        <summary class="pro-res-section-title">{t('pro.forcesTitle')} <span class="res-count">({results.elementForces.length})</span></summary>
+        <div class="pro-res-table-wrap">
+          <table class="pro-res-table">
+            <thead>
+              <tr>
+                <th>{t('pro.elemLabel')}</th>
+                <th>Ext.</th>
+                <th>N</th>
+                <th>Vy</th>
+                <th>Vz</th>
+                <th>T</th>
+                <th>My</th>
+                <th>Mz</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each results.elementForces as ef}
+                <tr>
+                  <td class="col-id" rowspan="2">{ef.elementId}</td>
+                  <td class="col-end">i</td>
+                  <td class="col-num">{fmtNum(ef.nStart)}</td>
+                  <td class="col-num">{fmtNum(ef.vyStart)}</td>
+                  <td class="col-num">{fmtNum(ef.vzStart)}</td>
+                  <td class="col-num">{fmtNum(ef.mxStart)}</td>
+                  <td class="col-num">{fmtNum(ef.myStart)}</td>
+                  <td class="col-num">{fmtNum(ef.mzStart)}</td>
+                </tr>
+                <tr>
+                  <td class="col-end">j</td>
+                  <td class="col-num">{fmtNum(ef.nEnd)}</td>
+                  <td class="col-num">{fmtNum(ef.vyEnd)}</td>
+                  <td class="col-num">{fmtNum(ef.vzEnd)}</td>
+                  <td class="col-num">{fmtNum(ef.mxEnd)}</td>
+                  <td class="col-num">{fmtNum(ef.myEnd)}</td>
+                  <td class="col-num">{fmtNum(ef.mzEnd)}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      </details>
+
+      <details class="res-detail">
+        <summary class="pro-res-section-title">{t('pro.displacementsTitle')} <span class="res-count">({results.displacements.length})</span></summary>
+        <div class="pro-res-table-wrap">
+          <table class="pro-res-table">
+            <thead>
+              <tr>
+                <th>{t('pro.nodeLabel')}</th>
+                <th>ux (m)</th>
+                <th>uy (m)</th>
+                <th>uz (m)</th>
+                <th>&#x03B8;x</th>
+                <th>&#x03B8;y</th>
+                <th>&#x03B8;z</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each results.displacements as d}
+                <tr>
+                  <td class="col-id">{d.nodeId}</td>
+                  <td class="col-num">{fmtNum(d.ux)}</td>
+                  <td class="col-num">{fmtNum(d.uy)}</td>
+                  <td class="col-num">{fmtNum(d.uz)}</td>
+                  <td class="col-num">{fmtNum(d.rx)}</td>
+                  <td class="col-num">{fmtNum(d.ry)}</td>
+                  <td class="col-num">{fmtNum(d.rz)}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      </details>
+
+      {#if results.plateStresses?.length || results.quadStresses?.length}
+        <details class="res-detail" open>
+          <summary class="pro-res-section-title">{t('pro.shellStresses')} <span class="res-count">({(results.plateStresses?.length ?? 0) + (results.quadStresses?.length ?? 0)})</span></summary>
+          <div class="pro-res-table-wrap">
+            {#if results.plateStresses?.length}
+              <table class="pro-res-table">
+                <thead><tr>
+                  <th>Elem</th><th>&sigma;xx</th><th>&sigma;yy</th><th>&tau;xy</th>
+                  <th>mx</th><th>my</th><th>mxy</th><th>Von Mises</th>
+                </tr></thead>
+                <tbody>
+                  {#each results.plateStresses as ps}
+                    <tr>
+                      <td class="col-id">{ps.elementId}</td>
+                      <td class="col-num">{fmtNum(ps.sigmaXx)}</td>
+                      <td class="col-num">{fmtNum(ps.sigmaYy)}</td>
+                      <td class="col-num">{fmtNum(ps.tauXy)}</td>
+                      <td class="col-num">{fmtNum(ps.mx)}</td>
+                      <td class="col-num">{fmtNum(ps.my)}</td>
+                      <td class="col-num">{fmtNum(ps.mxy)}</td>
+                      <td class="col-num">{fmtNum(ps.vonMises)}</td>
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+            {/if}
+            {#if results.quadStresses?.length}
+              <table class="pro-res-table">
+                <thead><tr>
+                  <th>Elem</th><th>&sigma;xx</th><th>&sigma;yy</th><th>&tau;xy</th>
+                  <th>mx</th><th>my</th><th>mxy</th><th>Von Mises</th>
+                </tr></thead>
+                <tbody>
+                  {#each results.quadStresses as qs}
+                    <tr>
+                      <td class="col-id">{qs.elementId}</td>
+                      <td class="col-num">{fmtNum(qs.sigmaXx)}</td>
+                      <td class="col-num">{fmtNum(qs.sigmaYy)}</td>
+                      <td class="col-num">{fmtNum(qs.tauXy)}</td>
+                      <td class="col-num">{fmtNum(qs.mx)}</td>
+                      <td class="col-num">{fmtNum(qs.my)}</td>
+                      <td class="col-num">{fmtNum(qs.mxy)}</td>
+                      <td class="col-num">{fmtNum(qs.vonMises)}</td>
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+            {/if}
+          </div>
+        </details>
+      {/if}
+
+      {#if results.quadStresses?.some(qs => qs.nodalVonMises?.length)}
+        {@const nodalQuads = results.quadStresses!.filter(qs => qs.nodalVonMises?.length)}
+        <details class="res-detail">
+          <summary class="pro-res-section-title">{t('pro.nodalShellStresses')} <span class="res-count">({nodalQuads.length})</span></summary>
+          <div class="pro-res-table-wrap">
+            <table class="pro-res-table">
+              <thead><tr>
+                <th>{t('pro.elemLabel')}</th>
+                <th>{t('pro.nodalVmNode')} 1</th>
+                <th>{t('pro.nodalVmNode')} 2</th>
+                <th>{t('pro.nodalVmNode')} 3</th>
+                <th>{t('pro.nodalVmNode')} 4</th>
+                <th>Min</th>
+                <th>Max</th>
+              </tr></thead>
+              <tbody>
+                {#each nodalQuads as qs}
+                  {@const nvm = qs.nodalVonMises!}
+                  {@const quadDef = modelStore.quads.get(qs.elementId)}
+                  {@const vmMin = Math.min(...nvm)}
+                  {@const vmMax = Math.max(...nvm)}
+                  <tr>
+                    <td class="col-id">{qs.elementId}</td>
+                    {#each nvm as vm, i}
+                      <td class="col-num" title="{quadDef ? t('pro.nodeLabel') + ' ' + quadDef.nodes[i] : ''}">
+                        {fmtNum(vm)}
+                      </td>
+                    {/each}
+                    {#if nvm.length < 4}
+                      {#each { length: 4 - nvm.length } as _}
+                        <td class="col-num">—</td>
+                      {/each}
+                    {/if}
+                    <td class="col-num col-min">{fmtNum(vmMin)}</td>
+                    <td class="col-num col-max">{fmtNum(vmMax)}</td>
+                  </tr>
+                  {#if quadDef}
+                    <tr class="nodal-ids-row">
+                      <td></td>
+                      {#each quadDef.nodes as nid}
+                        <td class="col-node-id">N{nid}</td>
+                      {/each}
+                      <td></td><td></td>
+                    </tr>
+                  {/if}
+                {/each}
+              </tbody>
+            </table>
+          </div>
+        </details>
+      {/if}
+
+      {#if (results.constraintForces?.length ?? 0) > 0 || resultsStore.constraintForces3D.length > 0}
+        {@const cForces = results.constraintForces?.length ? results.constraintForces : resultsStore.constraintForces3D}
+        <details class="res-detail">
+          <summary class="pro-res-section-title">{t('pro.constraintForces')} <span class="res-count">({cForces.length})</span></summary>
+          <div class="pro-res-table-wrap">
+            <table class="pro-res-table">
+              <thead><tr>
+                <th>{t('pro.nodeLabel')}</th><th>DOF</th><th>{t('pro.forceLabel')}</th>
+              </tr></thead>
+              <tbody>
+                {#each cForces as cf}
+                  <tr>
+                    <td class="col-id">{cf.nodeId}</td>
+                    <td>{cf.dof}</td>
+                    <td class="col-num">{fmtNum(cf.force)}</td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          </div>
+        </details>
+      {/if}
+
+      {#if results.diagnostics?.length}
+        <details class="res-detail">
+          <summary class="pro-res-section-title">{t('pro.diagnosticsTitle')} <span class="res-count">({results.diagnostics.length})</span></summary>
+          <div class="pro-res-table-wrap">
+            <table class="pro-res-table">
+              <thead><tr>
+                <th>{t('pro.elemLabel')}</th><th>{t('pro.metricLabel')}</th><th>{t('pro.valueLabel')}</th><th>{t('pro.thresholdLabel')}</th><th>{t('pro.messageLabel')}</th>
+              </tr></thead>
+              <tbody>
+                {#each results.diagnostics as diag}
+                  <tr>
+                    <td class="col-id">{diag.elementId}</td>
+                    <td>{diag.metric}</td>
+                    <td class="col-num">{fmtNum(diag.value)}</td>
+                    <td class="col-num">{fmtNum(diag.threshold)}</td>
+                    <td style="font-size:0.6rem">{diag.message}</td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          </div>
+        </details>
+      {/if}
+
+    </div>
+  {:else}
+    <div class="pro-empty">
+      {#if hasModel}
+        {t('pro.pressCalculate')}
+      {:else}
+        {t('pro.defineModelFirst')}
+      {/if}
+    </div>
+  {/if}
+
+
+</div>
+
+<style>
+  .pro-res { display: flex; flex-direction: column; height: 100%; overflow: hidden; }
+
+  .pro-res-header {
+    padding: 8px 10px;
+    border-bottom: 1px solid #1a3050;
+    flex-shrink: 0;
+  }
+
+  .pro-res-solve-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .pro-solve-btn {
+    padding: 6px 20px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #fff;
+    background: linear-gradient(135deg, #e94560, #c73e54);
+    border: 1px solid #e94560;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  .pro-solve-btn:hover { background: linear-gradient(135deg, #ff5a75, #e94560); }
+  .pro-solve-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+  .pro-sw-label {
+    font-size: 0.65rem;
+    color: #888;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+  }
+
+  .pro-sw-label input { cursor: pointer; }
+
+  .pro-solve-error {
+    margin-top: 6px;
+    padding: 4px 8px;
+    font-size: 0.7rem;
+    color: #ff8a9e;
+    background: rgba(233, 69, 96, 0.1);
+    border-radius: 3px;
+  }
+
+  .pro-res-status {
+    display: block;
+    margin-top: 6px;
+    font-size: 0.72rem;
+    color: #4ecdc4;
+    font-weight: 500;
+  }
+
+  /* Visualization controls */
+  .pro-viz-section {
+    padding: 6px 10px;
+    border-bottom: 1px solid #1a3050;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    background: #0d1b33;
+    flex-shrink: 0;
+  }
+
+  .pro-viz-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .pro-viz-label {
+    font-size: 0.62rem;
+    font-weight: 600;
+    color: #888;
+    min-width: 55px;
+  }
+
+  .pro-viz-sel {
+    padding: 2px 4px;
+    font-size: 0.64rem;
+    background: #0f2840;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ccc;
+    cursor: pointer;
+    flex: 1;
+  }
+
+  .pro-viz-range {
+    flex: 1;
+    height: 14px;
+    accent-color: #e94560;
+  }
+
+  .pro-viz-val {
+    font-size: 0.6rem;
+    font-family: monospace;
+    color: #4ecdc4;
+    min-width: 36px;
+    text-align: right;
+  }
+
+  .pro-viz-check {
+    font-size: 0.64rem;
+    color: #aaa;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+  }
+
+  .pro-viz-check input { cursor: pointer; }
+
+  /* View mode selector */
+  .pro-view-selector {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 5px 10px;
+    border-bottom: 1px solid #1a3050;
+    flex-wrap: wrap;
+    flex-shrink: 0;
+  }
+
+  .pro-view-btn {
+    padding: 3px 10px;
+    font-size: 0.64rem;
+    font-weight: 600;
+    color: #888;
+    background: #0f2840;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    cursor: pointer;
+  }
+
+  .pro-view-btn:hover { color: #ccc; background: #1a3860; }
+  .pro-view-btn.active { color: #fff; background: #1a4a7a; border-color: #4ecdc4; }
+
+  .pro-view-sel {
+    padding: 3px 6px;
+    font-size: 0.64rem;
+    background: #0f2840;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ccc;
+    cursor: pointer;
+    margin-left: 4px;
+  }
+
+  /* Scrollable results area */
+  .pro-res-scroll {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+  }
+
+  /* Collapsible result sections */
+  .res-detail {
+    border-bottom: 1px solid #1a3050;
+  }
+
+  .res-detail > summary {
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+  }
+
+  .res-detail > summary::-webkit-details-marker { display: none; }
+
+  .res-detail > summary::before {
+    content: '▸ ';
+    font-size: 0.55rem;
+    color: #666;
+  }
+
+  .res-detail[open] > summary::before {
+    content: '▾ ';
+  }
+
+  .pro-res-section-title {
+    padding: 5px 10px;
+    font-size: 0.62rem;
+    font-weight: 600;
+    color: #4ecdc4;
+    text-transform: uppercase;
+    background: #0a1a30;
+    border-bottom: 1px solid #1a3050;
+  }
+
+  .res-count {
+    font-weight: 400;
+    color: #666;
+    font-size: 0.58rem;
+  }
+
+  .pro-res-table-wrap { overflow-x: auto; }
+
+  .pro-res-table { width: 100%; border-collapse: collapse; font-size: 0.68rem; }
+  .pro-res-table thead { position: sticky; top: 0; z-index: 1; }
+  .pro-res-table th {
+    padding: 4px 5px; text-align: left; font-size: 0.56rem; font-weight: 600;
+    color: #888; text-transform: uppercase; background: #0a1a30; border-bottom: 1px solid #1a4a7a;
+  }
+  .pro-res-table td { padding: 3px 5px; border-bottom: 1px solid #0f2030; color: #ccc; }
+  .col-id { width: 30px; color: #666; font-family: monospace; text-align: center; }
+  .col-num { font-family: monospace; text-align: right; font-size: 0.66rem; }
+  .col-end { font-size: 0.6rem; color: #888; font-weight: 600; text-align: center; width: 20px; }
+
+  .nodal-ids-row td {
+    padding: 1px 5px;
+    border-bottom: 1px solid #0f2030;
+  }
+
+  .col-node-id {
+    font-size: 0.54rem;
+    font-family: monospace;
+    color: #556;
+    text-align: right;
+  }
+
+  .col-min { color: #4ecdc4; }
+  .col-max { color: #e94560; }
+
+  .pro-empty {
+    text-align: center;
+    color: #555;
+    font-style: italic;
+    padding: 40px 10px;
+  }
+
+</style>

--- a/web/src/components/pro/ProSectionsTab.svelte
+++ b/web/src/components/pro/ProSectionsTab.svelte
@@ -1,0 +1,669 @@
+<script lang="ts">
+  import { modelStore } from '../../lib/store';
+  import { t } from '../../lib/i18n';
+  import {
+    FAMILY_LIST, PROFILE_FAMILIES, searchProfiles, familyToShape,
+    type ProfileFamily, type SteelProfile,
+  } from '../../lib/data/steel-profiles';
+  import {
+    SECTION_SHAPES, STEEL_SHAPES, CONCRETE_SHAPES,
+    computeSectionProperties, generateSectionName,
+    type ShapeType, type SectionProperties, type MaterialCategory,
+  } from '../../lib/data/section-shapes';
+  import { crossSectionPath } from '../../lib/utils/section-drawing';
+
+  type MainTab = 'catalog' | 'builder';
+  let activeTab = $state<MainTab>('catalog');
+
+  // ─── Profile Catalog state ──────────────────
+  let activeFamily = $state<ProfileFamily>('IPN');
+  let searchQuery = $state('');
+  let filteredProfiles = $derived(searchProfiles(searchQuery, activeFamily));
+
+  const profilePreviewPath = $derived.by(() => {
+    const profiles = PROFILE_FAMILIES[activeFamily];
+    if (!profiles || profiles.length === 0) return null;
+    const rep = profiles[Math.floor(profiles.length / 2)];
+    const shape = familyToShape(activeFamily);
+    return crossSectionPath({
+      shape,
+      h: rep.h,
+      b: rep.b,
+      tw: rep.tw ?? 0,
+      tf: rep.tf ?? 0,
+      t: rep.t ?? 0,
+    });
+  });
+
+  function shapeForFamily(f: ProfileFamily): string {
+    if (f === 'IPE' || f === 'IPN') return 'I';
+    if (f === 'HEB' || f === 'HEA') return 'H';
+    if (f === 'UPN') return 'U';
+    if (f === 'L') return 'L';
+    if (f === 'RHS') return 'RHS';
+    return 'CHS';
+  }
+
+  function addProfile(p: SteelProfile) {
+    modelStore.addSection({
+      name: p.name,
+      a: p.a * 1e-4,
+      iz: p.iz * 1e-8,
+      iy: p.iy * 1e-8,
+      b: p.b / 1000,
+      h: p.h / 1000,
+      shape: shapeForFamily(p.family),
+      tw: p.tw ? p.tw / 1000 : undefined,
+      tf: p.tf ? p.tf / 1000 : undefined,
+      t: p.t ? p.t / 1000 : undefined,
+    });
+  }
+
+  // ─── Shape Builder state ──────────────────
+  let activeCategory = $state<MaterialCategory>('concrete');
+  let activeShape = $state<ShapeType>('concrete-rect');
+  let paramValues = $state<Record<string, number>>({});
+
+  const categoryShapes = $derived(
+    activeCategory === 'steel' ? STEEL_SHAPES : CONCRETE_SHAPES
+  );
+
+  let prevCategory = $state<MaterialCategory | null>(null);
+  $effect(() => {
+    const cat = activeCategory;
+    if (cat !== prevCategory) {
+      prevCategory = cat;
+      const shapes = cat === 'steel' ? STEEL_SHAPES : CONCRETE_SHAPES;
+      if (shapes.length > 0 && !shapes.find(s => s.id === activeShape)) {
+        activeShape = shapes[0].id;
+      }
+    }
+  });
+
+  let prevShape = $state<ShapeType | null>(null);
+  $effect(() => {
+    const shape = activeShape;
+    if (shape !== prevShape) {
+      prevShape = shape;
+      const def = SECTION_SHAPES.find(s => s.id === shape);
+      if (def) {
+        const vals: Record<string, number> = {};
+        for (const p of def.params) {
+          vals[p.id] = p.defaultValue;
+        }
+        paramValues = vals;
+      }
+    }
+  });
+
+  const shapeDef = $derived(SECTION_SHAPES.find(s => s.id === activeShape)!);
+  const computed = $derived(computeSectionProperties(activeShape, paramValues));
+  const autoName = $derived(generateSectionName(activeShape, paramValues));
+
+  const shapePreviewPath = $derived.by(() => {
+    if (!computed || !computed.h || !computed.b) return null;
+    return crossSectionPath({
+      shape: (computed.shape ?? 'rect') as any,
+      h: computed.h,
+      b: computed.b,
+      tw: computed.tw ?? 0,
+      tf: computed.tf ?? 0,
+      t: computed.t ?? 0,
+      tl: computed.tl,
+    });
+  });
+
+  function handleShapeConfirm() {
+    if (!computed) return;
+    modelStore.addSection({
+      name: autoName,
+      a: computed.a,
+      iz: computed.iz,
+      iy: computed.iy,
+      j: computed.j,
+      b: computed.b,
+      h: computed.h,
+      shape: computed.shape,
+      tw: computed.tw,
+      tf: computed.tf,
+      t: computed.t,
+    });
+  }
+
+  // ─── Sections list ──────────────────────
+  const sections = $derived([...modelStore.sections.values()]);
+
+  function removeSec(id: number) {
+    modelStore.removeSection(id);
+  }
+
+  function fmtNum(n: number): string {
+    if (n === 0) return '0';
+    if (Math.abs(n) < 0.001) return n.toExponential(2);
+    return n.toPrecision(4);
+  }
+</script>
+
+<div class="pro-sec">
+  <!-- Collapsible add-section panel -->
+  <details class="add-panel">
+    <summary class="add-panel-summary">{t('pro.addSectionPanel')}</summary>
+    <div class="add-panel-body">
+
+  <!-- Main tabs -->
+  <div class="main-tabs">
+    <button class:active={activeTab === 'catalog'} onclick={() => activeTab = 'catalog'}>
+      {t('dialog.chooseStandardProfile')}
+    </button>
+    <button class:active={activeTab === 'builder'} onclick={() => activeTab = 'builder'}>
+      {t('dialog.buildSection')}
+    </button>
+  </div>
+
+  <!-- ═══ Profile Catalog ═══ -->
+  {#if activeTab === 'catalog'}
+    <div class="tab-body catalog-body">
+      <div class="family-tabs">
+        {#each FAMILY_LIST as fam}
+          <button
+            class="fam-btn"
+            class:active={activeFamily === fam}
+            onclick={() => { activeFamily = fam; searchQuery = ''; }}
+          >{fam}</button>
+        {/each}
+      </div>
+
+      <div class="catalog-top">
+        {#if profilePreviewPath}
+          <div class="profile-preview">
+            <svg viewBox="-90 -90 180 180" class="preview-svg">
+              <path d={profilePreviewPath} fill="none" stroke="#4ecdc4" stroke-width="1.5" fill-rule="evenodd" />
+            </svg>
+          </div>
+        {/if}
+        <div class="search-wrap">
+          <input type="text" placeholder={t('search.profile')} bind:value={searchQuery} />
+        </div>
+      </div>
+
+      <div class="profile-table-wrap">
+        <table class="profile-table">
+          <thead>
+            <tr>
+              <th>{t('table.profile')}</th>
+              <th>h</th>
+              <th>b</th>
+              <th>A (cm²)</th>
+              <th>Iy (cm⁴)</th>
+              <th>Iz (cm⁴)</th>
+              <th>kg/m</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each filteredProfiles as p}
+              <tr class="profile-row" onclick={() => addProfile(p)}>
+                <td class="name-cell">{p.name}</td>
+                <td>{p.h}</td>
+                <td>{p.b}</td>
+                <td>{p.a.toFixed(1)}</td>
+                <td>{p.iy.toFixed(0)}</td>
+                <td>{p.iz.toFixed(0)}</td>
+                <td>{p.weight.toFixed(1)}</td>
+              </tr>
+            {/each}
+            {#if filteredProfiles.length === 0}
+              <tr><td colspan="7" class="no-results">{t('search.noResults')}</td></tr>
+            {/if}
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+  <!-- ═══ Shape Builder ═══ -->
+  {:else}
+    <div class="tab-body builder-body">
+      <div class="cat-toggle">
+        <button class:active={activeCategory === 'concrete'} onclick={() => { activeCategory = 'concrete'; }}>
+          {t('shapeBuilder.concrete')}
+        </button>
+        <button class:active={activeCategory === 'steel'} onclick={() => { activeCategory = 'steel'; }}>
+          {t('shapeBuilder.steel')}
+        </button>
+      </div>
+
+      <div class="shape-tabs">
+        {#each categoryShapes as shape}
+          <button
+            class="shape-btn"
+            class:active={activeShape === shape.id}
+            onclick={() => { activeShape = shape.id; }}
+          >{t(shape.label)}</button>
+        {/each}
+      </div>
+
+      <div class="builder-content">
+        {#if shapePreviewPath}
+          <div class="shape-preview">
+            <svg viewBox="-90 -90 180 180" class="preview-svg">
+              <path d={shapePreviewPath} fill="none" stroke="#4ecdc4" stroke-width="1.5" fill-rule="evenodd" />
+              <circle cx="0" cy="0" r="2" fill="#e94560" opacity="0.7" />
+            </svg>
+          </div>
+        {/if}
+
+        <p class="shape-desc">{t(shapeDef.description)}</p>
+
+        <div class="param-grid">
+          {#each shapeDef.params as p}
+            <label class="param-field">
+              <span>{t(p.label)}</span>
+              <div class="param-input">
+                <input
+                  type="number"
+                  step={p.step}
+                  value={paramValues[p.id] ?? p.defaultValue}
+                  oninput={(e) => {
+                    const v = parseFloat(e.currentTarget.value);
+                    if (!isNaN(v)) paramValues = { ...paramValues, [p.id]: v };
+                  }}
+                />
+                <span class="param-unit">{p.unit}</span>
+              </div>
+            </label>
+          {/each}
+        </div>
+
+        {#if computed}
+          <div class="results-box">
+            <div class="result-row"><span>{t('field.resultName')}</span><span class="result-val">{autoName}</span></div>
+            <div class="result-row"><span>A =</span><span class="result-val">{computed.a.toPrecision(4)} m²</span></div>
+            <div class="result-row"><span>Iy =</span><span class="result-val">{computed.iy.toPrecision(4)} m⁴</span></div>
+            <div class="result-row"><span>Iz =</span><span class="result-val">{computed.iz.toPrecision(4)} m⁴</span></div>
+            {#if computed.j}
+              <div class="result-row"><span>J =</span><span class="result-val">{computed.j.toPrecision(4)} m⁴</span></div>
+            {/if}
+          </div>
+          <button class="confirm-btn" onclick={handleShapeConfirm}>{t('pro.addSection')}</button>
+        {:else}
+          <div class="results-box error"><span>{t('shapeBuilder.invalidDimensions')}</span></div>
+        {/if}
+      </div>
+    </div>
+  {/if}
+
+    </div>
+  </details>
+
+  <!-- Sections table (always visible) -->
+  <div class="sec-list">
+    <div class="sec-list-header">
+      <span class="sec-count">{t('pro.nSections').replace('{n}', String(sections.length))}</span>
+    </div>
+    <div class="sec-table-wrap">
+      <table class="sec-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>{t('pro.thName')}</th>
+            <th>A (m²)</th>
+            <th>Iz (m⁴)</th>
+            <th>Iy (m⁴)</th>
+            <th>J (m⁴)</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each sections as s}
+            <tr>
+              <td class="col-id">{s.id}</td>
+              <td class="col-name">{s.name}</td>
+              <td class="col-num">{fmtNum(s.a)}</td>
+              <td class="col-num">{fmtNum(s.iz)}</td>
+              <td class="col-num">{fmtNum(s.iy ?? 0)}</td>
+              <td class="col-num">{fmtNum(s.j ?? 0)}</td>
+              <td><button class="del-btn" onclick={() => removeSec(s.id)}>×</button></td>
+            </tr>
+          {/each}
+          {#if sections.length === 0}
+            <tr><td colspan="7" class="no-results">{t('pro.noSections')}</td></tr>
+          {/if}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<style>
+  .pro-sec {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  /* ─── Add Panel (collapsible) ─── */
+  .add-panel {
+    flex-shrink: 0;
+    border-bottom: 2px solid #0f3460;
+  }
+  .add-panel[open] {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .add-panel-summary {
+    padding: 8px 12px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #4ecdc4;
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+  }
+  .add-panel-summary::-webkit-details-marker { display: none; }
+  .add-panel-summary::before {
+    content: '+ ';
+  }
+  .add-panel[open] > .add-panel-summary::before {
+    content: '− ';
+  }
+  .add-panel-summary:hover { color: #6eede4; }
+  .add-panel-body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  /* ─── Main Tabs ─── */
+  .main-tabs {
+    display: flex;
+    border-bottom: 2px solid #0f3460;
+    flex-shrink: 0;
+  }
+  .main-tabs button {
+    flex: 1;
+    padding: 0.5rem 0.5rem;
+    border: none;
+    background: transparent;
+    color: #888;
+    font-size: 0.78rem;
+    font-weight: 500;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -2px;
+    transition: all 0.15s;
+  }
+  .main-tabs button:hover { color: #ccc; background: rgba(15, 52, 96, 0.3); }
+  .main-tabs button.active { color: #4ecdc4; border-bottom-color: #4ecdc4; }
+
+  /* ─── Tab Body ─── */
+  .tab-body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  /* ─── Catalog Tab ─── */
+  .catalog-body { overflow: hidden; }
+
+  .family-tabs {
+    display: flex;
+    gap: 3px;
+    padding: 6px 8px 4px;
+    flex-wrap: wrap;
+    flex-shrink: 0;
+  }
+  .fam-btn {
+    padding: 3px 8px;
+    border: 1px solid #1a3050;
+    border-radius: 4px;
+    background: transparent;
+    color: #aaa;
+    font-size: 0.72rem;
+    cursor: pointer;
+    transition: all 0.12s;
+  }
+  .fam-btn:hover { background: #0f3460; color: #eee; }
+  .fam-btn.active { background: #e94560; border-color: #e94560; color: white; }
+
+  .catalog-top {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px 6px;
+    flex-shrink: 0;
+  }
+
+  .profile-preview { flex-shrink: 0; }
+  .preview-svg {
+    width: 64px;
+    height: 64px;
+    background: rgba(15, 52, 96, 0.3);
+    border-radius: 5px;
+    border: 1px solid rgba(26, 74, 122, 0.4);
+  }
+
+  .search-wrap { flex: 1; }
+  .search-wrap input {
+    width: 100%;
+    background: #0f2840;
+    border: 1px solid #1a3050;
+    border-radius: 4px;
+    color: #eee;
+    padding: 5px 8px;
+    font-size: 0.78rem;
+  }
+  .search-wrap input::placeholder { color: #555; }
+  .search-wrap input:focus { outline: none; border-color: #4ecdc4; }
+
+  .profile-table-wrap {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0 8px;
+    min-height: 0;
+  }
+  .profile-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.75rem;
+  }
+  .profile-table thead th {
+    position: sticky;
+    top: 0;
+    background: #0a1a30;
+    color: #888;
+    font-weight: 500;
+    text-align: right;
+    padding: 4px 5px;
+    border-bottom: 1px solid #0f3460;
+    font-size: 0.68rem;
+  }
+  .profile-table thead th:first-child { text-align: left; }
+  .profile-row { cursor: pointer; transition: background 0.1s; }
+  .profile-row:hover { background: #0f3460; }
+  .profile-row td {
+    padding: 4px 5px;
+    text-align: right;
+    color: #ccc;
+    border-bottom: 1px solid rgba(15, 52, 96, 0.4);
+  }
+  .name-cell { text-align: left !important; font-weight: 500; color: #eee !important; }
+  .no-results { text-align: center !important; color: #555 !important; padding: 1.5rem 0 !important; font-size: 0.75rem; }
+
+  /* ─── Builder Tab ─── */
+  .builder-body { overflow-y: auto; }
+
+  .cat-toggle {
+    display: flex;
+    margin: 6px 8px 4px;
+    flex-shrink: 0;
+  }
+  .cat-toggle button {
+    flex: 1;
+    padding: 5px 8px;
+    border: 1px solid #1a3050;
+    background: transparent;
+    color: #888;
+    font-size: 0.75rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.12s;
+  }
+  .cat-toggle button:first-child { border-radius: 5px 0 0 5px; border-right: none; }
+  .cat-toggle button:last-child { border-radius: 0 5px 5px 0; }
+  .cat-toggle button.active { background: #0f3460; color: #4ecdc4; border-color: #4ecdc4; }
+  .cat-toggle button:not(.active):hover { background: rgba(15, 52, 96, 0.4); color: #ccc; }
+
+  .shape-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 3px;
+    padding: 2px 8px 6px;
+    flex-shrink: 0;
+  }
+  .shape-btn {
+    padding: 3px 8px;
+    border: 1px solid #1a3050;
+    border-radius: 4px;
+    background: transparent;
+    color: #aaa;
+    font-size: 0.72rem;
+    cursor: pointer;
+    transition: all 0.12s;
+  }
+  .shape-btn:hover { background: #0f3460; color: #eee; }
+  .shape-btn.active { background: #1a4a7a; border-color: #4ecdc4; color: #fff; }
+
+  .builder-content {
+    padding: 0 10px 8px;
+  }
+
+  .shape-preview {
+    display: flex;
+    justify-content: center;
+    margin: 2px 0 6px;
+  }
+
+  .shape-desc {
+    font-size: 0.72rem;
+    color: #888;
+    margin: 0 0 6px;
+    font-style: italic;
+  }
+
+  .param-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+  .param-field {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.78rem;
+    color: #ccc;
+  }
+  .param-input { display: flex; align-items: center; gap: 4px; }
+  .param-input input {
+    width: 80px;
+    padding: 4px 5px;
+    background: #0f2840;
+    border: 1px solid #1a3050;
+    border-radius: 4px;
+    color: #eee;
+    font-size: 0.78rem;
+    text-align: right;
+    font-family: monospace;
+  }
+  .param-input input:focus { outline: none; border-color: #4ecdc4; }
+  .param-unit { font-size: 0.68rem; color: #666; min-width: 1.5rem; }
+
+  .results-box {
+    margin-top: 8px;
+    padding: 6px 8px;
+    background: #0f2840;
+    border: 1px solid #1a3050;
+    border-radius: 5px;
+  }
+  .results-box.error { border-color: #e94560; color: #e94560; text-align: center; font-size: 0.75rem; }
+  .result-row { display: flex; justify-content: space-between; font-size: 0.75rem; color: #aaa; padding: 1px 0; }
+  .result-val { color: #4ecdc4; font-family: monospace; }
+
+  .confirm-btn {
+    width: 100%;
+    margin-top: 8px;
+    padding: 6px;
+    background: #0f4a3a;
+    border: 1px solid #1a7a5a;
+    border-radius: 5px;
+    color: #4ecdc4;
+    cursor: pointer;
+    font-size: 0.8rem;
+    font-weight: 600;
+    transition: all 0.15s;
+  }
+  .confirm-btn:hover { background: #1a7a5a; color: white; }
+
+  /* ─── Sections List (bottom) ─── */
+  .sec-list {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .add-panel[open] ~ .sec-list {
+    flex: 0 0 auto;
+    max-height: 180px;
+  }
+
+  .sec-list-header {
+    padding: 5px 10px;
+    flex-shrink: 0;
+  }
+  .sec-count {
+    font-size: 0.78rem;
+    color: #4ecdc4;
+    font-weight: 600;
+  }
+
+  .sec-table-wrap {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+  }
+  .sec-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.72rem;
+  }
+  .sec-table thead { position: sticky; top: 0; z-index: 1; }
+  .sec-table th {
+    padding: 4px 6px;
+    text-align: left;
+    font-size: 0.65rem;
+    font-weight: 600;
+    color: #666;
+    text-transform: uppercase;
+    background: #0a1a30;
+    border-bottom: 1px solid #1a3050;
+  }
+  .sec-table td {
+    padding: 3px 6px;
+    border-bottom: 1px solid #0f2030;
+    color: #bbb;
+  }
+  .col-id { width: 28px; color: #555; font-family: monospace; text-align: center; }
+  .col-name { max-width: 100px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .col-num { font-family: monospace; text-align: right; font-size: 0.68rem; }
+  .del-btn {
+    background: none; border: none; color: #444; font-size: 0.9rem; cursor: pointer; padding: 0;
+  }
+  .del-btn:hover { color: #ff6b6b; }
+</style>

--- a/web/src/components/pro/ProShellTab.svelte
+++ b/web/src/components/pro/ProShellTab.svelte
@@ -1,0 +1,850 @@
+<script lang="ts">
+  import { modelStore } from '../../lib/store';
+  import { t } from '../../lib/i18n';
+  import { selectShellFamily } from '../../lib/engine/shell-family-selector';
+  import type { ShellFamily, ShellRecommendation } from '../../lib/engine/types-3d';
+  import { AVAILABLE_SHELL_FAMILIES } from '../../lib/engine/types-3d';
+  import type { Vec3 } from '../../lib/engine/shell-family-selector';
+
+  // --- Plate (DKT triangle) creator state ---
+  let plateNodes = $state<[string, string, string]>(['', '', '']);
+  let plateMaterialId = $state(1);
+  let plateThickness = $state(0.2);
+  let plateFamily = $state<ShellFamily | 'auto'>('auto');
+  let plateRecommendation = $state<ShellRecommendation | null>(null);
+
+  // --- Quad (MITC4) creator state ---
+  let quadNodes = $state<[string, string, string, string]>(['', '', '', '']);
+  let quadMaterialId = $state(1);
+  let quadThickness = $state(0.2);
+  let quadFamily = $state<ShellFamily | 'auto'>('auto');
+  let quadRecommendation = $state<ShellRecommendation | null>(null);
+
+  // --- Quick mesh generator state ---
+  let meshCorners = $state<[string, string, string, string]>(['', '', '', '']);
+  let meshNx = $state(2);
+  let meshNy = $state(2);
+  let meshMaterialId = $state(1);
+  let meshThickness = $state(0.2);
+  let meshError = $state<string | null>(null);
+  let meshSuccess = $state<string | null>(null);
+
+  // --- Error states ---
+  let plateError = $state<string | null>(null);
+  let quadError = $state<string | null>(null);
+
+  // Available materials
+  const materials = $derived([...modelStore.materials.values()]);
+
+  // Existing plates and quads from store
+  const plates = $derived(
+    modelStore.model.plates ? [...modelStore.model.plates.values()] : []
+  );
+  const quads = $derived(
+    modelStore.model.quads ? [...modelStore.model.quads.values()] : []
+  );
+  const plateCount = $derived(plates.length);
+  const quadCount = $derived(quads.length);
+
+  function validateNodeIds(ids: string[], count: number): number[] | null {
+    const parsed = ids.slice(0, count).map(s => parseInt(s));
+    if (parsed.some(isNaN)) return null;
+    if (new Set(parsed).size !== count) return null;
+    if (parsed.some(id => !modelStore.nodes.has(id))) return null;
+    return parsed;
+  }
+
+  /** Get Vec3 positions from node IDs */
+  function getNodePositions(ids: number[]): Vec3[] | null {
+    const positions: Vec3[] = [];
+    for (const id of ids) {
+      const n = modelStore.nodes.get(id);
+      if (!n) return null;
+      positions.push({ x: n.x, y: n.y, z: n.z ?? 0 });
+    }
+    return positions;
+  }
+
+  /** Run the selector and update recommendation state */
+  function updatePlateRecommendation() {
+    const nodeIds = validateNodeIds(plateNodes, 3);
+    if (!nodeIds || plateThickness <= 0) { plateRecommendation = null; return; }
+    const positions = getNodePositions(nodeIds);
+    if (!positions) { plateRecommendation = null; return; }
+    plateRecommendation = selectShellFamily({ nodes: positions, thickness: plateThickness });
+  }
+
+  function updateQuadRecommendation() {
+    const nodeIds = validateNodeIds(quadNodes, 4);
+    if (!nodeIds || quadThickness <= 0) { quadRecommendation = null; return; }
+    const positions = getNodePositions(nodeIds);
+    if (!positions) { quadRecommendation = null; return; }
+    quadRecommendation = selectShellFamily({ nodes: positions, thickness: quadThickness });
+  }
+
+  function addPlate() {
+    plateError = null;
+    const nodeIds = validateNodeIds(plateNodes, 3);
+    if (!nodeIds) {
+      plateError = t('pro.err3Nodes');
+      return;
+    }
+    if (!modelStore.materials.has(plateMaterialId)) {
+      plateError = t('pro.errMaterial');
+      return;
+    }
+    if (plateThickness <= 0) {
+      plateError = t('pro.errThickness');
+      return;
+    }
+    // Resolve shell family: auto → use recommendation, else use override
+    const family: ShellFamily = plateFamily === 'auto'
+      ? (plateRecommendation?.family ?? 'DKT')
+      : plateFamily;
+    modelStore.addPlate(nodeIds as [number, number, number], plateMaterialId, plateThickness);
+    // Set family on the just-created plate
+    const plates = [...modelStore.model.plates.values()];
+    const last = plates[plates.length - 1];
+    if (last) last.shellFamily = family;
+    plateNodes = ['', '', ''];
+    plateRecommendation = null;
+  }
+
+  function addQuad() {
+    quadError = null;
+    const nodeIds = validateNodeIds(quadNodes, 4);
+    if (!nodeIds) {
+      quadError = t('pro.err4Nodes');
+      return;
+    }
+    if (!modelStore.materials.has(quadMaterialId)) {
+      quadError = t('pro.errMaterial');
+      return;
+    }
+    if (quadThickness <= 0) {
+      quadError = t('pro.errThickness');
+      return;
+    }
+    const family: ShellFamily = quadFamily === 'auto'
+      ? (quadRecommendation?.family ?? 'MITC4')
+      : quadFamily;
+    modelStore.addQuad(nodeIds as [number, number, number, number], quadMaterialId, quadThickness);
+    const quads = [...modelStore.model.quads.values()];
+    const last = quads[quads.length - 1];
+    if (last) last.shellFamily = family;
+    quadNodes = ['', '', '', ''];
+    quadRecommendation = null;
+  }
+
+  function deletePlate(id: number) {
+    modelStore.removePlate(id);
+  }
+
+  function deleteQuad(id: number) {
+    modelStore.removeQuad(id);
+  }
+
+  /**
+   * Quick mesh generator: given 4 corner node IDs defining a rectangular region
+   * and nx x ny subdivisions, creates intermediate nodes and quad elements.
+   *
+   * Corner ordering:
+   *   n3 --- n2
+   *   |       |
+   *   n0 --- n1
+   *
+   * Bilinear interpolation is used to place intermediate nodes, so corners
+   * don't need to form a perfect rectangle — any quadrilateral works.
+   */
+  function generateMesh() {
+    meshError = null;
+    meshSuccess = null;
+
+    const cornerIds = validateNodeIds(meshCorners, 4);
+    if (!cornerIds) {
+      meshError = t('pro.err4Corners');
+      return;
+    }
+    if (meshNx < 1 || meshNy < 1) {
+      meshError = t('pro.errSubdivisions');
+      return;
+    }
+    if (!modelStore.materials.has(meshMaterialId)) {
+      meshError = t('pro.errMaterial');
+      return;
+    }
+    if (meshThickness <= 0) {
+      meshError = t('pro.errThickness');
+      return;
+    }
+
+    // Get corner positions
+    const corners = cornerIds.map(id => modelStore.nodes.get(id)!);
+    const [c0, c1, c2, c3] = corners;
+
+    // Build grid of node IDs: (nx+1) x (ny+1)
+    const nodeGrid: number[][] = [];
+
+    for (let j = 0; j <= meshNy; j++) {
+      const row: number[] = [];
+      const v = j / meshNy;
+      for (let i = 0; i <= meshNx; i++) {
+        const u = i / meshNx;
+
+        // Check if this is a corner node — reuse existing node
+        if (i === 0 && j === 0) { row.push(cornerIds[0]); continue; }
+        if (i === meshNx && j === 0) { row.push(cornerIds[1]); continue; }
+        if (i === meshNx && j === meshNy) { row.push(cornerIds[2]); continue; }
+        if (i === 0 && j === meshNy) { row.push(cornerIds[3]); continue; }
+
+        // Bilinear interpolation
+        const x = (1 - u) * (1 - v) * c0.x + u * (1 - v) * c1.x + u * v * c2.x + (1 - u) * v * c3.x;
+        const y = (1 - u) * (1 - v) * c0.y + u * (1 - v) * c1.y + u * v * c2.y + (1 - u) * v * c3.y;
+        const z0 = c0.z ?? 0, z1 = c1.z ?? 0, z2 = c2.z ?? 0, z3 = c3.z ?? 0;
+        const z = (1 - u) * (1 - v) * z0 + u * (1 - v) * z1 + u * v * z2 + (1 - u) * v * z3;
+
+        const nodeId = modelStore.addNode(x, y, z !== 0 ? z : undefined);
+        row.push(nodeId);
+      }
+      nodeGrid.push(row);
+    }
+
+    // Create quad elements for each cell
+    let quadCount = 0;
+    for (let j = 0; j < meshNy; j++) {
+      for (let i = 0; i < meshNx; i++) {
+        const n0 = nodeGrid[j][i];
+        const n1 = nodeGrid[j][i + 1];
+        const n2 = nodeGrid[j + 1][i + 1];
+        const n3 = nodeGrid[j + 1][i];
+        modelStore.addQuad([n0, n1, n2, n3], meshMaterialId, meshThickness);
+        quadCount++;
+      }
+    }
+
+    const nodeCount = (meshNx + 1) * (meshNy + 1) - 4; // minus 4 reused corners
+    meshSuccess = t('pro.meshSuccess').replace('{nodes}', String(nodeCount)).replace('{quads}', String(quadCount));
+  }
+
+  // Collapse states for sections
+  let showPlateCreator = $state(true);
+  let showQuadCreator = $state(true);
+  let showMeshGen = $state(false);
+  let showTable = $state(true);
+
+  function getMaterialName(id: number): string {
+    const m = modelStore.materials.get(id);
+    return m ? m.name : `#${id}`;
+  }
+</script>
+
+<div class="pro-shells">
+  <!-- Header -->
+  <div class="pro-shells-header">
+    <span class="pro-shells-count">{t('pro.nPlatesQuads').replace('{plates}', String(plateCount)).replace('{quads}', String(quadCount))}</span>
+  </div>
+
+  <div class="pro-shells-scroll">
+    <!-- Plate (DKT triangle) creator -->
+    <div class="section">
+      <button class="section-toggle" onclick={() => showPlateCreator = !showPlateCreator}>
+        <span class="toggle-arrow">{showPlateCreator ? '\u25BE' : '\u25B8'}</span>
+        {t('pro.plateTriDKT')}
+      </button>
+      {#if showPlateCreator}
+        <div class="section-body">
+          <div class="input-row">
+            <label>{t('pro.nodes')}:</label>
+            <input type="text" bind:value={plateNodes[0]} placeholder="N1" class="node-input" oninput={updatePlateRecommendation} />
+            <input type="text" bind:value={plateNodes[1]} placeholder="N2" class="node-input" oninput={updatePlateRecommendation} />
+            <input type="text" bind:value={plateNodes[2]} placeholder="N3" class="node-input" oninput={updatePlateRecommendation} />
+          </div>
+          <div class="input-row">
+            <label>{t('pro.thMaterial')}:</label>
+            <select bind:value={plateMaterialId} class="mat-select">
+              {#each materials as m}
+                <option value={m.id}>{m.name}</option>
+              {/each}
+            </select>
+          </div>
+          <div class="input-row">
+            <label>{t('pro.thickness')}:</label>
+            <input type="number" bind:value={plateThickness} step="0.01" min="0.001" class="thick-input" oninput={updatePlateRecommendation} />
+          </div>
+          <div class="input-row">
+            <label>Family:</label>
+            <select bind:value={plateFamily} class="family-select">
+              <option value="auto">Auto{plateRecommendation ? ` (${plateRecommendation.family})` : ''}</option>
+              <option value="DKT">DKT (Kirchhoff)</option>
+              <option value="DKMT" disabled>DKMT (Mindlin) — planned</option>
+            </select>
+          </div>
+          {#if plateRecommendation}
+            <div class="recommendation" class:warn={plateRecommendation.confidence !== 'high'}>
+              <span class="rec-icon">{plateRecommendation.confidence === 'high' ? '\u2713' : '\u26A0'}</span>
+              <span class="rec-text">{plateRecommendation.reason}</span>
+            </div>
+            {#each plateRecommendation.warnings as w}
+              <div class="rec-warning">{w}</div>
+            {/each}
+          {/if}
+          {#if plateError}
+            <div class="field-error">{plateError}</div>
+          {/if}
+          <button class="pro-btn pro-btn-accent" onclick={addPlate}>{t('pro.addPlate')}</button>
+        </div>
+      {/if}
+    </div>
+
+    <!-- Quad (MITC4) creator -->
+    <div class="section">
+      <button class="section-toggle" onclick={() => showQuadCreator = !showQuadCreator}>
+        <span class="toggle-arrow">{showQuadCreator ? '\u25BE' : '\u25B8'}</span>
+        {t('pro.quadMITC4')}
+      </button>
+      {#if showQuadCreator}
+        <div class="section-body">
+          <div class="input-row">
+            <label>{t('pro.nodes')}:</label>
+            <input type="text" bind:value={quadNodes[0]} placeholder="N1" class="node-input" oninput={updateQuadRecommendation} />
+            <input type="text" bind:value={quadNodes[1]} placeholder="N2" class="node-input" oninput={updateQuadRecommendation} />
+            <input type="text" bind:value={quadNodes[2]} placeholder="N2" class="node-input" oninput={updateQuadRecommendation} />
+            <input type="text" bind:value={quadNodes[3]} placeholder="N4" class="node-input" oninput={updateQuadRecommendation} />
+          </div>
+          <div class="input-row">
+            <label>{t('pro.thMaterial')}:</label>
+            <select bind:value={quadMaterialId} class="mat-select">
+              {#each materials as m}
+                <option value={m.id}>{m.name}</option>
+              {/each}
+            </select>
+          </div>
+          <div class="input-row">
+            <label>{t('pro.thickness')}:</label>
+            <input type="number" bind:value={quadThickness} step="0.01" min="0.001" class="thick-input" oninput={updateQuadRecommendation} />
+          </div>
+          <div class="input-row">
+            <label>Family:</label>
+            <select bind:value={quadFamily} class="family-select">
+              <option value="auto">Auto{quadRecommendation ? ` (${quadRecommendation.family})` : ''}</option>
+              <option value="MITC4">MITC4 (4-node)</option>
+              <option value="MITC9" disabled>MITC9 (9-node) — planned</option>
+              <option value="SHB8PS" disabled>SHB8PS (solid-shell) — planned</option>
+            </select>
+          </div>
+          {#if quadRecommendation}
+            <div class="recommendation" class:warn={quadRecommendation.confidence !== 'high'}>
+              <span class="rec-icon">{quadRecommendation.confidence === 'high' ? '\u2713' : '\u26A0'}</span>
+              <span class="rec-text">{quadRecommendation.reason}</span>
+            </div>
+            {#each quadRecommendation.warnings as w}
+              <div class="rec-warning">{w}</div>
+            {/each}
+          {/if}
+          {#if quadError}
+            <div class="field-error">{quadError}</div>
+          {/if}
+          <button class="pro-btn pro-btn-accent" onclick={addQuad}>{t('pro.addQuad')}</button>
+        </div>
+      {/if}
+    </div>
+
+    <!-- Quick mesh generator -->
+    <div class="section">
+      <button class="section-toggle" onclick={() => showMeshGen = !showMeshGen}>
+        <span class="toggle-arrow">{showMeshGen ? '\u25BE' : '\u25B8'}</span>
+        {t('pro.meshGenerator')}
+      </button>
+      {#if showMeshGen}
+        <div class="section-body">
+          <div class="mesh-hint">
+            {t('pro.meshHint')}
+          </div>
+          <div class="input-row">
+            <label>{t('pro.corners')}:</label>
+            <input type="text" bind:value={meshCorners[0]} placeholder="N0" class="node-input" />
+            <input type="text" bind:value={meshCorners[1]} placeholder="N1" class="node-input" />
+            <input type="text" bind:value={meshCorners[2]} placeholder="N2" class="node-input" />
+            <input type="text" bind:value={meshCorners[3]} placeholder="N3" class="node-input" />
+          </div>
+          <div class="input-row">
+            <label>{t('pro.subdivisions')}:</label>
+            <input type="number" bind:value={meshNx} min="1" max="50" class="sub-input" />
+            <span class="x-label">&times;</span>
+            <input type="number" bind:value={meshNy} min="1" max="50" class="sub-input" />
+          </div>
+          <div class="input-row">
+            <label>{t('pro.thMaterial')}:</label>
+            <select bind:value={meshMaterialId} class="mat-select">
+              {#each materials as m}
+                <option value={m.id}>{m.name}</option>
+              {/each}
+            </select>
+          </div>
+          <div class="input-row">
+            <label>{t('pro.thickness')}:</label>
+            <input type="number" bind:value={meshThickness} step="0.01" min="0.001" class="thick-input" />
+          </div>
+          {#if meshError}
+            <div class="field-error">{meshError}</div>
+          {/if}
+          {#if meshSuccess}
+            <div class="field-success">{meshSuccess}</div>
+          {/if}
+          <button class="pro-btn pro-btn-accent" onclick={generateMesh}>{t('pro.generateMesh')}</button>
+        </div>
+      {/if}
+    </div>
+
+    <!-- Table of existing shells -->
+    <div class="section">
+      <button class="section-toggle" onclick={() => showTable = !showTable}>
+        <span class="toggle-arrow">{showTable ? '\u25BE' : '\u25B8'}</span>
+        {t('pro.elemTable').replace('{n}', String(plateCount + quadCount))}
+      </button>
+      {#if showTable}
+        <div class="section-body">
+          {#if plates.length > 0}
+            <div class="table-label">{t('pro.triPlatesDKT')}</div>
+            <div class="pro-shells-table-wrap">
+              <table class="pro-shells-table">
+                <thead>
+                  <tr>
+                    <th class="col-id">ID</th>
+                    <th class="col-nodes">Nodos</th>
+                    <th class="col-family">Family</th>
+                    <th class="col-mat">Material</th>
+                    <th class="col-thick">Esp. (m)</th>
+                    <th class="col-actions"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {#each plates as plate}
+                    <tr>
+                      <td class="col-id">{plate.id}</td>
+                      <td class="col-nodes">{plate.nodes.join(', ')}</td>
+                      <td class="col-family">{plate.shellFamily ?? 'DKT'}</td>
+                      <td class="col-mat">{getMaterialName(plate.materialId)}</td>
+                      <td class="col-thick">{plate.thickness.toFixed(3)}</td>
+                      <td class="col-actions">
+                        <button class="pro-delete-btn" onclick={() => deletePlate(plate.id)}>&times;</button>
+                      </td>
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+            </div>
+          {/if}
+
+          {#if quads.length > 0}
+            <div class="table-label">{t('pro.quadsMITC4')}</div>
+            <div class="pro-shells-table-wrap">
+              <table class="pro-shells-table">
+                <thead>
+                  <tr>
+                    <th class="col-id">ID</th>
+                    <th class="col-nodes">Nodos</th>
+                    <th class="col-family">Family</th>
+                    <th class="col-mat">Material</th>
+                    <th class="col-thick">Esp. (m)</th>
+                    <th class="col-actions"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {#each quads as quad}
+                    <tr>
+                      <td class="col-id">{quad.id}</td>
+                      <td class="col-nodes">{quad.nodes.join(', ')}</td>
+                      <td class="col-family">{quad.shellFamily ?? 'MITC4'}</td>
+                      <td class="col-mat">{getMaterialName(quad.materialId)}</td>
+                      <td class="col-thick">{quad.thickness.toFixed(3)}</td>
+                      <td class="col-actions">
+                        <button class="pro-delete-btn" onclick={() => deleteQuad(quad.id)}>&times;</button>
+                      </td>
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+            </div>
+          {/if}
+
+          {#if plates.length === 0 && quads.length === 0}
+            <div class="pro-empty">{t('pro.emptyShells')}</div>
+          {/if}
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<style>
+  .pro-shells {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .pro-shells-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 10px;
+    border-bottom: 1px solid #1a3050;
+    flex-shrink: 0;
+  }
+
+  .pro-shells-count {
+    font-size: 0.82rem;
+    color: #4ecdc4;
+    font-weight: 600;
+  }
+
+  .pro-shells-scroll {
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  /* Collapsible sections */
+  .section {
+    border-bottom: 1px solid #1a3050;
+  }
+
+  .section-toggle {
+    width: 100%;
+    text-align: left;
+    padding: 8px 12px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #aaa;
+    background: #0a1a30;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .section-toggle:hover {
+    color: #ddd;
+    background: #0f2840;
+  }
+
+  .toggle-arrow {
+    font-size: 0.65rem;
+    color: #666;
+  }
+
+  .section-body {
+    padding: 10px 12px 12px;
+    background: #0f2840;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  /* Input rows */
+  .input-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .input-row label {
+    font-size: 0.75rem;
+    color: #888;
+    min-width: 70px;
+    flex-shrink: 0;
+  }
+
+  .node-input {
+    width: 48px;
+    padding: 4px 6px;
+    background: #0a1a30;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ddd;
+    font-size: 0.78rem;
+    font-family: monospace;
+    text-align: center;
+  }
+
+  .node-input:focus {
+    border-color: #1a4a7a;
+    outline: none;
+  }
+
+  .mat-select {
+    flex: 1;
+    padding: 4px 6px;
+    background: #0a1a30;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ccc;
+    font-size: 0.75rem;
+    cursor: pointer;
+  }
+
+  .mat-select:focus {
+    border-color: #1a4a7a;
+    outline: none;
+  }
+
+  .thick-input {
+    width: 75px;
+    padding: 4px 6px;
+    background: #0a1a30;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ddd;
+    font-size: 0.78rem;
+    font-family: monospace;
+  }
+
+  .thick-input:focus {
+    border-color: #1a4a7a;
+    outline: none;
+  }
+
+  .sub-input {
+    width: 44px;
+    padding: 3px 5px;
+    background: #0a1a30;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ddd;
+    font-size: 0.72rem;
+    font-family: monospace;
+    text-align: center;
+  }
+
+  .sub-input:focus {
+    border-color: #1a4a7a;
+    outline: none;
+  }
+
+  .x-label {
+    font-size: 0.72rem;
+    color: #666;
+  }
+
+  /* Buttons */
+  .pro-btn {
+    padding: 5px 14px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: #ccc;
+    background: #0f3460;
+    border: 1px solid #1a4a7a;
+    border-radius: 3px;
+    cursor: pointer;
+    align-self: flex-start;
+  }
+
+  .pro-btn:hover {
+    background: #1a4a7a;
+    color: #fff;
+  }
+
+  .pro-btn-accent {
+    background: #0f3460;
+    border-color: #4ecdc4;
+    color: #4ecdc4;
+  }
+
+  .pro-btn-accent:hover {
+    background: #1a4a7a;
+    color: #fff;
+  }
+
+  /* Errors / success */
+  .field-error {
+    font-size: 0.68rem;
+    color: #ff8a9e;
+    padding: 2px 0;
+  }
+
+  .field-success {
+    font-size: 0.68rem;
+    color: #4ecdc4;
+    padding: 2px 0;
+  }
+
+  .mesh-hint {
+    font-size: 0.72rem;
+    color: #668;
+    font-style: italic;
+    line-height: 1.4;
+  }
+
+  /* Tables */
+  .table-label {
+    font-size: 0.65rem;
+    font-weight: 600;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    margin-top: 4px;
+    margin-bottom: 2px;
+  }
+
+  .pro-shells-table-wrap {
+    overflow-x: auto;
+  }
+
+  .pro-shells-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.72rem;
+  }
+
+  .pro-shells-table thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+
+  .pro-shells-table th {
+    padding: 4px 4px;
+    text-align: left;
+    font-size: 0.6rem;
+    font-weight: 600;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    background: #0a1a30;
+    border-bottom: 1px solid #1a4a7a;
+    white-space: nowrap;
+  }
+
+  .pro-shells-table td {
+    padding: 3px 4px;
+    border-bottom: 1px solid #0f2030;
+  }
+
+  .pro-shells-table tr:hover {
+    background: rgba(78, 205, 196, 0.04);
+  }
+
+  .col-id {
+    width: 30px;
+    color: #666;
+    font-family: monospace;
+    font-size: 0.68rem;
+    text-align: center;
+  }
+
+  .col-nodes {
+    font-family: monospace;
+    font-size: 0.68rem;
+    color: #ccc;
+  }
+
+  .col-mat {
+    font-size: 0.68rem;
+    color: #aaa;
+  }
+
+  .col-thick {
+    font-family: monospace;
+    font-size: 0.68rem;
+    color: #aaa;
+    text-align: right;
+  }
+
+  .col-actions {
+    width: 20px;
+    text-align: center;
+  }
+
+  .pro-delete-btn {
+    background: none;
+    border: none;
+    color: #555;
+    font-size: 1rem;
+    cursor: pointer;
+    padding: 0;
+    line-height: 1;
+  }
+
+  .pro-delete-btn:hover {
+    color: #ff6b6b;
+  }
+
+  .pro-empty {
+    text-align: center;
+    color: #555;
+    font-style: italic;
+    padding: 16px 10px;
+    font-size: 0.72rem;
+  }
+
+  /* Shell family selector */
+  .family-select {
+    flex: 1;
+    padding: 4px 6px;
+    background: #0a1a30;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ccc;
+    font-size: 0.75rem;
+    cursor: pointer;
+  }
+
+  .family-select:focus {
+    border-color: #1a4a7a;
+    outline: none;
+  }
+
+  .family-select option:disabled {
+    color: #555;
+    font-style: italic;
+  }
+
+  /* Recommendation display */
+  .recommendation {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    padding: 6px 8px;
+    background: rgba(78, 205, 196, 0.06);
+    border: 1px solid rgba(78, 205, 196, 0.15);
+    border-radius: 4px;
+    font-size: 0.68rem;
+    line-height: 1.45;
+    color: #8ab4b0;
+  }
+
+  .recommendation.warn {
+    background: rgba(251, 191, 36, 0.06);
+    border-color: rgba(251, 191, 36, 0.15);
+    color: #c4a94d;
+  }
+
+  .rec-icon {
+    flex-shrink: 0;
+    font-size: 0.72rem;
+  }
+
+  .rec-text {
+    flex: 1;
+  }
+
+  .rec-warning {
+    font-size: 0.65rem;
+    color: #c4a94d;
+    padding: 2px 8px 2px 22px;
+    line-height: 1.4;
+  }
+
+  .rec-warning::before {
+    content: '\26A0 ';
+  }
+
+  .col-family {
+    font-size: 0.65rem;
+    font-weight: 600;
+    color: #4ecdc4;
+    font-family: monospace;
+    white-space: nowrap;
+  }
+</style>

--- a/web/src/components/pro/ProSupportsTab.svelte
+++ b/web/src/components/pro/ProSupportsTab.svelte
@@ -1,0 +1,177 @@
+<script lang="ts">
+  import { modelStore, uiStore } from '../../lib/store';
+  import type { SupportType } from '../../lib/store/model.svelte';
+  import { t } from '../../lib/i18n';
+
+  const supportTypes = $derived([
+    { value: 'fixed' as SupportType, label: t('pro.fixed') },
+    { value: 'pinned' as SupportType, label: t('pro.pinned') },
+    { value: 'rollerX' as SupportType, label: t('pro.rollerX') },
+    { value: 'rollerY' as SupportType, label: t('pro.rollerY') },
+    { value: 'spring' as SupportType, label: t('pro.spring') },
+  ]);
+
+  let newNodeId = $state('');
+  let newType = $state<SupportType>('fixed');
+
+  const supports = $derived([...modelStore.supports.values()]);
+
+  function addSupport() {
+    const nodeId = parseInt(newNodeId);
+    if (isNaN(nodeId) || !modelStore.nodes.has(nodeId)) return;
+    modelStore.addSupport(nodeId, newType);
+    newNodeId = '';
+  }
+
+  function removeSupport(id: number) {
+    modelStore.removeSupport(id);
+  }
+
+  function addFromSelection() {
+    for (const nodeId of uiStore.selectedNodes) {
+      if (!modelStore.nodes.has(nodeId)) continue;
+      // Check if already has support
+      const existing = [...modelStore.supports.values()].find(s => s.nodeId === nodeId);
+      if (!existing) {
+        modelStore.addSupport(nodeId, newType);
+      }
+    }
+  }
+</script>
+
+<div class="pro-sup">
+  <div class="pro-sup-header">
+    <span class="pro-sup-count">{t('pro.nSupports').replace('{n}', String(supports.length))}</span>
+  </div>
+
+  <div class="pro-sup-form">
+    <div class="pro-sup-row">
+      <label>Nodo: <input type="text" bind:value={newNodeId} placeholder="ID" class="pro-input-sm" /></label>
+      <label>Tipo:
+        <select bind:value={newType} class="pro-select-sm">
+          {#each supportTypes as st}
+            <option value={st.value}>{st.label}</option>
+          {/each}
+        </select>
+      </label>
+      <button class="pro-btn" onclick={addSupport}>{t('pro.add')}</button>
+    </div>
+    {#if uiStore.selectedNodes.size > 0}
+      <button class="pro-btn pro-btn-selection" onclick={addFromSelection}>
+        {t('pro.addToSelection').replace('{n}', String(uiStore.selectedNodes.size))}
+      </button>
+    {/if}
+  </div>
+
+  <div class="pro-sup-table-wrap">
+    <table class="pro-sup-table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>{t('pro.thNode')}</th>
+          <th>{t('pro.thType')}</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each supports as s}
+          <tr>
+            <td class="col-id">{s.id}</td>
+            <td class="col-num">{s.nodeId}</td>
+            <td>{supportTypes.find(st => st.value === s.type)?.label ?? s.type}</td>
+            <td><button class="pro-delete-btn" onclick={() => removeSupport(s.id)}>×</button></td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<style>
+  .pro-sup { display: flex; flex-direction: column; height: 100%; }
+
+  .pro-sup-header {
+    padding: 8px 10px;
+    border-bottom: 1px solid #1a3050;
+  }
+
+  .pro-sup-count { font-size: 0.82rem; color: #4ecdc4; font-weight: 600; }
+
+  .pro-sup-form {
+    padding: 10px 12px;
+    border-bottom: 1px solid #1a3050;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .pro-sup-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .pro-sup-row label {
+    font-size: 0.75rem;
+    color: #888;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
+
+  .pro-input-sm {
+    width: 55px;
+    padding: 4px 6px;
+    background: #0f2840;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ddd;
+    font-size: 0.78rem;
+    font-family: monospace;
+  }
+
+  .pro-input-sm:focus { border-color: #1a4a7a; outline: none; }
+
+  .pro-select-sm {
+    padding: 4px 6px;
+    background: #0f2840;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    color: #ccc;
+    font-size: 0.75rem;
+    cursor: pointer;
+  }
+
+  .pro-btn {
+    padding: 5px 12px;
+    font-size: 0.75rem;
+    color: #ccc;
+    background: #0f3460;
+    border: 1px solid #1a4a7a;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  .pro-btn:hover { background: #1a4a7a; color: #fff; }
+
+  .pro-btn-selection {
+    font-size: 0.72rem;
+    color: #4ecdc4;
+    border-color: #2a5a6a;
+  }
+
+  .pro-sup-table-wrap { flex: 1; overflow: auto; }
+
+  .pro-sup-table { width: 100%; border-collapse: collapse; font-size: 0.78rem; }
+  .pro-sup-table thead { position: sticky; top: 0; z-index: 1; }
+  .pro-sup-table th {
+    padding: 6px 8px; text-align: left; font-size: 0.7rem; font-weight: 600;
+    color: #888; text-transform: uppercase; background: #0a1a30; border-bottom: 1px solid #1a4a7a;
+  }
+  .pro-sup-table td { padding: 5px 8px; border-bottom: 1px solid #0f2030; color: #ccc; }
+  .col-id { width: 34px; color: #666; font-family: monospace; text-align: center; }
+  .col-num { font-family: monospace; }
+  .pro-delete-btn { background: none; border: none; color: #555; font-size: 1rem; cursor: pointer; padding: 0; }
+  .pro-delete-btn:hover { color: #ff6b6b; }
+</style>

--- a/web/src/components/pro/ProVerificationTab.svelte
+++ b/web/src/components/pro/ProVerificationTab.svelte
@@ -1,0 +1,1732 @@
+<script lang="ts">
+  import { modelStore, resultsStore, uiStore, verificationStore } from '../../lib/store';
+  import type { SolverDiagnostic } from '../../lib/engine/types';
+  import { verifyElement, classifyElement, REBAR_DB, computeJointPsiFromModel } from '../../lib/engine/codes/argentina/cirsoc201';
+  import type { ElementVerification, VerificationInput } from '../../lib/engine/codes/argentina/cirsoc201';
+  import { generateCrossSectionSvg, generateBeamElevationSvg, generateColumnElevationSvg, generateJointDetailSvg, generateSlabReinforcementSvg, designSlabReinforcement } from '../../lib/engine/reinforcement-svg';
+  import type { SlabDesignResult } from '../../lib/engine/reinforcement-svg';
+  import { checkCrackWidth, checkDeflection } from '../../lib/engine/codes/argentina/serviceability';
+  import type { CrackResult, DeflectionResult } from '../../lib/engine/codes/argentina/serviceability';
+  import { computeQuantities } from '../../lib/engine/quantity-takeoff';
+  import type { QuantitySummary } from '../../lib/engine/quantity-takeoff';
+  import { verifySteelElement } from '../../lib/engine/codes/argentina/cirsoc301';
+  import type { SteelVerification, SteelVerificationInput, SteelDesignParams } from '../../lib/engine/codes/argentina/cirsoc301';
+  import { generateInteractionDiagram, generateInteractionSvg } from '../../lib/engine/codes/argentina/interaction-diagram';
+  import type { DiagramParams } from '../../lib/engine/codes/argentina/interaction-diagram';
+  import { isDesignCheckAvailable, checkSteelMembers, checkRcMembers, checkEc2Members, checkEc3Members, checkTimberMembers, checkMasonryMembers, checkCfsMembers, checkBoltGroups, checkWeldGroups, checkSpreadFootings } from '../../lib/engine/wasm-solver';
+  import { t } from '../../lib/i18n';
+
+  /** Normative code options for design checks */
+  type NormativeCode = 'cirsoc' | 'aci-aisc' | 'eurocode' | 'nds' | 'masonry' | 'cfs';
+
+  const normativeOptions: { value: NormativeCode; label: string; wasmKeys: string[] }[] = [
+    { value: 'cirsoc', label: 'CIRSOC 201/301', wasmKeys: [] },
+    { value: 'aci-aisc', label: 'ACI 318 / AISC 360', wasmKeys: ['rcMembers', 'steelMembers'] },
+    { value: 'eurocode', label: 'Eurocode 2/3', wasmKeys: ['ec2Members', 'ec3Members'] },
+    { value: 'nds', label: 'NDS (Madera)', wasmKeys: ['timberMembers'] },
+    { value: 'masonry', label: 'Mampostería', wasmKeys: ['masonryMembers'] },
+    { value: 'cfs', label: 'CFS (Conformado en frío)', wasmKeys: ['cfsMembers'] },
+  ];
+
+  let { verifications = $bindable([]) }: { verifications: ElementVerification[] } = $props();
+  let expandedId = $state<number | null>(null);
+  let expandedSteelId = $state<number | null>(null);
+  let rebarFy = $state(420);    // MPa — default ADN 420
+  let cover = $state(0.025);    // m — default 2.5cm
+  let stirrupDia = $state(8);   // mm
+  let verifyError = $state<string | null>(null);
+  let exposure = $state<'interior' | 'exterior'>('interior');
+  let selectedNormative = $state<NormativeCode>('cirsoc');
+
+  /** Whether the selected normative code has its WASM checks compiled */
+  const selectedNormativeAvailable = $derived(() => {
+    const opt = normativeOptions.find(o => o.value === selectedNormative);
+    if (!opt || opt.wasmKeys.length === 0) return true; // CIRSOC uses JS, always available
+    return opt.wasmKeys.every(k => isDesignCheckAvailable(k));
+  });
+
+  const isCirsocSelected = $derived(selectedNormative === 'cirsoc');
+
+  // Store serviceability results per element
+  let crackResults = $state<Map<number, CrackResult>>(new Map());
+  let deflectionResults = $state<Map<number, DeflectionResult>>(new Map());
+  let quantities = $state<QuantitySummary | null>(null);
+
+  // Steel verification results (CIRSOC 301)
+  let steelVerifications = $state<SteelVerification[]>([]);
+
+  // Element lengths for elevation views
+  let elementLengthMap = $state<Map<number, number>>(new Map());
+
+  // Slab reinforcement results
+  let slabDesigns = $state<Array<{ quadId: number; spanX: number; spanZ: number; thickness: number; fc: number; designX: SlabDesignResult; designZ: SlabDesignResult }>>([]);
+
+  // Story drift results
+  interface StoryDriftResult {
+    level: number;      // floor elevation (m)
+    height: number;     // story height (m)
+    driftX: number;     // max lateral displacement X (m)
+    driftZ: number;     // max lateral displacement Z (m)
+    ratioX: number;     // drift ratio Δ/h
+    ratioZ: number;
+    status: 'ok' | 'warn' | 'fail';
+  }
+  let storyDrifts = $state<StoryDriftResult[]>([]);
+  const driftLimit = 0.015; // CIRSOC 103 §5.2.8: 0.015 for RC, 0.020 for steel
+
+  // Detail view tabs
+  type DetailSection = 'verification' | 'detailing' | 'schedule' | 'slabs' | 'drift' | 'connections';
+  let activeSection = $state<DetailSection>('verification');
+
+  const results = $derived(resultsStore.results3D);
+  const hasResults = $derived(results !== null);
+  const hasEnvelope = $derived(resultsStore.hasCombinations3D);
+
+  interface EnvelopeSolicitations {
+    Mu: number; Vu: number; Nu: number;
+    Muy: number; Vz: number; Tu: number;
+  }
+
+  /** Get max absolute solicitations for an element across all combination results */
+  function getEnvelopeSolicitations(elemId: number): EnvelopeSolicitations | null {
+    const envelope = resultsStore.fullEnvelope3D;
+    if (!envelope) return null;
+
+    const envForces = envelope.maxAbsResults3D.elementForces.find(ef => ef.elementId === elemId);
+    if (!envForces) return null;
+
+    return {
+      Mu: Math.max(Math.abs(envForces.mzStart), Math.abs(envForces.mzEnd)),
+      Vu: Math.max(Math.abs(envForces.vyStart), Math.abs(envForces.vyEnd)),
+      Nu: Math.max(Math.abs(envForces.nStart), Math.abs(envForces.nEnd)),
+      Muy: Math.max(Math.abs(envForces.myStart), Math.abs(envForces.myEnd)),
+      Vz: Math.max(Math.abs(envForces.vzStart), Math.abs(envForces.vzEnd)),
+      Tu: Math.max(Math.abs(envForces.mxStart), Math.abs(envForces.mxEnd)),
+    };
+  }
+
+  /** Build generic check payload from model data for WASM-based design checks */
+  function buildWasmCheckPayload() {
+    if (!results) return null;
+    const members: any[] = [];
+    for (const ef of results.elementForces) {
+      const elem = modelStore.elements.get(ef.elementId);
+      if (!elem) continue;
+      const sec = modelStore.sections.get(elem.sectionId);
+      const mat = modelStore.materials.get(elem.materialId);
+      const nI = modelStore.nodes.get(elem.nodeI);
+      const nJ = modelStore.nodes.get(elem.nodeJ);
+      if (!sec || !mat || !nI || !nJ) continue;
+      const dx = nJ.x - nI.x, dy = nJ.y - nI.y, dz = (nJ.z ?? 0) - (nI.z ?? 0);
+      const L = Math.sqrt(dx * dx + dy * dy + dz * dz);
+      members.push({
+        elementId: ef.elementId,
+        length: L,
+        section: { b: sec.b, h: sec.h, a: sec.a, iz: sec.iz, iy: sec.iy, profileName: sec.profileName },
+        material: { e: mat.e, fy: mat.fy, fu: mat.fu, rho: mat.rho },
+        forces: {
+          nStart: ef.nStart, nEnd: ef.nEnd,
+          vyStart: ef.vyStart, vyEnd: ef.vyEnd,
+          vzStart: ef.vzStart, vzEnd: ef.vzEnd,
+          mzStart: ef.mzStart, mzEnd: ef.mzEnd,
+          myStart: ef.myStart, myEnd: ef.myEnd,
+          mxStart: ef.mxStart, mxEnd: ef.mxEnd,
+        },
+      });
+    }
+    return { members };
+  }
+
+  // Store WASM-based verification results for non-CIRSOC codes
+  let wasmCheckResults = $state<any[] | null>(null);
+
+  function runVerification() {
+    verifyError = null;
+    wasmCheckResults = null;
+    if (!results) {
+      verifyError = t('pro.solveFirst');
+      return;
+    }
+
+    // If non-CIRSOC code selected, dispatch to WASM
+    if (!isCirsocSelected) {
+      const payload = buildWasmCheckPayload();
+      if (!payload) { verifyError = t('pro.solveFirst'); return; }
+      let checkResult: any = null;
+      try {
+        switch (selectedNormative) {
+          case 'aci-aisc':
+            checkResult = checkRcMembers(payload) ?? checkSteelMembers(payload);
+            break;
+          case 'eurocode':
+            checkResult = checkEc2Members(payload) ?? checkEc3Members(payload);
+            break;
+          case 'nds':
+            checkResult = checkTimberMembers(payload);
+            break;
+          case 'masonry':
+            checkResult = checkMasonryMembers(payload);
+            break;
+          case 'cfs':
+            checkResult = checkCfsMembers(payload);
+            break;
+        }
+      } catch (e: any) {
+        verifyError = e.message || t('pro.wasmCheckError');
+        return;
+      }
+      if (checkResult && Array.isArray(checkResult.members)) {
+        wasmCheckResults = checkResult.members;
+      } else if (checkResult) {
+        wasmCheckResults = [checkResult];
+      } else {
+        verifyError = t('pro.wasmCheckUnavailable');
+      }
+      return;
+    }
+
+    const verifs: ElementVerification[] = [];
+    const useEnvelope = hasEnvelope;
+    const lengths = new Map<number, number>();
+
+    for (const ef of results.elementForces) {
+      const elem = modelStore.elements.get(ef.elementId);
+      if (!elem) continue;
+
+      // Compute element length
+      const nodeI = modelStore.nodes.get(elem.nodeI);
+      const nodeJ = modelStore.nodes.get(elem.nodeJ);
+      if (!nodeI || !nodeJ) continue;
+      const dx = nodeJ.x - nodeI.x;
+      const dy = nodeJ.y - nodeI.y;
+      const dz = (nodeJ.z ?? 0) - (nodeI.z ?? 0);
+      const L = Math.sqrt(dx * dx + dy * dy + dz * dz);
+      lengths.set(ef.elementId, L);
+
+      const section = modelStore.sections.get(elem.sectionId);
+      const material = modelStore.materials.get(elem.materialId);
+      if (!section || !material) continue;
+
+      // Only verify concrete sections (need b and h)
+      if (!section.b || !section.h) continue;
+      // Need f'c from material
+      const fc = material.fy;
+      if (!fc || fc > 80) continue; // skip if no f'c or if it's steel (fy > 80 MPa means it's steel)
+
+      // Classify as beam, column, or wall (reuse nodeI/nodeJ from above)
+      const elemType = classifyElement(
+        nodeI.x, nodeI.y, nodeI.z ?? 0,
+        nodeJ.x, nodeJ.y, nodeJ.z ?? 0,
+        section.b, section.h,
+      );
+
+      // Extract max solicitations — from envelope if available, otherwise from single result
+      let MuMax: number, VuMax: number, NuMax: number;
+      let MuyMax = 0, VzMax = 0, TuMax = 0;
+      const envSol = useEnvelope ? getEnvelopeSolicitations(ef.elementId) : null;
+      if (envSol) {
+        MuMax = envSol.Mu;
+        VuMax = envSol.Vu;
+        NuMax = envSol.Nu;
+        MuyMax = envSol.Muy;
+        VzMax = envSol.Vz;
+        TuMax = envSol.Tu;
+      } else {
+        MuMax = Math.max(Math.abs(ef.mzStart), Math.abs(ef.mzEnd));
+        VuMax = Math.max(Math.abs(ef.vyStart), Math.abs(ef.vyEnd));
+        NuMax = Math.max(Math.abs(ef.nStart), Math.abs(ef.nEnd));
+        MuyMax = Math.max(Math.abs(ef.myStart), Math.abs(ef.myEnd));
+        VzMax = Math.max(Math.abs(ef.vzStart), Math.abs(ef.vzEnd));
+        TuMax = Math.max(Math.abs(ef.mxStart), Math.abs(ef.mxEnd));
+      }
+
+      // Unsupported length for columns/walls = element length
+      const isVertical = elemType === 'column' || elemType === 'wall';
+      const Lu = isVertical ? L : undefined;
+
+      // For slender columns: extract M1 (smaller) and M2 (larger) end moments with sign
+      let M1: number | undefined;
+      let M2: number | undefined;
+      if (isVertical) {
+        const mzI = ef.mzStart;
+        const mzJ = ef.mzEnd;
+        if (Math.abs(mzI) >= Math.abs(mzJ)) {
+          M2 = Math.abs(mzI);
+          // M1 positive if same curvature (same sign), negative if reverse
+          M1 = Math.sign(mzI) === Math.sign(mzJ) ? Math.abs(mzJ) : -Math.abs(mzJ);
+        } else {
+          M2 = Math.abs(mzJ);
+          M1 = Math.sign(mzI) === Math.sign(mzJ) ? Math.abs(mzI) : -Math.abs(mzI);
+        }
+      }
+
+      // Auto-compute Ψ from model topology for columns
+      let psiA: number | undefined;
+      let psiB: number | undefined;
+      if (isVertical) {
+        const psi = computeJointPsiFromModel(
+          ef.elementId,
+          modelStore.nodes as Map<number, { id: number; x: number; y: number; z?: number }>,
+          modelStore.elements as Map<number, { id: number; nodeI: number; nodeJ: number; materialId: number; sectionId: number; hingeStart: boolean; hingeEnd: boolean }>,
+          modelStore.sections as Map<number, { id: number; iz: number; iy?: number; b?: number; h?: number }>,
+          modelStore.materials as Map<number, { id: number; e: number }>,
+          modelStore.supports as Map<number, { nodeId: number; type?: string }>,
+        );
+        psiA = psi.psiA;
+        psiB = psi.psiB;
+      }
+
+      const input: VerificationInput = {
+        elementId: ef.elementId,
+        elementType: elemType,
+        Mu: MuMax,
+        Vu: VuMax,
+        Nu: NuMax,
+        b: section.b,
+        h: section.h,
+        fc,
+        fy: rebarFy,
+        cover,
+        stirrupDia,
+        Muy: isVertical ? MuyMax : undefined,
+        Vz: VzMax > 0.01 ? VzMax : undefined,
+        Tu: TuMax > 0.001 ? TuMax : undefined,
+        Lu,
+        M1,
+        M2,
+        psiA,
+        psiB,
+      };
+
+      verifs.push(verifyElement(input));
+    }
+
+    // Steel verification (CIRSOC 301) — elements with fy > 80 MPa
+    const steelVerifs: SteelVerification[] = [];
+    for (const ef of results.elementForces) {
+      const elem = modelStore.elements.get(ef.elementId);
+      if (!elem) continue;
+
+      const section = modelStore.sections.get(elem.sectionId);
+      const material = modelStore.materials.get(elem.materialId);
+      if (!section || !material) continue;
+
+      // Steel: fy > 80 MPa
+      if (!material.fy || material.fy <= 80) continue;
+
+      const nodeI = modelStore.nodes.get(elem.nodeI);
+      const nodeJ = modelStore.nodes.get(elem.nodeJ);
+      if (!nodeI || !nodeJ) continue;
+
+      const dx = nodeJ.x - nodeI.x;
+      const dy = nodeJ.y - nodeI.y;
+      const dz = (nodeJ.z ?? 0) - (nodeI.z ?? 0);
+      const elementLength = Math.sqrt(dx * dx + dy * dy + dz * dz);
+      if (elementLength <= 0) continue;
+
+      // Extract solicitations
+      let NuMax: number, MuzMax: number, MuyMax: number, VuMax: number;
+      const envSol = useEnvelope ? getEnvelopeSolicitations(ef.elementId) : null;
+      if (envSol) {
+        NuMax = envSol.Nu;
+        MuzMax = envSol.Mu;
+        MuyMax = envSol.Muy;
+        VuMax = envSol.Vu;
+      } else {
+        NuMax = Math.max(Math.abs(ef.nStart), Math.abs(ef.nEnd));
+        MuzMax = Math.max(Math.abs(ef.mzStart), Math.abs(ef.mzEnd));
+        MuyMax = Math.max(Math.abs(ef.myStart), Math.abs(ef.myEnd));
+        VuMax = Math.max(Math.abs(ef.vyStart), Math.abs(ef.vyEnd));
+      }
+
+      const sdp: SteelDesignParams = {
+        Fy: material.fy,
+        Fu: material.fu ?? material.fy * 1.25,
+        E: material.e,
+        A: section.a,
+        Iz: section.iz,
+        Iy: section.iy,
+        h: section.h ?? 0.3,
+        b: section.b ?? 0.15,
+        tw: section.tw ?? (section.b ? section.b / 10 : 0.01),
+        tf: section.tf ?? (section.b ? section.b / 15 : 0.01),
+        L: elementLength,
+        Lb: elementLength,
+        J: section.j ?? 0,
+      };
+
+      const steelInput: SteelVerificationInput = {
+        elementId: ef.elementId,
+        Nu: NuMax,
+        Muy: MuyMax,
+        Muz: MuzMax,
+        Vu: VuMax,
+        params: sdp,
+      };
+
+      steelVerifs.push(verifySteelElement(steelInput));
+    }
+    steelVerifications = steelVerifs;
+
+    // Check if there are any verifiable elements (including quads/plates for slabs)
+    const hasQuads = results.quadStresses && results.quadStresses.length > 0;
+    if (verifs.length === 0 && steelVerifs.length === 0 && !hasQuads) {
+      verifyError = t('pro.noVerifiableElems');
+      return;
+    }
+
+    // Serviceability checks (crack width for beams)
+    const newCracks = new Map<number, CrackResult>();
+    const newDefl = new Map<number, DeflectionResult>();
+    for (const v of verifs) {
+      if (v.elementType === 'beam') {
+        // Service moment ≈ Mu / 1.4 (approximate unfactoring)
+        const Ms = v.Mu / 1.4;
+        const crack = checkCrackWidth(
+          v.b, v.h, v.flexure.d,
+          v.flexure.AsProv, Ms,
+          v.cover, v.flexure.barDia, v.flexure.barCount,
+          exposure,
+        );
+        newCracks.set(v.elementId, crack);
+
+        // Deflection check: get max displacement from results
+        const elem = modelStore.elements.get(v.elementId);
+        if (elem) {
+          const nodeI = modelStore.nodes.get(elem.nodeI);
+          const nodeJ = modelStore.nodes.get(elem.nodeJ);
+          if (nodeI && nodeJ) {
+            const dx = nodeJ.x - nodeI.x;
+            const dy = nodeJ.y - nodeI.y;
+            const dz = (nodeJ.z ?? 0) - (nodeI.z ?? 0);
+            const L = Math.sqrt(dx * dx + dy * dy + dz * dz);
+            // Get max vertical displacement from either end node
+            const di = results!.displacements.find(d => d.nodeId === elem.nodeI);
+            const dj = results!.displacements.find(d => d.nodeId === elem.nodeJ);
+            const maxDisp = Math.max(
+              Math.abs(di?.uy ?? 0), Math.abs(dj?.uy ?? 0),
+              Math.abs(di?.uz ?? 0), Math.abs(dj?.uz ?? 0),
+            );
+            if (L > 0 && maxDisp > 0) {
+              newDefl.set(v.elementId, checkDeflection(L, maxDisp));
+            }
+          }
+        }
+      }
+    }
+    crackResults = newCracks;
+    deflectionResults = newDefl;
+
+    // Store lengths for elevation views
+    elementLengthMap = lengths;
+
+    // Compute material quantities
+    quantities = computeQuantities(verifs, lengths);
+
+    // Design slab reinforcement from quad stresses
+    const slabResults: typeof slabDesigns = [];
+    if (results.quadStresses && results.quadStresses.length > 0) {
+      // Group quads by unique geometry (spanX × spanZ × thickness)
+      const processedGeom = new Set<string>();
+      for (const qs of results.quadStresses) {
+        const quad = modelStore.quads.get(qs.elementId);
+        if (!quad) continue;
+        const mat = modelStore.materials.get(quad.materialId);
+        if (!mat) continue;
+        const fc = mat.fy ?? 30;
+
+        // Compute span from node positions
+        const qNodes = quad.nodes.map(nid => modelStore.nodes.get(nid)).filter(Boolean) as Array<{x:number;y:number;z?:number}>;
+        if (qNodes.length < 4) continue;
+        const xVals = qNodes.map(n => n.x);
+        const zVals = qNodes.map(n => n.z ?? 0);
+        const spanX = Math.max(...xVals) - Math.min(...xVals);
+        const spanZ = Math.max(...zVals) - Math.min(...zVals);
+        if (spanX < 0.1 || spanZ < 0.1) continue;
+
+        // Deduplicate by approximate geometry
+        const key = `${spanX.toFixed(1)}_${spanZ.toFixed(1)}_${quad.thickness.toFixed(2)}`;
+        if (processedGeom.has(key)) continue;
+        processedGeom.add(key);
+
+        const designX = designSlabReinforcement(qs.mx, quad.thickness, fc, rebarFy, cover, 'X');
+        const designZ = designSlabReinforcement(qs.my, quad.thickness, fc, rebarFy, cover, 'Z');
+        slabResults.push({
+          quadId: qs.elementId, spanX, spanZ,
+          thickness: quad.thickness, fc,
+          designX, designZ,
+        });
+      }
+    }
+    slabDesigns = slabResults;
+
+    // ─── Story drift computation ───
+    const drifts: StoryDriftResult[] = [];
+    if (results) {
+      // Group nodes by Y elevation (story level)
+      const yTol = 0.05; // 5cm tolerance
+      const yLevels: number[] = [];
+      for (const [, node] of modelStore.nodes) {
+        const y = node.y;
+        if (!yLevels.some(lv => Math.abs(lv - y) < yTol)) {
+          yLevels.push(y);
+        }
+      }
+      yLevels.sort((a, b) => a - b);
+
+      if (yLevels.length >= 2) {
+        // For each level (except base), compute max lateral drift
+        for (let i = 1; i < yLevels.length; i++) {
+          const level = yLevels[i];
+          const prevLevel = yLevels[i - 1];
+          const storyH = level - prevLevel;
+          if (storyH < 0.1) continue;
+
+          // Find max horizontal displacements at this level and previous
+          let maxUxCur = 0, maxUzCur = 0;
+          let maxUxPrev = 0, maxUzPrev = 0;
+          for (const d of results.displacements) {
+            const node = modelStore.nodes.get(d.nodeId);
+            if (!node) continue;
+            if (Math.abs(node.y - level) < yTol) {
+              maxUxCur = Math.max(maxUxCur, Math.abs(d.ux));
+              maxUzCur = Math.max(maxUzCur, Math.abs(d.uz));
+            } else if (Math.abs(node.y - prevLevel) < yTol) {
+              maxUxPrev = Math.max(maxUxPrev, Math.abs(d.ux));
+              maxUzPrev = Math.max(maxUzPrev, Math.abs(d.uz));
+            }
+          }
+          const deltaX = Math.abs(maxUxCur - maxUxPrev);
+          const deltaZ = Math.abs(maxUzCur - maxUzPrev);
+          const ratioX = deltaX / storyH;
+          const ratioZ = deltaZ / storyH;
+          const maxRatio = Math.max(ratioX, ratioZ);
+
+          drifts.push({
+            level,
+            height: storyH,
+            driftX: deltaX,
+            driftZ: deltaZ,
+            ratioX,
+            ratioZ,
+            status: maxRatio > driftLimit ? 'fail' : maxRatio > driftLimit * 0.8 ? 'warn' : 'ok',
+          });
+        }
+      }
+    }
+    storyDrifts = drifts;
+
+    verifications = verifs;
+
+    // Update global verification store for 3D color mapping
+    verificationStore.setConcrete(verifs);
+    verificationStore.setSteel(steelVerifs);
+
+    // Collect all diagnostics from verifications and push to results store
+    const allDiags: SolverDiagnostic[] = [];
+    for (const v of verifs) {
+      if (v.diagnostics) allDiags.push(...v.diagnostics);
+    }
+    for (const sv of steelVerifs) {
+      if (sv.diagnostics) allDiags.push(...sv.diagnostics);
+    }
+    for (const [, cr] of newCracks) {
+      if (cr.diagnostics) allDiags.push(...cr.diagnostics);
+    }
+    for (const [, dr] of newDefl) {
+      if (dr.diagnostics) allDiags.push(...dr.diagnostics);
+    }
+    if (allDiags.length > 0) {
+      resultsStore.addDiagnostics(allDiags, true);
+    }
+  }
+
+  // ─── Connection checks (Bolt/Weld/Footing) ────────────────
+
+  // Bolt group
+  let boltDia = $state(20);      // mm
+  let boltGrade = $state<'4.6' | '8.8' | '10.9'>('8.8');
+  let boltCount = $state(4);
+  let boltGauge = $state(60);    // mm
+  let boltPitch = $state(80);    // mm
+  let boltShearForce = $state(100); // kN
+  let boltTensionForce = $state(0); // kN
+  let boltResult = $state<any | null>(null);
+
+  function handleBoltCheck() {
+    try {
+      boltResult = checkBoltGroups({
+        diameter: boltDia,
+        grade: boltGrade,
+        count: boltCount,
+        gauge: boltGauge,
+        pitch: boltPitch,
+        shearForce: boltShearForce,
+        tensionForce: boltTensionForce,
+      });
+    } catch (e: any) {
+      verifyError = `Bulones: ${e.message ?? 'Error'}`;
+    }
+  }
+
+  // Weld group
+  let weldType = $state<'fillet' | 'groove'>('fillet');
+  let weldSize = $state(6);      // mm
+  let weldLength = $state(200);  // mm
+  let weldElectrode = $state(490); // MPa (E70xx)
+  let weldShear = $state(100);   // kN
+  let weldResult = $state<any | null>(null);
+
+  function handleWeldCheck() {
+    try {
+      weldResult = checkWeldGroups({
+        type: weldType,
+        size: weldSize,
+        length: weldLength,
+        electrodeStrength: weldElectrode,
+        shearForce: weldShear,
+      });
+    } catch (e: any) {
+      verifyError = `Soldadura: ${e.message ?? 'Error'}`;
+    }
+  }
+
+  // Spread footing
+  let footB = $state(1.5);       // m
+  let footL = $state(1.5);       // m
+  let footH = $state(0.5);       // m
+  let footFc = $state(25);       // MPa
+  let footSigmaAdm = $state(200); // kPa
+  let footNu = $state(500);      // kN
+  let footMu = $state(50);       // kN·m
+  let footResult = $state<any | null>(null);
+
+  function handleFootingCheck() {
+    try {
+      footResult = checkSpreadFootings({
+        width: footB,
+        length: footL,
+        depth: footH,
+        fc: footFc,
+        allowableBearing: footSigmaAdm,
+        axialLoad: footNu,
+        moment: footMu,
+      });
+    } catch (e: any) {
+      verifyError = `Fundación: ${e.message ?? 'Error'}`;
+    }
+  }
+
+  function toggleExpand(id: number) {
+    expandedId = expandedId === id ? null : id;
+  }
+
+  function toggleSteelExpand(id: number) {
+    expandedSteelId = expandedSteelId === id ? null : id;
+  }
+
+  /** Activate verification color map on 3D model */
+  function showOnModel() {
+    resultsStore.diagramType = 'verification';
+  }
+
+  /** Select element in 3D viewport when clicking verification row */
+  function selectElementInViewport(elementId: number) {
+    uiStore.selectElement(elementId, false);
+  }
+
+  function statusIcon(s: 'ok' | 'fail' | 'warn'): string {
+    if (s === 'ok') return '✓';
+    if (s === 'fail') return '✗';
+    return '⚠';
+  }
+
+  function statusClass(s: 'ok' | 'fail' | 'warn'): string {
+    if (s === 'ok') return 'status-ok';
+    if (s === 'fail') return 'status-fail';
+    return 'status-warn';
+  }
+
+  function fmtNum(n: number): string {
+    if (Math.abs(n) < 0.01) return '0';
+    return n.toFixed(2);
+  }
+
+  const countOk = $derived(verifications.filter(v => v.overallStatus === 'ok').length + steelVerifications.filter(v => v.overallStatus === 'ok').length);
+  const countFail = $derived(verifications.filter(v => v.overallStatus === 'fail').length + steelVerifications.filter(v => v.overallStatus === 'fail').length);
+  const countWarn = $derived(verifications.filter(v => v.overallStatus === 'warn').length + steelVerifications.filter(v => v.overallStatus === 'warn').length);
+
+  // Rebar schedule: group by identical reinforcement design and track element IDs
+  interface RebarScheduleEntry {
+    sectionName: string;
+    elementType: 'beam' | 'column' | 'wall';
+    elementIds: number[];
+    b: number; h: number;
+    mainBars: string;
+    stirrups: string;
+    totalAsPerElem: number; // cm² per element
+  }
+  const rebarSchedule = $derived.by(() => {
+    const groups = new Map<string, RebarScheduleEntry>();
+    for (const v of verifications) {
+      const mainBars = v.column ? v.column.bars : v.flexure.bars;
+      const stirrups = `eØ${v.shear.stirrupDia} c/${(v.shear.spacing * 100).toFixed(0)}`;
+      // Group by identical reinforcement: same type + dimensions + bars + stirrups
+      const key = `${v.elementType}_${(v.b*100).toFixed(0)}x${(v.h*100).toFixed(0)}_${mainBars}_${stirrups}`;
+      const existing = groups.get(key);
+      if (existing) {
+        existing.elementIds.push(v.elementId);
+      } else {
+        const sec = modelStore.sections.get(
+          modelStore.elements.get(v.elementId)?.sectionId ?? 0
+        );
+        groups.set(key, {
+          sectionName: sec?.name ?? `${(v.b*100).toFixed(0)}×${(v.h*100).toFixed(0)}`,
+          elementType: v.elementType,
+          elementIds: [v.elementId],
+          b: v.b, h: v.h,
+          mainBars,
+          stirrups,
+          totalAsPerElem: v.column ? v.column.AsProv : v.flexure.AsProv,
+        });
+      }
+    }
+    return Array.from(groups.values());
+  });
+
+  // Find a beam-column joint pair for the joint detail drawing
+  const jointDetail = $derived.by(() => {
+    const beams = verifications.filter(v => v.elementType === 'beam');
+    const cols = verifications.filter(v => v.elementType === 'column' || v.elementType === 'wall');
+    if (beams.length === 0 || cols.length === 0) return null;
+    const beam = beams[0];
+    const col = cols[0];
+    return {
+      beamB: beam.b, beamH: beam.h,
+      colB: col.b, colH: col.h,
+      cover: beam.cover,
+      beamBars: beam.flexure.bars,
+      colBars: col.column?.bars ?? `${col.flexure.barCount} Ø${col.flexure.barDia}`,
+      stirrupDia: col.shear.stirrupDia,
+      stirrupSpacing: col.shear.spacing,
+    };
+  });
+
+  // Grouped schedule entries by element type
+  const beamEntries = $derived(rebarSchedule.filter(e => e.elementType === 'beam'));
+  const colEntries = $derived(rebarSchedule.filter(e => e.elementType === 'column'));
+  const wallEntries = $derived(rebarSchedule.filter(e => e.elementType === 'wall'));
+
+  /** Get support type for an element end node */
+  function getSupportType(nodeId: number): 'fixed' | 'pinned' | 'free' {
+    const sup = modelStore.supports.get(nodeId);
+    if (!sup) return 'free';
+    if (sup.type === 'fixed') return 'fixed';
+    return 'pinned';
+  }
+</script>
+
+<div class="pro-verif">
+  <div class="pro-verif-header">
+    <div class="pro-verif-title-row">
+      <div class="pro-verif-title">{t('pro.normativeVerif')}</div>
+      <select bind:value={selectedNormative} class="pro-sel normative-sel">
+        {#each normativeOptions as opt}
+          <option value={opt.value}>{opt.label}</option>
+        {/each}
+      </select>
+    </div>
+    {#if !isCirsocSelected && !selectedNormativeAvailable()}
+      <div class="pro-wasm-notice">
+        {t('pro.wasmNotice').replace('{code}', normativeOptions.find(o => o.value === selectedNormative)?.label ?? '')}
+      </div>
+    {/if}
+    <div class="pro-verif-params">
+      <label>{t('pro.rebarSteel')}: <select bind:value={rebarFy} class="pro-sel">
+        <option value={420}>ADN 420</option>
+        <option value={500}>ADN 500</option>
+      </select></label>
+      <label>{t('pro.coverLabel')}:
+        <select bind:value={cover} class="pro-sel">
+          <option value={0.020}>2.0 cm</option>
+          <option value={0.025}>2.5 cm</option>
+          <option value={0.030}>3.0 cm</option>
+          <option value={0.035}>3.5 cm</option>
+          <option value={0.040}>4.0 cm</option>
+          <option value={0.050}>5.0 cm</option>
+        </select>
+      </label>
+      <label>{t('pro.stirrupLabel')}:
+        <select bind:value={stirrupDia} class="pro-sel">
+          {#each REBAR_DB.filter(r => r.diameter <= 12) as r}
+            <option value={r.diameter}>{r.label}</option>
+          {/each}
+        </select>
+      </label>
+      <label>{t('pro.exposureLabel')}:
+        <select bind:value={exposure} class="pro-sel">
+          <option value="interior">{t('pro.interior')}</option>
+          <option value="exterior">{t('pro.exterior')}</option>
+        </select>
+      </label>
+    </div>
+    <button class="pro-verify-btn" onclick={runVerification} disabled={!hasResults || (!isCirsocSelected && !selectedNormativeAvailable())}>
+      {t('pro.verifyElements')}
+    </button>
+    {#if hasEnvelope}
+      <span class="pro-env-badge">{t('pro.envelopeActive')}</span>
+    {/if}
+    {#if verifyError}
+      <div class="pro-verify-error">{verifyError}</div>
+    {/if}
+  </div>
+
+  {#if verifications.length > 0 || steelVerifications.length > 0 || slabDesigns.length > 0}
+    <div class="pro-verif-summary">
+      <span class="status-ok">{countOk} ✓</span>
+      <span class="status-warn">{countWarn} ⚠</span>
+      <span class="status-fail">{countFail} ✗</span>
+      {#if quantities}
+        <span class="qty-badge">H°: {quantities.totalConcreteVolume.toFixed(2)} m³</span>
+        <span class="qty-badge">Acero: {quantities.totalSteelWeight.toFixed(0)} kg ({quantities.steelRatio.toFixed(0)} kg/m³)</span>
+      {/if}
+      <button class="pro-show-model-btn" onclick={showOnModel} title={t('pro.showOnModel')}>
+        {t('pro.showOnModel')}
+      </button>
+    </div>
+
+    <!-- Section tabs -->
+    <div class="section-tabs">
+      <button class:active={activeSection === 'verification'} onclick={() => activeSection = 'verification'}>{t('pro.verificationTab')}</button>
+      <button class:active={activeSection === 'detailing'} onclick={() => activeSection = 'detailing'}>{t('pro.detailingTab')}</button>
+      <button class:active={activeSection === 'schedule'} onclick={() => activeSection = 'schedule'}>{t('pro.scheduleTab')}</button>
+      {#if slabDesigns.length > 0}
+        <button class:active={activeSection === 'slabs'} onclick={() => activeSection = 'slabs'}>{t('pro.slabsTab')}</button>
+      {/if}
+      {#if storyDrifts.length > 0}
+        <button class:active={activeSection === 'drift'} onclick={() => activeSection = 'drift'}>Drift{#if storyDrifts.some(d => d.status === 'fail')} ✗{/if}</button>
+      {/if}
+      <button class:active={activeSection === 'connections'} onclick={() => activeSection = 'connections'}>{t('pro.connectionsTab')}</button>
+    </div>
+
+    <!-- ═══ VERIFICATION TAB ═══ -->
+    {#if activeSection === 'verification'}
+      {#if verifications.length > 0}
+        <div class="pro-section-label">{t('pro.cirsoc201')}</div>
+      {/if}
+      <div class="pro-verif-table-wrap">
+        {#if verifications.length > 0}
+        <table class="pro-verif-table">
+          <thead>
+            <tr>
+              <th>Elem</th>
+              <th>Tipo</th>
+              <th>Mu</th>
+              <th>Vu</th>
+              <th>Nu</th>
+              <th>As req</th>
+              <th>As prov</th>
+              <th>Estribos</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each verifications as v}
+              <tr class={statusClass(v.overallStatus)} onclick={() => { toggleExpand(v.elementId); selectElementInViewport(v.elementId); }} style="cursor:pointer">
+                <td class="col-id">{v.elementId}</td>
+                <td class="col-type">{v.elementType === 'beam' ? t('pro.beam') : v.elementType === 'wall' ? t('pro.wall') : t('pro.column')}</td>
+                <td class="col-num">{fmtNum(v.Mu)}</td>
+                <td class="col-num">{fmtNum(v.Vu)}</td>
+                <td class="col-num">{fmtNum(v.Nu)}</td>
+                <td class="col-num">{v.column ? v.column.AsTotal.toFixed(1) : v.flexure.AsReq.toFixed(1)}</td>
+                <td class="col-num">{v.column ? v.column.AsProv.toFixed(1) : v.flexure.AsProv.toFixed(1)}{#if !v.column && v.flexure.isDoublyReinforced && v.flexure.AsComp}<br><span style="font-size:0.65rem;color:#4a90d9">+{v.flexure.AsComp.toFixed(1)} A's</span>{/if}</td>
+                <td class="col-stirrup">eØ{v.shear.stirrupDia} c/{(v.shear.spacing * 100).toFixed(0)}</td>
+                <td class="col-status"><span class={statusClass(v.overallStatus)}>{statusIcon(v.overallStatus)}</span></td>
+              </tr>
+              {#if expandedId === v.elementId}
+                <tr class="detail-row">
+                  <td colspan="9">
+                    <div class="detail-panel">
+                      <!-- Cross section SVG -->
+                      <div class="detail-svg">
+                        {@html generateCrossSectionSvg({
+                          b: v.b, h: v.h, cover: v.cover,
+                          flexure: v.flexure, shear: v.shear,
+                          column: v.column, isColumn: v.elementType === 'column' || v.elementType === 'wall',
+                        })}
+                      </div>
+
+                      <!-- Elevation SVG -->
+                      {#if v.elementType === 'beam'}
+                        {@const elemLen = elementLengthMap.get(v.elementId) ?? 3}
+                        {@const elem = modelStore.elements.get(v.elementId)}
+                        <div class="detail-svg">
+                          {@html generateBeamElevationSvg({
+                            length: elemLen, h: v.h, cover: v.cover,
+                            flexure: v.flexure, shear: v.shear,
+                            supportI: elem ? getSupportType(elem.nodeI) : 'pinned',
+                            supportJ: elem ? getSupportType(elem.nodeJ) : 'pinned',
+                          })}
+                        </div>
+                      {:else if v.column && (v.elementType === 'column' || v.elementType === 'wall')}
+                        {@const elemLen = elementLengthMap.get(v.elementId) ?? 3}
+                        <div class="detail-svg">
+                          {@html generateColumnElevationSvg({
+                            height: elemLen, b: v.b, h: v.h, cover: v.cover,
+                            column: v.column, shear: v.shear,
+                          })}
+                        </div>
+                      {/if}
+
+                      {#if v.column}
+                        {@const diagParams = {
+                          b: v.b, h: v.h, fc: v.fc, fy: rebarFy,
+                          cover: v.cover + stirrupDia / 2000 + v.flexure.barDia / 2000,
+                          AsProv: v.column.AsProv ?? v.flexure.AsProv,
+                          barCount: v.column.barCount ?? v.flexure.barCount,
+                          barDia: v.flexure.barDia,
+                        } satisfies DiagramParams}
+                        {@const diagram = generateInteractionDiagram(diagParams)}
+                        <div class="detail-svg interaction-diagram">
+                          {@html generateInteractionSvg(diagram, { Nu: v.Nu, Mu: v.Mu }, 280, 350)}
+                        </div>
+                      {/if}
+
+                      <div class="detail-memo">
+                        <div class="memo-section">
+                          <div class="memo-title">{t('pro.flexure')}</div>
+                          {#each v.flexure.steps as step}<div class="memo-step">{step}</div>{/each}
+                        </div>
+                        <div class="memo-section">
+                          <div class="memo-title">{t('pro.shear')}</div>
+                          {#each v.shear.steps as step}<div class="memo-step">{step}</div>{/each}
+                        </div>
+                        {#if v.column}
+                          <div class="memo-section">
+                            <div class="memo-title">{t('pro.flexoCompression')}</div>
+                            {#each v.column.steps as step}<div class="memo-step">{step}</div>{/each}
+                          </div>
+                        {/if}
+                        {#if v.torsion}
+                          <div class="memo-section">
+                            <div class="memo-title">{t('pro.torsion')} {v.torsion.neglect ? t('pro.torsionNeglect') : ''}</div>
+                            {#each v.torsion.steps as step}<div class="memo-step">{step}</div>{/each}
+                          </div>
+                        {/if}
+                        {#if v.biaxial}
+                          <div class="memo-section">
+                            <div class="memo-title">{t('pro.biaxialBresler')}</div>
+                            {#each v.biaxial.steps as step}<div class="memo-step">{step}</div>{/each}
+                          </div>
+                        {/if}
+                        {#if v.slender}
+                          <div class="memo-section">
+                            <div class="memo-title">{t('pro.slenderness')} {v.slender.isSlender ? t('pro.slenderCol') : t('pro.shortCol')}</div>
+                            {#each v.slender.steps as step}<div class="memo-step">{step}</div>{/each}
+                          </div>
+                        {/if}
+                        {#if crackResults.get(v.elementId)}
+                          {@const cr = crackResults.get(v.elementId)!}
+                          <div class="memo-section">
+                            <div class="memo-title">{t('pro.cracking')} <span class={statusClass(cr.status)}>{statusIcon(cr.status)}</span></div>
+                            {#each cr.steps as step}<div class="memo-step">{step}</div>{/each}
+                          </div>
+                        {/if}
+                        {#if deflectionResults.get(v.elementId)}
+                          {@const dr = deflectionResults.get(v.elementId)!}
+                          <div class="memo-section">
+                            <div class="memo-title">{t('pro.deflection')} <span class={statusClass(dr.status)}>{statusIcon(dr.status)}</span></div>
+                            {#each dr.steps as step}<div class="memo-step">{step}</div>{/each}
+                          </div>
+                        {/if}
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              {/if}
+            {/each}
+          </tbody>
+        </table>
+        {/if}
+      </div>
+      {#if steelVerifications.length > 0}
+        <div class="pro-section-label">{t('pro.cirsoc301')}</div>
+        <div class="pro-verif-table-wrap">
+          <table class="pro-verif-table">
+            <thead><tr><th>Elem</th><th>Nu</th><th>Muz</th><th>Muy</th><th>Vu</th><th>{t('pro.interaction')}</th><th></th></tr></thead>
+            <tbody>
+              {#each steelVerifications as sv}
+                <tr class={statusClass(sv.overallStatus)} onclick={() => toggleSteelExpand(sv.elementId)} style="cursor:pointer">
+                  <td class="col-id">{sv.elementId}</td>
+                  <td class="col-num">{fmtNum(sv.Nu)}</td>
+                  <td class="col-num">{fmtNum(sv.Muz)}</td>
+                  <td class="col-num">{fmtNum(sv.Muy)}</td>
+                  <td class="col-num">{fmtNum(sv.Vu)}</td>
+                  <td class="col-num">{sv.interaction?.ratio != null ? sv.interaction.ratio.toFixed(2) : '—'}</td>
+                  <td class="col-status"><span class={statusClass(sv.overallStatus)}>{statusIcon(sv.overallStatus)}</span></td>
+                </tr>
+                {#if expandedSteelId === sv.elementId}
+                  <tr class="detail-row">
+                    <td colspan="7">
+                      <div class="detail-panel"><div class="detail-memo">
+                        {#if sv.tension}<div class="memo-section"><div class="memo-title">{t('pro.tension')} <span class={statusClass(sv.tension.status)}>{statusIcon(sv.tension.status)}</span></div>{#each sv.tension.steps as step}<div class="memo-step">{step}</div>{/each}</div>{/if}
+                        {#if sv.compression}<div class="memo-section"><div class="memo-title">{t('pro.compression')} <span class={statusClass(sv.compression.status)}>{statusIcon(sv.compression.status)}</span></div>{#each sv.compression.steps as step}<div class="memo-step">{step}</div>{/each}</div>{/if}
+                        {#if sv.flexure}<div class="memo-section"><div class="memo-title">{t('pro.flexure')} <span class={statusClass(sv.flexure.status)}>{statusIcon(sv.flexure.status)}</span></div>{#each sv.flexure.steps as step}<div class="memo-step">{step}</div>{/each}</div>{/if}
+                        {#if sv.shear}<div class="memo-section"><div class="memo-title">{t('pro.shear')} <span class={statusClass(sv.shear.status)}>{statusIcon(sv.shear.status)}</span></div>{#each sv.shear.steps as step}<div class="memo-step">{step}</div>{/each}</div>{/if}
+                        {#if sv.interaction}<div class="memo-section"><div class="memo-title">{t('pro.interaction')} <span class={statusClass(sv.interaction.status)}>{statusIcon(sv.interaction.status)}</span></div>{#each sv.interaction.steps as step}<div class="memo-step">{step}</div>{/each}</div>{/if}
+                      </div></div>
+                    </td>
+                  </tr>
+                {/if}
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      {/if}
+
+    <!-- ═══ DETAILING TAB ═══ -->
+    {:else if activeSection === 'detailing'}
+      <div class="detailing-content">
+        {#if beamEntries.length > 0}
+          <div class="pro-section-label">{t('pro.beamsLabel')}</div>
+          <div class="detailing-gallery">
+            {#each beamEntries as entry}
+              {@const rep = verifications.find(v => v.elementId === entry.elementIds[0])}
+              {#if rep}
+                {@const elemLen = elementLengthMap.get(rep.elementId) ?? 3}
+                {@const elem = modelStore.elements.get(rep.elementId)}
+                <div class="gallery-item">
+                  <div class="gallery-title">{entry.sectionName} — Elementos {entry.elementIds.join(', ')}</div>
+                  <div class="detail-svg">
+                    {@html generateCrossSectionSvg({
+                      b: rep.b, h: rep.h, cover: rep.cover,
+                      flexure: rep.flexure, shear: rep.shear,
+                      column: rep.column, isColumn: false,
+                    })}
+                  </div>
+                  <div class="detail-svg">
+                    {@html generateBeamElevationSvg({
+                      length: elemLen, h: rep.h, cover: rep.cover,
+                      flexure: rep.flexure, shear: rep.shear,
+                      supportI: elem ? getSupportType(elem.nodeI) : 'pinned',
+                      supportJ: elem ? getSupportType(elem.nodeJ) : 'pinned',
+                    })}
+                  </div>
+                </div>
+              {/if}
+            {/each}
+          </div>
+        {/if}
+
+        {#if colEntries.length > 0}
+          <div class="pro-section-label">{t('pro.columnsLabel')}</div>
+          <div class="detailing-gallery">
+            {#each colEntries as entry}
+              {@const rep = verifications.find(v => v.elementId === entry.elementIds[0])}
+              {#if rep && rep.column}
+                {@const elemLen = elementLengthMap.get(rep.elementId) ?? 3}
+                <div class="gallery-item">
+                  <div class="gallery-title">{entry.sectionName} — Elementos {entry.elementIds.join(', ')}</div>
+                  <div class="detail-svg">
+                    {@html generateCrossSectionSvg({
+                      b: rep.b, h: rep.h, cover: rep.cover,
+                      flexure: rep.flexure, shear: rep.shear,
+                      column: rep.column, isColumn: true,
+                    })}
+                  </div>
+                  <div class="detail-svg">
+                    {@html generateColumnElevationSvg({
+                      height: elemLen, b: rep.b, h: rep.h, cover: rep.cover,
+                      column: rep.column, shear: rep.shear,
+                    })}
+                  </div>
+                </div>
+              {/if}
+            {/each}
+          </div>
+        {/if}
+
+        {#if wallEntries.length > 0}
+          <div class="pro-section-label">{t('pro.wallsLabel')}</div>
+          <div class="detailing-gallery">
+            {#each wallEntries as entry}
+              {@const rep = verifications.find(v => v.elementId === entry.elementIds[0])}
+              {#if rep && rep.column}
+                {@const elemLen = elementLengthMap.get(rep.elementId) ?? 3}
+                <div class="gallery-item">
+                  <div class="gallery-title">{entry.sectionName} — Elementos {entry.elementIds.join(', ')}</div>
+                  <div class="detail-svg">
+                    {@html generateCrossSectionSvg({
+                      b: rep.b, h: rep.h, cover: rep.cover,
+                      flexure: rep.flexure, shear: rep.shear,
+                      column: rep.column, isColumn: true,
+                    })}
+                  </div>
+                  <div class="detail-svg">
+                    {@html generateColumnElevationSvg({
+                      height: elemLen, b: rep.b, h: rep.h, cover: rep.cover,
+                      column: rep.column, shear: rep.shear,
+                    })}
+                  </div>
+                </div>
+              {/if}
+            {/each}
+          </div>
+        {/if}
+
+        <!-- Joint detail -->
+        {#if jointDetail}
+          <div class="pro-section-label">{t('pro.jointDetail')}</div>
+          <div class="detailing-gallery">
+            <div class="gallery-item">
+              <div class="detail-svg">
+                {@html generateJointDetailSvg(jointDetail)}
+              </div>
+              <div class="joint-notes">
+                <div class="memo-step">{t('pro.jointAnchor')}</div>
+                <div class="memo-step">{t('pro.jointStirrup')} eØ{jointDetail.stirrupDia} c/{(jointDetail.stirrupSpacing * 100).toFixed(0)} (CIRSOC 201 §21.5)</div>
+                <div class="memo-step">{t('pro.jointLd')}</div>
+                <div class="memo-step">{t('pro.jointConfined')}</div>
+              </div>
+            </div>
+          </div>
+        {/if}
+      </div>
+
+    <!-- ═══ SCHEDULE TAB ═══ -->
+    {:else if activeSection === 'schedule'}
+      <div class="pro-section-label">{t('pro.scheduleTitle')}</div>
+      <div class="pro-verif-table-wrap">
+        <table class="pro-verif-table">
+          <thead>
+            <tr>
+              <th>{t('pro.thSectionName')}</th>
+              <th>{t('pro.thType')}</th>
+              <th>{t('pro.thElements')}</th>
+              <th>b×h</th>
+              <th>{t('pro.thMainBars')}</th>
+              <th>{t('pro.thStirrups')}</th>
+              <th>{t('pro.thAsPerElem')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each rebarSchedule as entry}
+              <tr>
+                <td style="color:#4ecdc4">{entry.sectionName}</td>
+                <td class="col-type">{entry.elementType === 'beam' ? t('pro.elemTypeBeam') : entry.elementType === 'wall' ? t('pro.elemTypeWall') : t('pro.elemTypeColumn')}</td>
+                <td class="col-elems" title={entry.elementIds.join(', ')}>{entry.elementIds.length === 1 ? entry.elementIds[0] : `${entry.elementIds.length} elem. (${entry.elementIds.join(', ')})`}</td>
+                <td class="col-num">{(entry.b * 100).toFixed(0)}×{(entry.h * 100).toFixed(0)}</td>
+                <td class="col-stirrup">{entry.mainBars}</td>
+                <td class="col-stirrup">{entry.stirrups}</td>
+                <td class="col-num">{entry.totalAsPerElem.toFixed(1)} cm²</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+
+      {#if quantities}
+        <div class="pro-section-label">{t('pro.materialsSummary')}</div>
+        <div class="schedule-summary">
+          <div class="schedule-item">
+            <span class="schedule-label">{t('pro.totalConcrete')}</span>
+            <span class="schedule-value">{quantities.totalConcreteVolume.toFixed(2)} m³</span>
+          </div>
+          <div class="schedule-item">
+            <span class="schedule-label">{t('pro.totalSteel')}</span>
+            <span class="schedule-value">{quantities.totalSteelWeight.toFixed(0)} kg</span>
+          </div>
+          <div class="schedule-item">
+            <span class="schedule-label">{t('pro.globalRatio')}</span>
+            <span class="schedule-value">{quantities.steelRatio.toFixed(1)} kg/m³</span>
+          </div>
+          {#if slabDesigns.length > 0}
+            {@const totalSlabArea = slabDesigns.reduce((s, d) => s + d.spanX * d.spanZ, 0)}
+            {@const totalSlabVol = slabDesigns.reduce((s, d) => s + d.spanX * d.spanZ * d.thickness, 0)}
+            <div class="schedule-item">
+              <span class="schedule-label">{t('pro.slabTotalArea')}</span>
+              <span class="schedule-value">{totalSlabArea.toFixed(1)} m²</span>
+            </div>
+            <div class="schedule-item">
+              <span class="schedule-label">{t('pro.slabConcrete')}</span>
+              <span class="schedule-value">{totalSlabVol.toFixed(2)} m³</span>
+            </div>
+          {/if}
+        </div>
+      {/if}
+
+    <!-- ═══ SLABS TAB ═══ -->
+    {:else if activeSection === 'slabs'}
+      <div class="pro-section-label">{t('pro.slabReinfTitle')}</div>
+      {#each slabDesigns as slab, i}
+        <div class="slab-card">
+          <div class="slab-header">{t('pro.slabPanelN').replace('{n}', String(i + 1))} — {slab.spanX.toFixed(1)}×{slab.spanZ.toFixed(1)} m, e={( slab.thickness * 100).toFixed(0)} cm, f'c={slab.fc} MPa</div>
+          <div class="slab-detail-row">
+            <div class="detail-svg">
+              {@html generateSlabReinforcementSvg({
+                spanX: slab.spanX, spanZ: slab.spanZ,
+                thickness: slab.thickness,
+                mxDesign: slab.designX.Mu, mzDesign: slab.designZ.Mu,
+                barsX: slab.designX.bars, barsZ: slab.designZ.bars,
+                asxProv: slab.designX.AsProv, aszProv: slab.designZ.AsProv,
+              })}
+            </div>
+            <div class="slab-memo">
+              <div class="memo-section">
+                <div class="memo-title">{t('pro.dirX')}</div>
+                <div class="memo-step">Mu = {slab.designX.Mu.toFixed(2)} kN·m/m</div>
+                <div class="memo-step">d = {(slab.designX.d * 100).toFixed(1)} cm</div>
+                <div class="memo-step">As,req = {slab.designX.AsReq.toFixed(2)} cm²/m</div>
+                <div class="memo-step">As,min = {slab.designX.AsMin.toFixed(2)} cm²/m {t('pro.shrinkageLabel')}</div>
+                <div class="memo-step">{t('pro.adopted')} {slab.designX.bars} → As,prov = {slab.designX.AsProv.toFixed(2)} cm²/m</div>
+              </div>
+              <div class="memo-section">
+                <div class="memo-title">{t('pro.dirZ')}</div>
+                <div class="memo-step">Mu = {slab.designZ.Mu.toFixed(2)} kN·m/m</div>
+                <div class="memo-step">d = {(slab.designZ.d * 100).toFixed(1)} cm</div>
+                <div class="memo-step">As,req = {slab.designZ.AsReq.toFixed(2)} cm²/m</div>
+                <div class="memo-step">As,min = {slab.designZ.AsMin.toFixed(2)} cm²/m {t('pro.shrinkageLabel')}</div>
+                <div class="memo-step">{t('pro.adopted')} {slab.designZ.bars} → As,prov = {slab.designZ.AsProv.toFixed(2)} cm²/m</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      {/each}
+      {#if slabDesigns.length === 0}
+        <div class="pro-empty">{t('pro.noSlabs')}</div>
+      {/if}
+
+    {:else if activeSection === 'drift'}
+      <!-- ═══ STORY DRIFT TAB ═══ -->
+      <div class="pro-section-label">{t('pro.driftTitle')}</div>
+      <div class="drift-limit-note">{t('pro.driftLimit')}: Δ/h ≤ {driftLimit} (hormigón armado)</div>
+      <div class="pro-verif-table-wrap">
+        <table class="pro-verif-table">
+          <thead>
+            <tr>
+              <th>Nivel (m)</th>
+              <th>h piso (m)</th>
+              <th>Δx (mm)</th>
+              <th>Δz (mm)</th>
+              <th>Δx/h</th>
+              <th>Δz/h</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each storyDrifts as d}
+              <tr class={d.status === 'fail' ? 'status-fail' : d.status === 'warn' ? 'status-warn' : ''}>
+                <td class="col-num">{d.level.toFixed(2)}</td>
+                <td class="col-num">{d.height.toFixed(2)}</td>
+                <td class="col-num">{(d.driftX * 1000).toFixed(2)}</td>
+                <td class="col-num">{(d.driftZ * 1000).toFixed(2)}</td>
+                <td class="col-num">{d.ratioX < 0.0001 ? '<0.0001' : d.ratioX.toFixed(4)}</td>
+                <td class="col-num">{d.ratioZ < 0.0001 ? '<0.0001' : d.ratioZ.toFixed(4)}</td>
+                <td class="col-status"><span class={'status-' + d.status}>{d.status === 'ok' ? '✓' : d.status === 'fail' ? '✗' : '⚠'}</span></td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+      {#if storyDrifts.length === 0}
+        <div class="pro-empty">{t('pro.noDriftDetected')}</div>
+      {/if}
+
+    {:else if activeSection === 'connections'}
+      <!-- ═══ CONNECTIONS TAB ═══ -->
+      <div class="pro-section-label">{t('pro.connectionsTitle')}</div>
+
+      <!-- Bolt group check -->
+      <details class="conn-details">
+        <summary class="conn-summary">{t('pro.boltGroupTitle')}</summary>
+        <div class="conn-panel">
+          <div class="conn-form">
+            <label class="conn-label">∅ (mm): <input type="number" class="adv-num" bind:value={boltDia} min={6} max={36} step={2} /></label>
+            <label class="conn-label">{t('pro.grade')}: <select class="pro-sel" bind:value={boltGrade}><option value="4.6">4.6</option><option value="8.8">8.8</option><option value="10.9">10.9</option></select></label>
+            <label class="conn-label">n: <input type="number" class="adv-num" bind:value={boltCount} min={1} max={50} /></label>
+            <label class="conn-label">g (mm): <input type="number" class="adv-num" bind:value={boltGauge} min={30} max={200} /></label>
+            <label class="conn-label">p (mm): <input type="number" class="adv-num" bind:value={boltPitch} min={40} max={300} /></label>
+          </div>
+          <div class="conn-form">
+            <label class="conn-label">V (kN): <input type="number" class="adv-num" bind:value={boltShearForce} min={0} step={10} /></label>
+            <label class="conn-label">T (kN): <input type="number" class="adv-num" bind:value={boltTensionForce} min={0} step={10} /></label>
+            <button class="adv-btn-sm" onclick={handleBoltCheck}>{t('pro.verify')}</button>
+          </div>
+          {#if boltResult}
+            <div class="conn-result" class:fail={boltResult.ratio >= 1}>
+              <span>{t('pro.utilization')}: {((boltResult.ratio ?? 0) * 100).toFixed(0)}%</span>
+              {#if boltResult.shearCapacity != null}<span>Vn={boltResult.shearCapacity.toFixed(1)} kN</span>{/if}
+              {#if boltResult.tensionCapacity != null}<span>Tn={boltResult.tensionCapacity.toFixed(1)} kN</span>{/if}
+              {#if boltResult.status}<span class={'status-' + boltResult.status}>{boltResult.status === 'ok' ? '✓' : '✗'}</span>{/if}
+            </div>
+          {/if}
+        </div>
+      </details>
+
+      <!-- Weld group check -->
+      <details class="conn-details">
+        <summary class="conn-summary">{t('pro.weldGroupTitle')}</summary>
+        <div class="conn-panel">
+          <div class="conn-form">
+            <label class="conn-label">{t('pro.weldType')}:
+              <select class="pro-sel" bind:value={weldType}><option value="fillet">{t('pro.fillet')}</option><option value="groove">{t('pro.groove')}</option></select>
+            </label>
+            <label class="conn-label">a (mm): <input type="number" class="adv-num" bind:value={weldSize} min={3} max={25} /></label>
+            <label class="conn-label">L (mm): <input type="number" class="adv-num" bind:value={weldLength} min={20} max={2000} /></label>
+            <label class="conn-label">Fexx (MPa): <input type="number" class="adv-num" bind:value={weldElectrode} min={350} max={700} step={10} /></label>
+          </div>
+          <div class="conn-form">
+            <label class="conn-label">V (kN): <input type="number" class="adv-num" bind:value={weldShear} min={0} step={10} /></label>
+            <button class="adv-btn-sm" onclick={handleWeldCheck}>{t('pro.verify')}</button>
+          </div>
+          {#if weldResult}
+            <div class="conn-result" class:fail={weldResult.ratio >= 1}>
+              <span>{t('pro.utilization')}: {((weldResult.ratio ?? 0) * 100).toFixed(0)}%</span>
+              {#if weldResult.capacity != null}<span>Rn={weldResult.capacity.toFixed(1)} kN</span>{/if}
+              {#if weldResult.status}<span class={'status-' + weldResult.status}>{weldResult.status === 'ok' ? '✓' : '✗'}</span>{/if}
+            </div>
+          {/if}
+        </div>
+      </details>
+
+      <!-- Spread footing check -->
+      <details class="conn-details">
+        <summary class="conn-summary">{t('pro.footingTitle')}</summary>
+        <div class="conn-panel">
+          <div class="conn-form">
+            <label class="conn-label">B (m): <input type="number" class="adv-num" bind:value={footB} min={0.3} max={5} step={0.1} /></label>
+            <label class="conn-label">L (m): <input type="number" class="adv-num" bind:value={footL} min={0.3} max={5} step={0.1} /></label>
+            <label class="conn-label">h (m): <input type="number" class="adv-num" bind:value={footH} min={0.2} max={2} step={0.05} /></label>
+            <label class="conn-label">f'c (MPa): <input type="number" class="adv-num" bind:value={footFc} min={15} max={50} /></label>
+          </div>
+          <div class="conn-form">
+            <label class="conn-label">σ_adm (kPa): <input type="number" class="adv-num" bind:value={footSigmaAdm} min={50} max={1000} step={10} /></label>
+            <label class="conn-label">N (kN): <input type="number" class="adv-num" bind:value={footNu} min={0} step={50} /></label>
+            <label class="conn-label">M (kN·m): <input type="number" class="adv-num" bind:value={footMu} min={0} step={10} /></label>
+            <button class="adv-btn-sm" onclick={handleFootingCheck}>{t('pro.verify')}</button>
+          </div>
+          {#if footResult}
+            <div class="conn-result" class:fail={footResult.ratio >= 1}>
+              <span>{t('pro.utilization')}: {((footResult.ratio ?? 0) * 100).toFixed(0)}%</span>
+              {#if footResult.bearingPressure != null}<span>σ={footResult.bearingPressure.toFixed(0)} kPa</span>{/if}
+              {#if footResult.punchingRatio != null}<span>{t('pro.punching')}: {(footResult.punchingRatio * 100).toFixed(0)}%</span>{/if}
+              {#if footResult.status}<span class={'status-' + footResult.status}>{footResult.status === 'ok' ? '✓' : '✗'}</span>{/if}
+            </div>
+          {/if}
+        </div>
+      </details>
+    {/if}
+
+  {:else if wasmCheckResults && wasmCheckResults.length > 0}
+    <!-- Generic WASM check results display -->
+    <div class="pro-verif-wasm">
+      <div class="pro-verif-summary">
+        <span class="status-ok">{wasmCheckResults.filter((m: any) => m.status === 'ok' || m.ratio < 1).length} ✓</span>
+        <span class="status-fail">{wasmCheckResults.filter((m: any) => m.status === 'fail' || m.ratio >= 1).length} ✗</span>
+      </div>
+      <div class="pro-verif-scroll">
+        {#each wasmCheckResults as member}
+          <div class="wasm-check-card" class:fail={member.status === 'fail' || member.ratio >= 1}>
+            <div class="wasm-check-header">
+              <strong>E{member.elementId ?? '?'}</strong>
+              {#if member.ratio != null}
+                <span class="wasm-ratio" class:fail={member.ratio >= 1}>{(member.ratio * 100).toFixed(0)}%</span>
+              {/if}
+              {#if member.status}
+                <span class="wasm-status">{member.status}</span>
+              {/if}
+            </div>
+            {#if member.checks && Array.isArray(member.checks)}
+              <div class="wasm-checks">
+                {#each member.checks as check}
+                  <div class="wasm-check-line">
+                    <span class="wasm-check-name">{check.name ?? check.type ?? ''}</span>
+                    {#if check.ratio != null}
+                      <span class="wasm-check-ratio" class:fail={check.ratio >= 1}>{(check.ratio * 100).toFixed(0)}%</span>
+                    {/if}
+                    {#if check.message}<span class="wasm-check-msg">{check.message}</span>{/if}
+                  </div>
+                {/each}
+              </div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    </div>
+  {:else if !verifyError}
+    <div class="pro-empty">
+      {#if hasResults}
+        {t('pro.verifyPrompt')}
+      {:else}
+        {t('pro.solveFirst')}
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .pro-verif { display: flex; flex-direction: column; height: 100%; }
+
+  .pro-verif-header {
+    padding: 8px 10px;
+    border-bottom: 1px solid #1a3050;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .pro-verif-title-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .pro-verif-title {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #4ecdc4;
+  }
+
+  .normative-sel {
+    font-size: 0.65rem;
+    padding: 3px 6px;
+    min-width: 130px;
+  }
+
+  .pro-wasm-notice {
+    padding: 4px 8px;
+    font-size: 0.62rem;
+    color: #f0a500;
+    background: rgba(240, 165, 0, 0.1);
+    border: 1px solid rgba(240, 165, 0, 0.25);
+    border-radius: 3px;
+  }
+
+  .pro-verif-params {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .pro-verif-params label {
+    font-size: 0.62rem;
+    color: #888;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .pro-sel {
+    padding: 2px 4px;
+    background: #0f2840;
+    border: 1px solid #1a3050;
+    border-radius: 2px;
+    color: #ccc;
+    font-size: 0.62rem;
+    cursor: pointer;
+  }
+
+  .pro-verify-btn {
+    align-self: flex-start;
+    padding: 5px 16px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #fff;
+    background: linear-gradient(135deg, #0f7b6c, #0a5a4e);
+    border: 1px solid #4ecdc4;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  .pro-verify-btn:hover { background: linear-gradient(135deg, #1a9a8a, #0f7b6c); }
+  .pro-verify-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+  .qty-badge {
+    font-size: 0.62rem;
+    color: #aaa;
+    font-family: monospace;
+    margin-left: auto;
+  }
+
+  .qty-badge + .qty-badge { margin-left: 8px; }
+
+  .pro-env-badge {
+    font-size: 0.6rem;
+    color: #4ecdc4;
+    background: rgba(78, 205, 196, 0.1);
+    padding: 2px 8px;
+    border-radius: 3px;
+    border: 1px solid rgba(78, 205, 196, 0.3);
+  }
+
+  .pro-verify-error {
+    padding: 4px 8px;
+    font-size: 0.68rem;
+    color: #ff8a9e;
+    background: rgba(233, 69, 96, 0.1);
+    border-radius: 3px;
+  }
+
+  .pro-verif-summary {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    padding: 6px 10px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    border-bottom: 1px solid #1a3050;
+  }
+  .pro-show-model-btn {
+    margin-left: auto;
+    padding: 3px 10px;
+    font-size: 0.65rem;
+    font-weight: 600;
+    background: linear-gradient(135deg, #2a6a5a, #1a5040);
+    color: #ccc;
+    border: 1px solid #3a7a6a;
+    border-radius: 4px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .pro-show-model-btn:hover { background: linear-gradient(135deg, #3a8a7a, #2a6060); color: #fff; }
+
+  .pro-verif-table-wrap { flex: 1; overflow: auto; }
+
+  .pro-verif-table { width: 100%; border-collapse: collapse; font-size: 0.68rem; }
+  .pro-verif-table thead { position: sticky; top: 0; z-index: 2; }
+  .pro-verif-table th {
+    padding: 4px 5px; text-align: left; font-size: 0.56rem; font-weight: 600;
+    color: #888; text-transform: uppercase; background: #0a1a30; border-bottom: 1px solid #1a4a7a;
+  }
+  .pro-verif-table td { padding: 3px 5px; border-bottom: 1px solid #0f2030; color: #ccc; }
+  .pro-verif-table tbody tr:hover { background: rgba(78, 205, 196, 0.05); }
+
+  .col-id { width: 30px; color: #666; font-family: monospace; text-align: center; }
+  .col-type { font-size: 0.62rem; }
+  .col-num { font-family: monospace; text-align: right; font-size: 0.65rem; }
+  .col-stirrup { font-family: monospace; font-size: 0.6rem; white-space: nowrap; }
+  .col-elems { font-size: 0.58rem; color: #888; max-width: 140px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .col-status { text-align: center; font-size: 0.85rem; }
+
+  .status-ok { color: #4ecdc4; }
+  .status-fail { color: #e94560; }
+  .status-warn { color: #f0a500; }
+
+  .detail-row td { padding: 0 !important; background: #0a1628 !important; }
+
+  .detail-panel {
+    display: flex;
+    gap: 10px;
+    padding: 10px;
+    flex-wrap: wrap;
+  }
+
+  .detail-svg {
+    flex-shrink: 0;
+    background: #0f1a30;
+    border: 1px solid #1a3050;
+    border-radius: 4px;
+    padding: 8px;
+    overflow: auto;
+    max-width: 100%;
+  }
+
+  .detail-svg :global(svg) {
+    max-width: 100%;
+    height: auto;
+  }
+
+  .detail-memo {
+    flex: 1;
+    min-width: 200px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .memo-section {
+    background: #0f1a30;
+    border: 1px solid #1a3050;
+    border-radius: 4px;
+    padding: 6px 8px;
+  }
+
+  .memo-title {
+    font-size: 0.65rem;
+    font-weight: 600;
+    color: #4ecdc4;
+    margin-bottom: 4px;
+    text-transform: uppercase;
+  }
+
+  .memo-step {
+    font-size: 0.62rem;
+    color: #aaa;
+    font-family: monospace;
+    line-height: 1.5;
+  }
+
+  .pro-section-label {
+    padding: 6px 10px;
+    font-size: 0.65rem;
+    font-weight: 600;
+    color: #4ecdc4;
+    text-transform: uppercase;
+    border-bottom: 1px solid #1a3050;
+    background: rgba(78, 205, 196, 0.05);
+  }
+
+  .interaction-diagram {
+    flex-shrink: 0;
+  }
+
+  .pro-empty {
+    text-align: center;
+    color: #555;
+    font-style: italic;
+    padding: 40px 10px;
+  }
+
+  /* ─── Section tabs ─── */
+  .section-tabs {
+    display: flex;
+    gap: 0;
+    border-bottom: 1px solid #1a3050;
+    background: #0a1628;
+  }
+  .section-tabs button {
+    padding: 6px 14px;
+    font-size: 0.65rem;
+    font-weight: 600;
+    color: #666;
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s;
+  }
+  .section-tabs button:hover { color: #aaa; }
+  .section-tabs button.active {
+    color: #4ecdc4;
+    border-bottom-color: #4ecdc4;
+  }
+
+  /* ─── Detailing gallery ─── */
+  .detailing-content { flex: 1; overflow: auto; }
+
+  .detailing-gallery {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    padding: 10px;
+  }
+
+  .gallery-item {
+    background: #0a1628;
+    border: 1px solid #1a3050;
+    border-radius: 4px;
+    padding: 8px;
+    min-width: 200px;
+    max-width: 500px;
+  }
+
+  .gallery-title {
+    font-size: 0.62rem;
+    font-weight: 600;
+    color: #4ecdc4;
+    margin-bottom: 6px;
+    text-transform: uppercase;
+  }
+
+  .joint-notes {
+    margin-top: 8px;
+    padding: 6px 8px;
+    background: #0f1a30;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+  }
+
+  /* ─── Schedule summary ─── */
+  .schedule-summary {
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .schedule-item {
+    display: flex;
+    justify-content: space-between;
+    padding: 5px 10px;
+    background: #0f1a30;
+    border: 1px solid #1a3050;
+    border-radius: 3px;
+    font-size: 0.68rem;
+  }
+  .schedule-label { color: #888; }
+  .schedule-value { color: #4ecdc4; font-family: monospace; font-weight: 600; }
+
+  /* ─── Slab cards ─── */
+  .slab-card {
+    margin: 8px 10px;
+    background: #0a1628;
+    border: 1px solid #1a3050;
+    border-radius: 4px;
+    overflow: hidden;
+  }
+  .slab-header {
+    padding: 6px 10px;
+    font-size: 0.65rem;
+    font-weight: 600;
+    color: #4ecdc4;
+    background: rgba(78, 205, 196, 0.05);
+    border-bottom: 1px solid #1a3050;
+  }
+  .slab-detail-row {
+    display: flex;
+    gap: 10px;
+    padding: 10px;
+    flex-wrap: wrap;
+  }
+  .slab-memo {
+    flex: 1;
+    min-width: 180px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .drift-limit-note {
+    font-size: 0.65rem;
+    color: #8ba;
+    padding: 2px 10px 4px;
+  }
+
+  /* ─── WASM check results ─── */
+  .pro-verif-wasm { padding: 8px; overflow-y: auto; flex: 1; }
+  .wasm-check-card { padding: 6px 8px; margin-bottom: 4px; background: #0d1b33; border: 1px solid #1a3a5a; border-radius: 4px; font-size: 0.72rem; }
+  .wasm-check-card.fail { border-color: #e94560; }
+  .wasm-check-header { display: flex; align-items: center; gap: 8px; }
+  .wasm-ratio { font-weight: 700; color: #4ecdc4; }
+  .wasm-ratio.fail { color: #e94560; }
+  .wasm-status { font-size: 0.65rem; color: #778; }
+  .wasm-checks { margin-top: 4px; padding-left: 8px; border-left: 2px solid #1a3a5a; }
+  .wasm-check-line { display: flex; gap: 6px; font-size: 0.65rem; color: #aaa; padding: 1px 0; }
+  .wasm-check-name { color: #8ab; }
+  .wasm-check-ratio { font-weight: 600; color: #4ecdc4; }
+  .wasm-check-ratio.fail { color: #e94560; }
+  .wasm-check-msg { color: #888; font-size: 0.6rem; }
+
+  /* ── Connections tab ── */
+  .conn-details { margin-bottom: 6px; }
+  .conn-summary { font-size: 0.72rem; color: #4ecdc4; font-weight: 600; cursor: pointer; padding: 4px 8px; background: #0d1b33; border-radius: 4px; }
+  .conn-summary:hover { background: #122644; }
+  .conn-panel { padding: 6px 8px; display: flex; flex-direction: column; gap: 6px; }
+  .conn-form { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+  .conn-label { font-size: 0.62rem; color: #888; display: flex; align-items: center; gap: 3px; }
+  .conn-label .adv-num { width: 55px; }
+  .conn-result { padding: 4px 8px; font-size: 0.68rem; color: #ccc; background: rgba(78, 205, 196, 0.08); border: 1px solid rgba(78, 205, 196, 0.2); border-radius: 4px; display: flex; gap: 10px; flex-wrap: wrap; }
+  .conn-result.fail { border-color: #e94560; background: rgba(233, 69, 96, 0.08); }
+  .adv-btn-sm { padding: 3px 10px; border: 1px solid #1a4a7a; border-radius: 4px; background: #0f3460; color: #4ecdc4; font-size: 0.68rem; cursor: pointer; }
+  .adv-btn-sm:hover { background: #1a4a7a; color: white; }
+</style>


### PR DESCRIPTION
## Summary
- Add PRO panel with 13 analysis tabs: nodes, elements, materials, sections, supports, loads, connections, constraints, diagnostics, results, shell, verification, advanced
- Add PRO dialogs: auto-loads calculator, report generator
- Add EDU panel: guided exercises, step-by-step solver, educational verification
- Wire basico/educativo/pro mode toggle in App header
- Per-mode model persistence (switching modes saves/restores model state)
- Conditional sidebar and toolbar rendering based on active mode

**22 files changed** — 14 Pro components, 5 Edu components, App.svelte (final version)

## Test plan
- [ ] `npm run build` passes
- [ ] Mode toggle switches between Basico/EDU/PRO
- [ ] PRO panel renders all 13 tabs without errors
- [ ] PRO dialogs (auto-loads, report) open correctly
- [ ] EDU panel renders exercises
- [ ] Switching modes preserves model state

**Stack:** 4/4 — depends on #16. Final state matches `feat/i18n-full-sweep` exactly.