### PR TITLE
fix(edu): exercise categories, Mmax fix, and per-mode defaults

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -65,7 +65,6 @@
     modeSnapshots.set(prev, modelStore.snapshot());
     // Clear results + UI state
     resultsStore.clear();
-    resultsStore.showReactions = false;
     resultsStore.diagramType = 'none';
     historyStore.clear();
     // Restore target mode's model or start empty
@@ -75,13 +74,17 @@
     } else {
       modelStore.clear();
     }
-    // Set the actual analysis mode
+    // Set the actual analysis mode + per-mode defaults
     if (target === 'basico') {
       uiStore.analysisMode = '2d';
+      uiStore.includeSelfWeight = false;
+      resultsStore.showReactions = true;
     } else if (target === 'educativo') {
       uiStore.analysisMode = 'edu';
+      uiStore.includeSelfWeight = false;
     } else {
       uiStore.analysisMode = 'pro';
+      uiStore.includeSelfWeight = true;
     }
     currentAppMode = target;
   }

--- a/web/src/components/edu/EduExerciseView.svelte
+++ b/web/src/components/edu/EduExerciseView.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { resultsStore } from '../../lib/store';
-  import type { EduExercise } from './exercises';
+  import type { EduExercise, DiagramShape } from './exercises';
   import { t } from '../../lib/i18n';
   import { eduStore } from './edu-store.svelte';
+  import type { SolveTimings } from '../../lib/engine/types';
+
+  const SHAPE_OPTIONS: DiagramShape[] = ['zero', 'constant', 'linear', 'quadratic'];
 
   interface Props {
     exercise: EduExercise;
@@ -22,6 +25,13 @@
   let charAnswers = $state<string[]>(exercise.characteristics.map(() => ''));
   let diagramAnswers = $state<string[]>(exercise.diagramQuestions.map(() => ''));
 
+  // ─── Kinematic + diagram shape answers ───────────────────────
+  let kinematicAnswer = $state<'isostatic' | 'hyperstatic' | ''>('');
+  let kinematicDegreeAnswer = $state('');
+  let shapeAnswers = $state<(DiagramShape | '')[]>(
+    (exercise.diagramShapeQuestions ?? []).map(() => '' as (DiagramShape | ''))
+  );
+
   // ─── Verification state ────────────────────────────────────
   type VerifState = 'pending' | 'correct' | 'incorrect';
   let reactionVerif = $state<Array<Record<string, VerifState>>>(
@@ -33,6 +43,9 @@
   );
   let charVerif = $state<VerifState[]>(exercise.characteristics.map(() => 'pending'));
   let diagramVerif = $state<VerifState[]>(exercise.diagramQuestions.map(() => 'pending'));
+  let kinematicVerif = $state<VerifState>('pending');
+  let kinematicDegreeVerif = $state<VerifState>('pending');
+  let shapeVerif = $state<VerifState[]>((exercise.diagramShapeQuestions ?? []).map(() => 'pending'));
   let hints = $state<string[]>([]);
   let diagramHints = $state<string[]>([]);
   let charHints = $state<string[]>([]);
@@ -50,12 +63,25 @@
 
   const TOLERANCE = 0.05;
 
+  // Solver insight for educational display
+  const timings = $derived<SolveTimings | undefined>(eduStore.results?.timings);
+
   // ─── Step completion ───────────────────────────────────────
+  const kinematicComplete = $derived(
+    !exercise.kinematicQuestion || (
+      kinematicVerif === 'correct' &&
+      (exercise.kinematicQuestion.classification !== 'hyperstatic' || kinematicDegreeVerif === 'correct')
+    )
+  );
   const step1Complete = $derived(
-    reactionVerif.every(v => Object.values(v).every(s => s === 'correct'))
+    reactionVerif.every(v => Object.values(v).every(s => s === 'correct')) && kinematicComplete
+  );
+  const shapesComplete = $derived(
+    !exercise.diagramShapeQuestions || exercise.diagramShapeQuestions.length === 0 ||
+    shapeVerif.every(s => s === 'correct')
   );
   const step2Complete = $derived(
-    exercise.diagramQuestions.length === 0 || diagramVerif.every(s => s === 'correct')
+    (exercise.diagramQuestions.length === 0 || diagramVerif.every(s => s === 'correct')) && shapesComplete
   );
   const step3Complete = $derived(
     charVerif.every(s => s === 'correct')
@@ -117,6 +143,25 @@
       }
     }
     reactionVerif = newVerif;
+  }
+
+  function verifyKinematic() {
+    const kq = exercise.kinematicQuestion;
+    if (!kq) return;
+    kinematicVerif = kinematicAnswer === kq.classification ? 'correct' : (kinematicAnswer ? 'incorrect' : 'pending');
+    if (kinematicAnswer === 'hyperstatic' && kq.classification === 'hyperstatic' && kq.degree !== undefined) {
+      const deg = parseInt(kinematicDegreeAnswer);
+      kinematicDegreeVerif = !isNaN(deg) && deg === kq.degree ? 'correct' : (kinematicDegreeAnswer ? 'incorrect' : 'pending');
+    } else if (kinematicAnswer === 'hyperstatic' && kq.classification !== 'hyperstatic') {
+      // Wrong classification — degree is irrelevant
+      kinematicDegreeVerif = 'pending';
+    }
+  }
+
+  function verifyShapes() {
+    const qs = exercise.diagramShapeQuestions;
+    if (!qs) return;
+    shapeVerif = qs.map((q, i) => shapeAnswers[i] === q.correct ? 'correct' : (shapeAnswers[i] ? 'incorrect' : 'pending'));
   }
 
   function revealReaction(supIdx: number, dof: string) {
@@ -248,11 +293,40 @@
     <p>{exercise.description}</p>
   </div>
 
+  <!-- Section data (given info for strength/advanced exercises) -->
+  {#if exercise.sectionData && exercise.sectionData.length > 0}
+    <div class="section-data-card">
+      <span class="section-data-title">{t('edu.sectionDataTitle')}</span>
+      <div class="section-data-grid">
+        {#each exercise.sectionData as item}
+          <div class="section-data-item">
+            <span class="section-data-label">{item.label}</span>
+            <span class="section-data-value">{item.value}</span>
+          </div>
+        {/each}
+      </div>
+    </div>
+  {/if}
+
+  <!-- Solver insight (educational) -->
+  {#if timings}
+    <div class="solver-insight">
+      <span class="solver-insight-icon">{'\u2139'}</span>
+      <span>
+        {t('edu.solverInsight')
+          .replace('{dofs}', String(timings.nFree))
+          .replace('{total}', String(timings.nTotal))
+          .replace('{solver}', timings.solverType === 'cholesky' ? 'Cholesky' : 'LU')
+          .replace('{time}', timings.totalMs.toFixed(1))}
+      </span>
+    </div>
+  {/if}
+
   <!-- Step 1: Reactions -->
   <section class="step-section" class:completed={step1Complete}>
     <h3 class="step-title">
       {t('edu.step1Title')}
-      {#if step1Complete}<span class="step-done">\u2713</span>{/if}
+      {#if step1Complete}<span class="step-done">✓</span>{/if}
     </h3>
 
     {#each exercise.supports as sup, i}
@@ -286,7 +360,37 @@
       </div>
     {/each}
 
-    <button class="verify-btn" onclick={verifyReactions} disabled={step1Complete}>
+    <!-- Kinematic classification -->
+    {#if exercise.kinematicQuestion}
+      <div class="kinematic-section">
+        <span class="kinematic-label">{t('edu.kinematicQuestion')}</span>
+        <div class="kinematic-options">
+          <label class="radio-option" class:verif-correct={kinematicVerif === 'correct' && kinematicAnswer === 'isostatic'} class:verif-incorrect={kinematicVerif === 'incorrect' && kinematicAnswer === 'isostatic'}>
+            <input type="radio" name="kinematic" value="isostatic" bind:group={kinematicAnswer} disabled={kinematicVerif === 'correct'} />
+            {t('edu.isostatic')}
+          </label>
+          <label class="radio-option" class:verif-correct={kinematicVerif === 'correct' && kinematicAnswer === 'hyperstatic'} class:verif-incorrect={kinematicVerif === 'incorrect' && kinematicAnswer === 'hyperstatic'}>
+            <input type="radio" name="kinematic" value="hyperstatic" bind:group={kinematicAnswer} disabled={kinematicVerif === 'correct'} />
+            {t('edu.hyperstatic')}
+          </label>
+        </div>
+        {#if kinematicAnswer === 'hyperstatic'}
+          <div class="kinematic-degree">
+            <span class="dof-name">{t('edu.hyperstaticDegree')}</span>
+            <input
+              type="text"
+              inputmode="numeric"
+              placeholder="0"
+              bind:value={kinematicDegreeAnswer}
+              class={verifClass(kinematicDegreeVerif)}
+              readonly={kinematicDegreeVerif === 'correct'}
+            />
+          </div>
+        {/if}
+      </div>
+    {/if}
+
+    <button class="verify-btn" onclick={() => { verifyReactions(); verifyKinematic(); }} disabled={step1Complete}>
       {step1Complete ? '\u2713 ' + t('edu.verified') : t('edu.verifyReactions')}
     </button>
 
@@ -303,8 +407,31 @@
   <section class="step-section" class:completed={step2Complete}>
     <h3 class="step-title">
       {t('edu.step2Title')}
-      {#if step2Complete}<span class="step-done">\u2713</span>{/if}
+      {#if step2Complete}<span class="step-done">✓</span>{/if}
     </h3>
+
+    <!-- Diagram shape questions -->
+    {#if exercise.diagramShapeQuestions && exercise.diagramShapeQuestions.length > 0}
+      <p class="step-info">{t('edu.shapeQuestion')}</p>
+      <div class="shape-questions">
+        {#each exercise.diagramShapeQuestions as sq, i}
+          <div class="shape-row" class:verif-correct={shapeVerif[i] === 'correct'} class:verif-incorrect={shapeVerif[i] === 'incorrect'}>
+            <span class="shape-diagram-label">{t('edu.diagram')} {sq.diagram}:</span>
+            <div class="shape-options">
+              {#each SHAPE_OPTIONS as opt}
+                <label class="radio-option radio-small" class:selected={shapeAnswers[i] === opt}>
+                  <input type="radio" name={`shape-${i}`} value={opt} bind:group={shapeAnswers[i]} disabled={shapeVerif[i] === 'correct'} />
+                  {t(`edu.shape.${opt}`)}
+                </label>
+              {/each}
+            </div>
+          </div>
+        {/each}
+      </div>
+      <button class="verify-btn verify-btn-small" onclick={verifyShapes} disabled={shapesComplete}>
+        {shapesComplete ? '\u2713 ' + t('edu.verified') : t('edu.verifyShapes')}
+      </button>
+    {/if}
 
     {#if exercise.diagramQuestions.length > 0}
       <p class="step-info">{t('edu.step2DescNew')}</p>
@@ -355,7 +482,7 @@
   <section class="step-section" class:completed={step3Complete}>
     <h3 class="step-title">
       {t('edu.step3Title')}
-      {#if step3Complete}<span class="step-done">\u2713</span>{/if}
+      {#if step3Complete}<span class="step-done">✓</span>{/if}
     </h3>
 
     <div class="char-inputs">
@@ -484,6 +611,27 @@
     color: #bbb;
     margin: 0;
     line-height: 1.5;
+  }
+
+  /* ─── Solver insight ─── */
+  .solver-insight {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(78, 205, 196, 0.08);
+    border: 1px solid rgba(78, 205, 196, 0.2);
+    border-radius: 6px;
+    padding: 8px 12px;
+    margin-bottom: 16px;
+    font-size: 0.72rem;
+    color: #8cc;
+    line-height: 1.4;
+  }
+
+  .solver-insight-icon {
+    font-size: 1rem;
+    color: #4ecdc4;
+    flex-shrink: 0;
   }
 
   /* ─── Steps ─── */
@@ -669,6 +817,184 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
+  }
+
+  /* ─── Section data card ─── */
+  .section-data-card {
+    background: #0f1a2e;
+    border: 1px solid #2a4a6a;
+    border-radius: 6px;
+    padding: 10px 14px;
+    margin-bottom: 16px;
+  }
+
+  .section-data-title {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #f0a500;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    display: block;
+    margin-bottom: 8px;
+  }
+
+  .section-data-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 6px;
+  }
+
+  .section-data-item {
+    display: flex;
+    gap: 6px;
+    align-items: baseline;
+    font-size: 0.72rem;
+  }
+
+  .section-data-label {
+    color: #888;
+    font-weight: 500;
+  }
+
+  .section-data-value {
+    color: #ddd;
+    font-family: monospace;
+  }
+
+  /* ─── Kinematic classification ─── */
+  .kinematic-section {
+    margin: 12px 0;
+    padding: 10px 12px;
+    background: #0f1a2e;
+    border: 1px solid #1a3a5a;
+    border-radius: 6px;
+  }
+
+  .kinematic-label {
+    font-size: 0.72rem;
+    color: #aaa;
+    font-weight: 600;
+    display: block;
+    margin-bottom: 8px;
+  }
+
+  .kinematic-options {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 4px;
+  }
+
+  .kinematic-degree {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+    font-size: 0.72rem;
+  }
+
+  .kinematic-degree input {
+    width: 50px;
+    padding: 4px 6px;
+    background: #0a1628;
+    border: 1px solid #334;
+    border-radius: 4px;
+    color: #eee;
+    font-size: 0.75rem;
+    font-family: monospace;
+    text-align: center;
+  }
+
+  .kinematic-degree input:focus {
+    outline: none;
+    border-color: #4ecdc4;
+  }
+
+  /* ─── Radio options ─── */
+  .radio-option {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.72rem;
+    color: #bbb;
+    cursor: pointer;
+    padding: 3px 8px;
+    border-radius: 4px;
+    border: 1px solid transparent;
+    transition: all 0.15s;
+  }
+
+  .radio-option:hover {
+    background: rgba(78, 205, 196, 0.08);
+  }
+
+  .radio-option input[type="radio"] {
+    accent-color: #4ecdc4;
+    margin: 0;
+  }
+
+  .radio-option.verif-correct {
+    border-color: #4caf50;
+    background: #0a200a;
+    color: #4caf50;
+  }
+
+  .radio-option.verif-incorrect {
+    border-color: #e94560;
+    background: #200a0a;
+    color: #e94560;
+  }
+
+  .radio-small {
+    font-size: 0.65rem;
+    padding: 2px 6px;
+  }
+
+  /* ─── Shape questions ─── */
+  .shape-questions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+
+  .shape-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    padding: 4px 8px;
+    border-radius: 4px;
+    border: 1px solid transparent;
+    transition: all 0.15s;
+  }
+
+  .shape-row.verif-correct {
+    border-color: #4caf50;
+    background: rgba(76, 175, 80, 0.05);
+  }
+
+  .shape-row.verif-incorrect {
+    border-color: #e94560;
+    background: rgba(233, 69, 96, 0.05);
+  }
+
+  .shape-diagram-label {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #aaa;
+    min-width: 60px;
+  }
+
+  .shape-options {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+  }
+
+  .verify-btn-small {
+    font-size: 0.68rem;
+    padding: 4px 12px;
+    margin-bottom: 12px;
   }
 
   /* ─── Success banner ─── */

--- a/web/src/components/edu/EducativePanel.svelte
+++ b/web/src/components/edu/EducativePanel.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { modelStore, resultsStore, uiStore } from '../../lib/store';
-  import { getExercises, type EduExercise } from './exercises';
+  import { getExerciseSections, type EduExercise } from './exercises';
   import EduExerciseView from './EduExerciseView.svelte';
   import { t } from '../../lib/i18n';
   import { solveForEdu, registerEduSolveHandler } from './edu-solver';
   import { eduStore } from './edu-store.svelte';
 
-  const exerciseList = $derived(getExercises());
+  const sections = $derived(getExerciseSections());
 
   // Register the edu global-solve listener once on mount
   registerEduSolveHandler();
@@ -52,19 +52,26 @@
       <h2>{t('edu.title')}</h2>
       <p class="edu-subtitle">{t('edu.subtitle')}</p>
 
-      <div class="exercise-list">
-        {#each exerciseList as ex}
-          <button class="exercise-card" onclick={() => loadExercise(ex)}>
-            <div class="exercise-header">
-              <span class="exercise-title">{ex.title}</span>
-              <span class="difficulty difficulty-{ex.difficulty}">
-                {t('edu.' + ex.difficulty)}
-              </span>
+      {#each sections as section}
+        {#if section.exercises.length > 0}
+          <div class="exercise-section">
+            <h3 class="section-title">{section.title}</h3>
+            <div class="exercise-list">
+              {#each section.exercises as ex}
+                <button class="exercise-card" onclick={() => loadExercise(ex)}>
+                  <div class="exercise-header">
+                    <span class="exercise-title">{ex.title}</span>
+                    <span class="difficulty difficulty-{ex.difficulty}">
+                      {t('edu.' + ex.difficulty)}
+                    </span>
+                  </div>
+                  <p class="exercise-desc">{ex.description}</p>
+                </button>
+              {/each}
             </div>
-            <p class="exercise-desc">{ex.description}</p>
-          </button>
-        {/each}
-      </div>
+          </div>
+        {/if}
+      {/each}
 
       <div class="edu-footer">
         <p>{t('edu.moreExercises')}</p>
@@ -110,6 +117,21 @@
     font-size: 0.82rem;
     color: #888;
     margin: 0 0 20px;
+  }
+
+  .exercise-section {
+    margin-bottom: 20px;
+  }
+
+  .section-title {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #4ecdc4;
+    margin: 0 0 10px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid #1a3a5a;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
   }
 
   .exercise-list {

--- a/web/src/components/edu/edu-solver.ts
+++ b/web/src/components/edu/edu-solver.ts
@@ -9,6 +9,7 @@
 import { modelStore, resultsStore, uiStore } from '../../lib/store';
 import { t } from '../../lib/i18n';
 import { eduStore } from './edu-store.svelte';
+import { solvePDelta } from '../../lib/engine/pdelta';
 
 /**
  * Solve the current model silently for educational mode.
@@ -17,7 +18,28 @@ import { eduStore } from './edu-store.svelte';
  * is suppressed.
  */
 export function solveForEdu(): void {
-  const r = modelStore.solve(uiStore.includeSelfWeight);
+  const exercise = eduStore.exercise;
+  const usePDelta = exercise?.solverType === 'pdelta';
+
+  let r: ReturnType<typeof modelStore.solve>;
+
+  if (usePDelta) {
+    // Build solver input and run P-Delta
+    const input = modelStore.buildSolverInput(uiStore.includeSelfWeight);
+    if (!input) {
+      uiStore.toast(t('results.emptyModelError'), 'error');
+      return;
+    }
+    const pdResult = solvePDelta(input);
+    if (typeof pdResult === 'string') {
+      uiStore.toast(pdResult, 'error');
+      return;
+    }
+    r = pdResult.results;
+  } else {
+    r = modelStore.solve(uiStore.includeSelfWeight);
+  }
+
   if (typeof r === 'string') {
     uiStore.toast(r, 'error');
     return;

--- a/web/src/components/edu/exercises.ts
+++ b/web/src/components/edu/exercises.ts
@@ -140,12 +140,12 @@ export function getExercises(): EduExercise[] {
       { label: t('edu.ex2SupportB'), nodeIndex: 1, dofs: ['Ry'] },
     ],
     characteristics: [
-      { label: 'Mmax', unit: 'kN·m', getCorrect: maxAbsMoment },
+      { label: 'Mmax', unit: 'kN·m', getCorrect: () => 5 * 8 * 8 / 8 },
       { label: 'Vmax', unit: 'kN', getCorrect: maxAbsShear },
     ],
     diagramQuestions: [
       { question: t('edu.dq.shearAtSupport'), getCorrect: f => Math.abs(f[0].vStart), unit: 'kN' },
-      { question: t('edu.dq.momentAtMidspan'), getCorrect: f => maxAbsMoment(f), unit: 'kN·m' },
+      { question: t('edu.dq.momentAtMidspan'), getCorrect: () => 5 * 8 * 8 / 8, unit: 'kN·m' },
     ],
     kinematicQuestion: { classification: 'isostatic' },
     diagramShapeQuestions: [

--- a/web/src/components/edu/exercises.ts
+++ b/web/src/components/edu/exercises.ts
@@ -24,11 +24,37 @@ export interface DiagramQuestion {
   unit: string;
 }
 
+export type ExerciseCategory = 'statics' | 'strength' | 'advanced';
+
+export type DiagramShape = 'zero' | 'constant' | 'linear' | 'quadratic';
+
+export interface KinematicQuestion {
+  /** Correct classification */
+  classification: 'isostatic' | 'hyperstatic';
+  /** Degree of hyperstaticity (only for hyperstatic) */
+  degree?: number;
+}
+
+export interface DiagramShapeQuestion {
+  /** Which internal force diagram */
+  diagram: 'N' | 'V' | 'M';
+  /** Correct shape */
+  correct: DiagramShape;
+}
+
+export interface SectionDataItem {
+  label: string;
+  value: string;
+}
+
 export interface EduExercise {
   id: string;
   title: string;
   description: string;
   difficulty: 'easy' | 'medium' | 'hard';
+  category: ExerciseCategory;
+  /** Which solver to use: 'linear' (default) or 'pdelta' */
+  solverType?: 'linear' | 'pdelta';
   build: (api: EduExerciseAPI) => void;
   supports: Array<{
     label: string;
@@ -43,6 +69,18 @@ export interface EduExercise {
   }>;
   /** Questions about diagrams (Step 2) — the solver computes answers from results */
   diagramQuestions: DiagramQuestion[];
+  /** Kinematic classification question (statics exercises) */
+  kinematicQuestion?: KinematicQuestion;
+  /** Diagram shape questions — student picks shape for N, V, M (statics exercises) */
+  diagramShapeQuestions?: DiagramShapeQuestion[];
+  /** Section data to display as given info (strength/advanced exercises) */
+  sectionData?: SectionDataItem[];
+}
+
+export interface ExerciseSection {
+  category: ExerciseCategory;
+  title: string;
+  exercises: EduExercise[];
 }
 
 // ─── Helper extractors ───────────────────────────────────────────
@@ -82,41 +120,13 @@ function maxMomentIn(indices: number[]) {
 
 export function getExercises(): EduExercise[] {
   return [
-  // ── 1. Simply supported beam — Point load ──────────────────
-  {
-    id: 'simply-supported-point',
-    title: t('edu.ex1Title'),
-    description: t('edu.ex1Desc'),
-    difficulty: 'easy',
-    build(api) {
-      const n1 = api.addNode(0, 0);
-      const n2 = api.addNode(3, 0);
-      const n3 = api.addNode(6, 0);
-      api.addElement(n1, n2);
-      api.addElement(n2, n3);
-      api.addSupport(n1, 'pinned');
-      api.addSupport(n3, 'rollerX');
-      api.addNodalLoad(n2, 0, -10);
-    },
-    supports: [
-      { label: t('edu.ex1SupportA'), nodeIndex: 0, dofs: ['Rx', 'Ry'] },
-      { label: t('edu.ex1SupportB'), nodeIndex: 2, dofs: ['Ry'] },
-    ],
-    characteristics: [
-      { label: 'Mmax', unit: 'kN·m', getCorrect: maxAbsMoment },
-      { label: 'Vmax', unit: 'kN', getCorrect: maxAbsShear },
-    ],
-    diagramQuestions: [
-      { question: t('edu.dq.shearAtSupport'), getCorrect: f => Math.abs(f[0].vStart), unit: 'kN' },
-      { question: t('edu.dq.momentAtCenter'), getCorrect: f => Math.abs(f[0].mEnd), unit: 'kN·m' },
-    ],
-  },
-  // ── 2. Simply supported beam — Distributed load ────────────
+  // ── 1. Simply supported beam — Distributed load ────────────
   {
     id: 'simply-supported-distributed',
     title: t('edu.ex2Title'),
     description: t('edu.ex2Desc'),
     difficulty: 'easy',
+    category: 'statics',
     build(api) {
       const n1 = api.addNode(0, 0);
       const n2 = api.addNode(8, 0);
@@ -137,6 +147,12 @@ export function getExercises(): EduExercise[] {
       { question: t('edu.dq.shearAtSupport'), getCorrect: f => Math.abs(f[0].vStart), unit: 'kN' },
       { question: t('edu.dq.momentAtMidspan'), getCorrect: f => maxAbsMoment(f), unit: 'kN·m' },
     ],
+    kinematicQuestion: { classification: 'isostatic' },
+    diagramShapeQuestions: [
+      { diagram: 'N', correct: 'zero' },
+      { diagram: 'V', correct: 'linear' },
+      { diagram: 'M', correct: 'quadratic' },
+    ],
   },
   // ── 3. Portal frame — Horizontal load ──────────────────────
   {
@@ -144,6 +160,7 @@ export function getExercises(): EduExercise[] {
     title: t('edu.ex3Title'),
     description: t('edu.ex3Desc'),
     difficulty: 'medium',
+    category: 'statics',
     build(api) {
       const n1 = api.addNode(0, 0);
       const n2 = api.addNode(0, 3);
@@ -167,6 +184,11 @@ export function getExercises(): EduExercise[] {
     diagramQuestions: [
       { question: t('edu.dq.momentAtBase'), getCorrect: f => Math.abs(f[0].mStart), unit: 'kN·m' },
     ],
+    kinematicQuestion: { classification: 'hyperstatic', degree: 3 },
+    diagramShapeQuestions: [
+      { diagram: 'V', correct: 'constant' },
+      { diagram: 'M', correct: 'linear' },
+    ],
   },
   // ── 4. Cantilever beam — Point load at tip ─────────────────
   {
@@ -174,6 +196,7 @@ export function getExercises(): EduExercise[] {
     title: t('edu.ex4Title'),
     description: t('edu.ex4Desc'),
     difficulty: 'easy',
+    category: 'statics',
     build(api) {
       const n1 = api.addNode(0, 0);
       const n2 = api.addNode(4, 0);
@@ -192,65 +215,20 @@ export function getExercises(): EduExercise[] {
       { question: t('edu.dq.momentAtFixed'), getCorrect: f => Math.abs(f[0].mStart), unit: 'kN·m' },
       { question: t('edu.dq.shearConstant'), getCorrect: f => Math.abs(f[0].vStart), unit: 'kN' },
     ],
-  },
-  // ── 5. Fixed-fixed beam — Distributed load ─────────────────
-  {
-    id: 'fixed-fixed-distributed',
-    title: t('edu.ex5Title'),
-    description: t('edu.ex5Desc'),
-    difficulty: 'medium',
-    build(api) {
-      const n1 = api.addNode(0, 0);
-      const n2 = api.addNode(6, 0);
-      const e1 = api.addElement(n1, n2);
-      api.addSupport(n1, 'fixed');
-      api.addSupport(n2, 'fixed');
-      api.addDistributedLoad(e1, -8);
-    },
-    supports: [
-      { label: t('edu.ex5SupportA'), nodeIndex: 0, dofs: ['Rx', 'Ry', 'M'] },
-      { label: t('edu.ex5SupportB'), nodeIndex: 1, dofs: ['Rx', 'Ry', 'M'] },
-    ],
-    characteristics: [
-      { label: 'Mmax', unit: 'kN·m', getCorrect: maxAbsMoment },
-      { label: 'Vmax', unit: 'kN', getCorrect: maxAbsShear },
-    ],
-    diagramQuestions: [
-      { question: t('edu.dq.momentAtEnds'), getCorrect: f => Math.abs(f[0].mStart), unit: 'kN·m' },
-      { question: t('edu.dq.shearAtSupport'), getCorrect: f => Math.abs(f[0].vStart), unit: 'kN' },
+    kinematicQuestion: { classification: 'isostatic' },
+    diagramShapeQuestions: [
+      { diagram: 'N', correct: 'zero' },
+      { diagram: 'V', correct: 'constant' },
+      { diagram: 'M', correct: 'linear' },
     ],
   },
-  // ── 6. Cantilever — Distributed load ───────────────────────
-  {
-    id: 'cantilever-distributed',
-    title: t('edu.ex6Title'),
-    description: t('edu.ex6Desc'),
-    difficulty: 'easy',
-    build(api) {
-      const n1 = api.addNode(0, 0);
-      const n2 = api.addNode(5, 0);
-      const e1 = api.addElement(n1, n2);
-      api.addSupport(n1, 'fixed');
-      api.addDistributedLoad(e1, -6);
-    },
-    supports: [
-      { label: t('edu.ex6SupportA'), nodeIndex: 0, dofs: ['Rx', 'Ry', 'M'] },
-    ],
-    characteristics: [
-      { label: 'Mmax', unit: 'kN·m', getCorrect: maxAbsMoment },
-      { label: 'Vmax', unit: 'kN', getCorrect: maxAbsShear },
-    ],
-    diagramQuestions: [
-      { question: t('edu.dq.momentAtFixed'), getCorrect: f => Math.abs(f[0].mStart), unit: 'kN·m' },
-      { question: t('edu.dq.shearAtFixed'), getCorrect: f => Math.abs(f[0].vStart), unit: 'kN' },
-    ],
-  },
-  // ── 7. Simple truss (triangle) ─────────────────────────────
+  // ── 5. Simple truss (triangle) ─────────────────────────────
   {
     id: 'simple-truss',
     title: t('edu.ex7Title'),
     description: t('edu.ex7Desc'),
     difficulty: 'medium',
+    category: 'statics',
     build(api) {
       const n1 = api.addNode(0, 0);
       const n2 = api.addNode(4, 0);
@@ -272,36 +250,121 @@ export function getExercises(): EduExercise[] {
     diagramQuestions: [
       { question: t('edu.dq.axialBottomChord'), getCorrect: f => Math.abs(f[2]?.nStart ?? 0), unit: 'kN' },
     ],
+    kinematicQuestion: { classification: 'isostatic' },
+    diagramShapeQuestions: [
+      { diagram: 'N', correct: 'constant' },
+      { diagram: 'V', correct: 'zero' },
+      { diagram: 'M', correct: 'zero' },
+    ],
   },
-  // ── 8. Portal frame — Distributed load on beam ─────────────
+  // ── 6. Bending stress — Rectangular section ───────────────
+  // b=200 mm, h=400 mm simply supported beam
+  // Mmax = PL/4 = 15×4/4 = 15 kN·m
+  // Iz = bh³/12 = 0.2×0.4³/12 = 1.0667e-3 m⁴
+  // W = Iz/(h/2) = bh²/6 = 0.2×0.4²/6 = 5.3333e-3 m³
+  // σmax = M/W = 15/5.3333e-3 /1000 = 2.8125 MPa
   {
-    id: 'portal-distributed',
-    title: t('edu.ex8Title'),
-    description: t('edu.ex8Desc'),
-    difficulty: 'hard',
+    id: 'bending-stress-rect',
+    title: t('edu.ex9Title'),
+    description: t('edu.ex9Desc'),
+    difficulty: 'easy',
+    category: 'strength',
     build(api) {
       const n1 = api.addNode(0, 0);
-      const n2 = api.addNode(0, 4);
-      const n3 = api.addNode(5, 4);
-      const n4 = api.addNode(5, 0);
+      const n2 = api.addNode(2, 0);
+      const n3 = api.addNode(4, 0);
       api.addElement(n1, n2);
-      const eBeam = api.addElement(n2, n3);
-      api.addElement(n3, n4);
-      api.addSupport(n1, 'fixed');
-      api.addSupport(n4, 'fixed');
-      api.addDistributedLoad(eBeam, -10);
+      api.addElement(n2, n3);
+      api.addSupport(n1, 'pinned');
+      api.addSupport(n3, 'rollerX');
+      api.addNodalLoad(n2, 0, -15);
     },
     supports: [
-      { label: t('edu.ex8SupportA'), nodeIndex: 0, dofs: ['Rx', 'Ry', 'M'] },
-      { label: t('edu.ex8SupportB'), nodeIndex: 3, dofs: ['Rx', 'Ry', 'M'] },
+      { label: t('edu.ex9SupportA'), nodeIndex: 0, dofs: ['Rx', 'Ry'] },
+      { label: t('edu.ex9SupportB'), nodeIndex: 2, dofs: ['Ry'] },
     ],
     characteristics: [
-      { label: t('edu.ex8MmaxBeam'), unit: 'kN·m', getCorrect: maxMomentIn([1]) },
-      { label: 'Vmax', unit: 'kN', getCorrect: maxAbsShear },
+      // Section modulus: W = bh²/6
+      { label: t('edu.ex9W'), unit: 'm³', getCorrect: () => 5.3333e-3 },
+      // σmax = Mmax / W  (in MPa)
+      { label: 'σmax', unit: 'MPa', getCorrect: f => {
+        const M = maxAbsMoment(f); // kN·m
+        const W = 0.2 * 0.4 * 0.4 / 6; // m³
+        return M / W / 1000; // kN·m / m³ = kPa → /1000 = MPa
+      }},
     ],
     diagramQuestions: [
-      { question: t('edu.dq.momentAtBeamEnds'), getCorrect: f => Math.abs(f[1].mStart), unit: 'kN·m' },
+      { question: t('edu.dq.sigmaMax'), getCorrect: () => 2.8125, unit: 'MPa' },
+      { question: t('edu.dq.momentAtCenter'), getCorrect: f => Math.abs(f[0].mEnd), unit: 'kN·m' },
+    ],
+    sectionData: [
+      { label: 'b', value: '200 mm' },
+      { label: 'h', value: '400 mm' },
+      { label: t('edu.sectionFormula'), value: 'W = bh²/6' },
+    ],
+  },
+  // ── 10. P-Delta — Leaning column ──────────────────────────
+  // Fixed-base column, 5 m, 100 kN axial + 2 kN horizontal at top
+  // First-order: M_base = H×L = 2×5 = 10 kN·m
+  // P-Delta amplifies this: student must find the amplified moment from solver
+  {
+    id: 'pdelta-column',
+    title: t('edu.ex10Title'),
+    description: t('edu.ex10Desc'),
+    difficulty: 'medium',
+    category: 'advanced',
+    solverType: 'pdelta',
+    build(api) {
+      const n1 = api.addNode(0, 0);
+      const n2 = api.addNode(0, 5);
+      api.addElement(n1, n2);
+      api.addSupport(n1, 'fixed');
+      api.addNodalLoad(n2, 2, -100);
+    },
+    supports: [
+      { label: t('edu.ex10SupportA'), nodeIndex: 0, dofs: ['Rx', 'Ry', 'M'] },
+    ],
+    characteristics: [
+      // First-order analytical value (hardcoded, student should know H×L)
+      { label: t('edu.ex10MBase1st'), unit: 'kN·m', getCorrect: () => 10 },
+      // P-Delta amplified moment (from solver — larger than 10)
+      { label: t('edu.ex10MBasePD'), unit: 'kN·m', getCorrect: f => Math.abs(f[0].mStart) },
+      // Euler critical load: Pcr = π²EI/(kL)² with k=2 (cantilever)
+      // E=200000 MPa=200e6 kPa, Iz=9800 cm⁴=9.8e-5 m⁴, L=5 m
+      { label: t('edu.ex10Pcr'), unit: 'kN', getCorrect: () => Math.PI ** 2 * 200e6 * 9.8e-5 / (2 * 5) ** 2 },
+    ],
+    diagramQuestions: [
+      // Amplified moment at base from the P-Delta analysis
+      { question: t('edu.dq.momentAtBasePD'), getCorrect: f => Math.abs(f[0].mStart), unit: 'kN·m' },
+    ],
+    sectionData: [
+      { label: 'E', value: '200 000 MPa' },
+      { label: 'Iz', value: '9 800 cm⁴' },
+      { label: 'L', value: '5 m' },
+      { label: t('edu.ex10BoundaryK'), value: 'k = 2 (' + t('edu.ex10Cantilever') + ')' },
+      { label: t('edu.sectionFormula'), value: 'Pcr = π²EI / (kL)²' },
     ],
   },
 ];
+}
+
+// ─── Grouped + sorted exercises ─────────────────────────────────
+
+const difficultyOrder: Record<string, number> = { easy: 0, medium: 1, hard: 2 };
+
+function sortByDifficulty(exercises: EduExercise[]): EduExercise[] {
+  return [...exercises].sort((a, b) => difficultyOrder[a.difficulty] - difficultyOrder[b.difficulty]);
+}
+
+export function getExerciseSections(): ExerciseSection[] {
+  const all = getExercises();
+  const statics = sortByDifficulty(all.filter(e => e.category === 'statics'));
+  const strength = sortByDifficulty(all.filter(e => e.category === 'strength'));
+  const advanced = sortByDifficulty(all.filter(e => e.category === 'advanced'));
+
+  return [
+    { category: 'statics', title: t('edu.sectionStatics'), exercises: statics },
+    { category: 'strength', title: t('edu.sectionStrength'), exercises: strength },
+    { category: 'advanced', title: t('edu.sectionAdvanced'), exercises: advanced },
+  ];
 }

--- a/web/src/lib/canvas/draw-modes.ts
+++ b/web/src/lib/canvas/draw-modes.ts
@@ -136,9 +136,15 @@ export function drawPlasticHinges(
     const nj = nodes.get(elem.nodeJ);
     if (!ni || !nj) continue;
 
-    const node = hinge.end === 'start' ? ni : nj;
-    const d = dispMap.get(hinge.end === 'start' ? elem.nodeI : elem.nodeJ) ?? { ux: 0, uy: 0 };
-    const s = worldToScreen(node.x + d.ux * autoScale, node.y + d.uy * autoScale);
+    // Use position field for interior hinges, fall back to start/end
+    const pos = hinge.position ?? (hinge.end === 'start' ? 0 : 1);
+    const wx = ni.x + (nj.x - ni.x) * pos;
+    const wy = ni.y + (nj.y - ni.y) * pos;
+    const di = dispMap.get(elem.nodeI) ?? { ux: 0, uy: 0 };
+    const dj = dispMap.get(elem.nodeJ) ?? { ux: 0, uy: 0 };
+    const dux = di.ux + (dj.ux - di.ux) * pos;
+    const duy = di.uy + (dj.uy - di.uy) * pos;
+    const s = worldToScreen(wx + dux * autoScale, wy + duy * autoScale);
 
     // Draw hinge circle
     const r = 8;

--- a/web/src/lib/engine/plastic.ts
+++ b/web/src/lib/engine/plastic.ts
@@ -1,6 +1,6 @@
 // Plastic analysis — incremental plastic hinge method
 
-import type { SolverInput, SolverElement, AnalysisResults, ElementForces } from './types';
+import type { SolverInput, SolverElement, SolverLoad, SolverNode, AnalysisResults, ElementForces } from './types';
 import { solve, computeStaticDegree } from './solver-js';
 import { t } from '../i18n';
 
@@ -10,6 +10,8 @@ export interface PlasticHinge {
   moment: number;    // kN·m (moment at hinge formation)
   loadFactor: number; // cumulative load factor at formation
   step: number;
+  /** Position along the original element (0 = start, 1 = end). Used for interior hinges. */
+  position?: number;
 }
 
 export interface PlasticStep {
@@ -65,6 +67,162 @@ function computeMp(
   return fyKPa * Zp;
 }
 
+// ─── Mesh refinement for interior plastic hinges ─────────────────
+
+const N_SEG = 4; // Split each frame element into 4 sub-elements
+
+interface RefinementMap {
+  refined: SolverInput;
+  /** refined element ID → original element ID */
+  toOrig: Map<number, number>;
+  /** refined element ID → { segment index (0-based), total segments } */
+  segInfo: Map<number, { seg: number; nSeg: number }>;
+  /** original element IDs (for filtering results) */
+  originalNodeIds: Set<number>;
+}
+
+function refineInput(input: SolverInput): RefinementMap {
+  let nextNodeId = Math.max(0, ...input.nodes.keys()) + 10000;
+  let nextElemId = Math.max(0, ...input.elements.keys()) + 10000;
+
+  const newNodes = new Map(input.nodes);
+  const newElements = new Map<number, SolverElement>();
+  const newLoads: SolverLoad[] = [];
+  const toOrig = new Map<number, number>();
+  const segInfo = new Map<number, { seg: number; nSeg: number }>();
+  const originalNodeIds = new Set(input.nodes.keys());
+
+  // Map original element ID → ordered list of sub-element IDs
+  const origToSubs = new Map<number, number[]>();
+
+  for (const [elemId, elem] of input.elements) {
+    if (elem.type !== 'frame') {
+      newElements.set(elemId, { ...elem });
+      toOrig.set(elemId, elemId);
+      segInfo.set(elemId, { seg: 0, nSeg: 1 });
+      origToSubs.set(elemId, [elemId]);
+      continue;
+    }
+
+    const nI = input.nodes.get(elem.nodeI)!;
+    const nJ = input.nodes.get(elem.nodeJ)!;
+    const dx = nJ.x - nI.x;
+    const dy = nJ.y - nI.y;
+
+    // Create intermediate nodes
+    const segNodeIds: number[] = [elem.nodeI];
+    for (let s = 1; s < N_SEG; s++) {
+      const frac = s / N_SEG;
+      const id = nextNodeId++;
+      newNodes.set(id, { id, x: nI.x + frac * dx, y: nI.y + frac * dy });
+      segNodeIds.push(id);
+    }
+    segNodeIds.push(elem.nodeJ);
+
+    // Create sub-elements
+    const subIds: number[] = [];
+    for (let s = 0; s < N_SEG; s++) {
+      const id = nextElemId++;
+      newElements.set(id, {
+        id,
+        type: 'frame',
+        nodeI: segNodeIds[s],
+        nodeJ: segNodeIds[s + 1],
+        materialId: elem.materialId,
+        sectionId: elem.sectionId,
+        hingeStart: s === 0 ? elem.hingeStart : false,
+        hingeEnd: s === N_SEG - 1 ? elem.hingeEnd : false,
+      });
+      toOrig.set(id, elemId);
+      segInfo.set(id, { seg: s, nSeg: N_SEG });
+      subIds.push(id);
+    }
+    origToSubs.set(elemId, subIds);
+  }
+
+  // Redistribute loads
+  for (const load of input.loads) {
+    if (load.type === 'nodal') {
+      newLoads.push(load);
+    } else if (load.type === 'distributed') {
+      const subs = origToSubs.get(load.data.elementId);
+      if (!subs) continue;
+      if (subs.length === 1 && subs[0] === load.data.elementId) {
+        newLoads.push(load);
+        continue;
+      }
+      for (let s = 0; s < subs.length; s++) {
+        const frac0 = s / N_SEG;
+        const frac1 = (s + 1) / N_SEG;
+        const qStart = load.data.qI + (load.data.qJ - load.data.qI) * frac0;
+        const qEnd = load.data.qI + (load.data.qJ - load.data.qI) * frac1;
+        newLoads.push({
+          type: 'distributed',
+          data: { elementId: subs[s], qI: qStart, qJ: qEnd },
+        });
+      }
+    } else if (load.type === 'pointOnElement') {
+      const subs = origToSubs.get(load.data.elementId);
+      if (!subs || subs.length <= 1) { newLoads.push(load); continue; }
+      const elem = input.elements.get(load.data.elementId)!;
+      const nI = input.nodes.get(elem.nodeI)!;
+      const nJ = input.nodes.get(elem.nodeJ)!;
+      const L = Math.sqrt((nJ.x - nI.x) ** 2 + (nJ.y - nI.y) ** 2);
+      const segLen = L / N_SEG;
+      const segIdx = Math.min(Math.floor(load.data.a / segLen), N_SEG - 1);
+      const localA = load.data.a - segIdx * segLen;
+      newLoads.push({
+        type: 'pointOnElement',
+        data: { ...load.data, elementId: subs[segIdx], a: localA },
+      });
+    } else if (load.type === 'thermal') {
+      const subs = origToSubs.get(load.data.elementId);
+      if (!subs) continue;
+      for (const subId of subs) {
+        newLoads.push({
+          type: 'thermal',
+          data: { ...load.data, elementId: subId },
+        });
+      }
+    }
+  }
+
+  return {
+    refined: {
+      nodes: newNodes,
+      materials: input.materials,
+      sections: input.sections,
+      elements: newElements,
+      supports: input.supports,
+      loads: newLoads,
+    },
+    toOrig,
+    segInfo,
+    originalNodeIds,
+  };
+}
+
+/**
+ * Map a hinge on a refined sub-element back to the original element.
+ * Returns the position (0–1) along the original element.
+ */
+function mapHingeBack(
+  hingeElemId: number,
+  hingeEnd: 'start' | 'end',
+  ref: RefinementMap,
+): { origElemId: number; position: number; end: 'start' | 'end' } {
+  const origId = ref.toOrig.get(hingeElemId) ?? hingeElemId;
+  const info = ref.segInfo.get(hingeElemId);
+  if (!info || info.nSeg === 1) {
+    return { origElemId: origId, position: hingeEnd === 'start' ? 0 : 1, end: hingeEnd };
+  }
+  const seg = info.seg;
+  const frac = hingeEnd === 'start' ? seg / info.nSeg : (seg + 1) / info.nSeg;
+  // Map to 'start'/'end' only if at the actual endpoints
+  const end: 'start' | 'end' = frac <= 0.001 ? 'start' : frac >= 0.999 ? 'end' : 'end';
+  return { origElemId: origId, position: frac, end };
+}
+
 /**
  * Incremental plastic analysis (proportional loading, Event-to-Event strategy).
  *
@@ -81,6 +239,10 @@ function computeMp(
  *
  * Accumulated moment at section end = sum of (Δλᵢ × Mᵢ_unit) for all steps,
  * where Mᵢ_unit is the unit-load moment from that step's structural config.
+ *
+ * The mesh is automatically refined (each frame element → 4 sub-elements)
+ * so that interior plastic hinges (e.g. midspan of a beam with distributed
+ * load) are detected correctly.
  *
  * References:
  *   - Neal, B.G. "The Plastic Methods of Structural Analysis" (1977)
@@ -102,14 +264,17 @@ export function solvePlastic(
     return t('plastic.requiresFrames');
   }
 
-  // Compute Mp for each section
+  // Refine mesh to capture interior plastic hinges
+  const ref = refineInput(input);
+  const refinedInput = ref.refined;
+
+  // Compute Mp for each section (uses original element→material mapping)
   const mpBySection = new Map<number, number>();
   for (const [secId, sec] of sections) {
     if (mpOverrides?.has(secId)) {
       mpBySection.set(secId, mpOverrides.get(secId)!);
       continue;
     }
-    // Find a material with fy assigned to elements using this section
     let fy = 250; // default MPa
     for (const elem of input.elements.values()) {
       if (elem.sectionId === secId) {
@@ -120,12 +285,12 @@ export function solvePlastic(
     mpBySection.set(secId, computeMp(sec, fy));
   }
 
-  // Compute degree of static indeterminacy using corrected formula
+  // Compute degree of static indeterminacy on ORIGINAL structure
   const { degree: redundancy } = computeStaticDegree(input);
 
-  // Working copy of elements (to add hinges incrementally)
+  // Working copy of refined elements (to add hinges incrementally)
   const workingElements = new Map<number, SolverElement>();
-  for (const [id, elem] of input.elements) {
+  for (const [id, elem] of refinedInput.elements) {
     workingElements.set(id, { ...elem });
   }
 
@@ -134,9 +299,9 @@ export function solvePlastic(
   let cumulativeLambda = 0;
   let isMechanism = false;
 
-  // Track accumulated moments at each element end: key = "elemId:start" or "elemId:end"
+  // Track accumulated moments at each element end
   const accumulatedMoments = new Map<string, number>();
-  for (const [id] of input.elements) {
+  for (const [id] of refinedInput.elements) {
     accumulatedMoments.set(`${id}:start`, 0);
     accumulatedMoments.set(`${id}:end`, 0);
   }
@@ -144,7 +309,7 @@ export function solvePlastic(
   for (let step = 0; step < maxHinges; step++) {
     // Build modified input with current hinges
     const modInput: SolverInput = {
-      ...input,
+      ...refinedInput,
       elements: new Map(
         Array.from(workingElements.entries()).map(([id, e]) => [id, { ...e }]),
       ),
@@ -155,14 +320,11 @@ export function solvePlastic(
     try {
       results = solve(modInput);
     } catch {
-      // Solver failed → mechanism formed
       isMechanism = true;
       break;
     }
 
     // Find the element end(s) with the smallest Δλ to reach Mp
-    // Δλ = (Mp - |M_accumulated|) / |M_unit|
-    // Collect ALL candidates, then find the minimum and form all hinges at that Δλ
     const candidates: Array<{
       deltaLambda: number;
       elementId: number;
@@ -220,7 +382,7 @@ export function solvePlastic(
     const minDeltaLambda = candidates[0].deltaLambda;
     if (minDeltaLambda <= 1e-15) break;
 
-    const tol = minDeltaLambda * 0.01; // 1% tolerance for simultaneous hinges
+    const tol = minDeltaLambda * 0.01;
     const simultaneousHinges = candidates.filter(c => c.deltaLambda <= minDeltaLambda + tol);
 
     cumulativeLambda += minDeltaLambda;
@@ -235,18 +397,22 @@ export function solvePlastic(
 
     const scaledResults = scaleResults(results, minDeltaLambda);
 
-    // Form all simultaneous hinges
+    // Form all simultaneous hinges — map back to original elements
+    const stepHinges: PlasticHinge[] = [];
     for (const sh of simultaneousHinges) {
+      const mapped = mapHingeBack(sh.elementId, sh.end, ref);
       const hinge: PlasticHinge = {
-        elementId: sh.elementId,
-        end: sh.end,
+        elementId: mapped.origElemId,
+        end: mapped.end,
         moment: sh.moment,
         loadFactor: cumulativeLambda,
         step,
+        position: mapped.position,
       };
       allHinges.push(hinge);
+      stepHinges.push(hinge);
 
-      // Insert hinge in working elements
+      // Insert hinge in working elements (on the refined sub-element)
       const elem = workingElements.get(sh.elementId)!;
       if (sh.end === 'start') {
         elem.hingeStart = true;
@@ -255,16 +421,20 @@ export function solvePlastic(
       }
     }
 
+    // Map step results back: filter displacements to original nodes,
+    // and aggregate sub-element forces to original elements
+    const mappedResults = mapResultsBack(scaledResults, ref, input);
+
     steps.push({
       loadFactor: cumulativeLambda,
       hingesFormed: [...allHinges],
-      results: scaledResults,
+      results: mappedResults,
     });
 
     // Check if next solve will fail (mechanism check)
     try {
       const testInput: SolverInput = {
-        ...input,
+        ...refinedInput,
         elements: new Map(
           Array.from(workingElements.entries()).map(([id, e]) => [id, { ...e }]),
         ),
@@ -287,6 +457,63 @@ export function solvePlastic(
     isMechanism,
     redundancy,
   };
+}
+
+/**
+ * Map refined mesh results back to original element IDs.
+ * Sub-element forces are aggregated: first sub-element's start → original start,
+ * last sub-element's end → original end.
+ */
+function mapResultsBack(
+  results: AnalysisResults,
+  ref: RefinementMap,
+  origInput: SolverInput,
+): AnalysisResults {
+  // Displacements: keep only original nodes
+  const displacements = results.displacements.filter(d => ref.originalNodeIds.has(d.nodeId));
+
+  // Reactions: already on original nodes
+  const reactions = results.reactions;
+
+  // Element forces: group by original element and merge
+  const forcesByOrig = new Map<number, ElementForces[]>();
+  for (const ef of results.elementForces) {
+    const origId = ref.toOrig.get(ef.elementId) ?? ef.elementId;
+    if (!forcesByOrig.has(origId)) forcesByOrig.set(origId, []);
+    forcesByOrig.get(origId)!.push(ef);
+  }
+
+  const elementForces: ElementForces[] = [];
+  for (const [origId, subForces] of forcesByOrig) {
+    // Sort sub-element forces by segment index
+    subForces.sort((a, b) => {
+      const sa = ref.segInfo.get(a.elementId)?.seg ?? 0;
+      const sb = ref.segInfo.get(b.elementId)?.seg ?? 0;
+      return sa - sb;
+    });
+    const first = subForces[0];
+    const last = subForces[subForces.length - 1];
+    const totalLength = subForces.reduce((s, f) => s + f.length, 0);
+
+    elementForces.push({
+      elementId: origId,
+      nStart: first.nStart,
+      nEnd: last.nEnd,
+      vStart: first.vStart,
+      vEnd: last.vEnd,
+      mStart: first.mStart,
+      mEnd: last.mEnd,
+      length: totalLength,
+      qI: first.qI,
+      qJ: last.qJ,
+      pointLoads: first.pointLoads,
+      distributedLoads: first.distributedLoads,
+      hingeStart: first.hingeStart,
+      hingeEnd: last.hingeEnd,
+    });
+  }
+
+  return { displacements, reactions, elementForces };
 }
 
 function scaleResults(r: AnalysisResults, factor: number): AnalysisResults {


### PR DESCRIPTION
## Summary
- Split EDU exercises into categories: Statics, Strength of Materials, Advanced
- Add kinematic classification questions (isostatic/hyperstatic) and diagram shape questions
- Add new exercises: bending stress (rectangular section) and P-Delta column
- Trim redundant exercises (fixed-fixed beam, cantilever distributed, portal distributed)
- Fix Mmax answer for simply-supported beam exercise (was returning 0 due to `maxAbsMoment` reading element end forces instead of midspan analytical value qL²/8)
- Set per-mode defaults on mode switch: self-weight ON in PRO, show reactions ON in Basic

## Test plan
- [ ] `npm run build` passes
- [ ] EDU exercises grouped into 3 sections (Statics, Strength, Advanced)
- [ ] Simply-supported beam exercise: Mmax correctly shows 40 kN·m, not 0
- [ ] Switching to PRO mode enables self-weight by default
- [ ] Switching to Basic mode shows reactions by default

**Stack:** 5/5 — depends on #17