### PR TITLE
[10] fix(ui): correct panel behavior and mobile mode access

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -489,9 +489,11 @@
           <EducativePanel />
         </aside>
       {:else}
-        <button class="sidebar-toggle-btn right-toggle" class:sidebar-closed={!uiStore.rightSidebarOpen} onclick={() => uiStore.rightSidebarOpen = !uiStore.rightSidebarOpen} title={uiStore.rightSidebarOpen ? t('app.hideRightPanel') : t('app.showRightPanel')}>
-          {uiStore.rightSidebarOpen ? '▸' : '◂'}
-        </button>
+        {#if !uiStore.aiDrawerOpen}
+          <button class="sidebar-toggle-btn right-toggle" class:sidebar-closed={!uiStore.rightSidebarOpen} onclick={() => uiStore.rightSidebarOpen = !uiStore.rightSidebarOpen} title={uiStore.rightSidebarOpen ? t('app.hideRightPanel') : t('app.showRightPanel')}>
+            {uiStore.rightSidebarOpen ? '▸' : '◂'}
+          </button>
+        {/if}
         {#if uiStore.rightSidebarOpen}
           <aside class="sidebar right" data-tour="right-sidebar" class:wizard-open={dsmStepsStore.isOpen}>
             {#if dsmStepsStore.isOpen}
@@ -532,7 +534,11 @@
   {#if uiStore.isMobile && uiStore.rightDrawerOpen}
     <div class="drawer-backdrop" onclick={() => uiStore.rightDrawerOpen = false}></div>
     <aside class="drawer drawer-right" data-tour="right-sidebar">
-      {#if dsmStepsStore.isOpen}
+      {#if uiStore.appMode === 'pro'}
+        <ProPanel />
+      {:else if uiStore.appMode === 'educativo'}
+        <EducativePanel />
+      {:else if dsmStepsStore.isOpen}
         <StepWizard />
       {:else}
         <PropertyPanel {showResults} />
@@ -551,12 +557,18 @@
   <!-- Mobile bottom bar -->
   {#if uiStore.isMobile}
     <nav class="mobile-bottom-bar">
-      <button class="mobile-bar-btn" onclick={() => uiStore.leftDrawerOpen = !uiStore.leftDrawerOpen} title={t('app.tools')}>
-        ☰
-      </button>
-      <button class="mobile-bar-btn" onclick={() => uiStore.rightDrawerOpen = !uiStore.rightDrawerOpen} title={t('app.properties')}>
-        ⚙
-      </button>
+      {#if uiStore.appMode === 'basico'}
+        <button class="mobile-bar-btn" onclick={() => uiStore.leftDrawerOpen = !uiStore.leftDrawerOpen} title={t('app.tools')}>
+          ☰
+        </button>
+        <button class="mobile-bar-btn" onclick={() => uiStore.rightDrawerOpen = !uiStore.rightDrawerOpen} title={t('app.properties')}>
+          ⚙
+        </button>
+      {:else}
+        <button class="mobile-bar-btn" onclick={() => uiStore.rightDrawerOpen = !uiStore.rightDrawerOpen} title={uiStore.appMode === 'pro' ? 'PRO' : t('app.properties')}>
+          {uiStore.appMode === 'pro' ? '⚡' : '📐'}
+        </button>
+      {/if}
     </nav>
   {/if}
 </div>


### PR DESCRIPTION
## Summary

Fixes panel behavior and mobile mode access so Basic, Education, and PRO have coherent, mode-appropriate controls and accessible side panels.

- **Hide floating right-toggle when AI drawer is open**: the `.right-toggle` button was `position: absolute` and overlapped the AI drawer in Basic mode. Now hidden when drawer is open.
- **Make mobile bottom bar mode-aware**: Basic mode shows both Tools (☰) + Properties (⚙) buttons. Education and PRO show only a single mode-appropriate panel button — no misleading Tools button where no left toolbar exists.
- **Make mobile right drawer mode-aware**: renders `ProPanel` in PRO mode, `EducativePanel` in Education mode, `PropertyPanel` + `DataTable` in Basic mode. Previously always rendered Basic-mode content regardless of mode, making Education and PRO panels completely unreachable on mobile.

### Explicitly out of scope

- No solver changes
- No feature redesign — uses existing drawer/panel infrastructure
- No new components — routes existing panels into the mobile drawer container
- Focused on responsive/state correctness only

## Test plan

- [ ] Desktop Basic + AI drawer: open AI drawer → right-toggle disappears; close → reappears
- [ ] Mobile Basic (<768px): bottom bar shows ☰ + ⚙, both drawers work
- [ ] Mobile Education: bottom bar shows single 📐 button, opens EducativePanel in right drawer
- [ ] Mobile PRO: bottom bar shows single ⚡ button, opens ProPanel in right drawer
- [ ] Backdrop click closes drawer in all modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)