### PR TITLE
fix: landing page "Try Demo" button broken after rebrand

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -47,7 +47,7 @@
 
   // Listen for enter-app event from LandingPage "Try Demo" buttons
   if (typeof window !== 'undefined') {
-    window.addEventListener('dedaliano-enter-app', enterApp);
+    window.addEventListener('stabileo-enter-app', enterApp);
   }
 
   // ─── Per-mode model persistence ───


### PR DESCRIPTION
## Summary
- The rebrand commit renamed all `dedaliano-*` events to `stabileo-*` but missed the `enter-app` listener in `App.svelte`
- This broke the "Try Demo" button on the landing page — clicking it dispatched `stabileo-enter-app` but nothing was listening

## Fix
One-line change: `dedaliano-enter-app` → `stabileo-enter-app` in `App.svelte` line 50.

## Test plan
- [x] Click "Try Demo" on landing page → enters the app