### PR TITLE
[11] feat(ui): surface diagnostics panel in Basic mode

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -37,6 +37,7 @@
   import { runLiveCalc, runGlobalSolve } from './lib/engine/live-calc';
   import LandingPage from './components/LandingPage.svelte';
   import AiDrawer from './components/AiDrawer.svelte';
+  import ProDiagnosticsTab from './components/pro/ProDiagnosticsTab.svelte';
 
   if (typeof window !== 'undefined') {
     const redirectedRoute = new URLSearchParams(location.search).get('route');
@@ -177,6 +178,7 @@
   const showResults = $derived(resultsStore.results !== null || resultsStore.results3D !== null);
   let showAutosaveBanner = $state(false);
   let showImportDialog = $state(false);
+  let showDiagnostics = $state(false);
   let importText = $state('');
   let autosaveData = $state<ReturnType<typeof loadFromLocalStorage>>(null);
   let autosaveInterval: ReturnType<typeof setInterval> | null = null;
@@ -507,6 +509,14 @@
                   <DataTable />
                 </div>
               {/if}
+              <button class="datatable-toggle" onclick={() => showDiagnostics = !showDiagnostics}>
+                {showDiagnostics ? '▾' : '▸'} {t('diag.tab')}
+              </button>
+              {#if showDiagnostics}
+                <div class="diagnostics-sidebar">
+                  <ProDiagnosticsTab />
+                </div>
+              {/if}
             {/if}
           </aside>
         {/if}
@@ -548,6 +558,14 @@
         {#if uiStore.showDataTable}
           <div class="data-table-sidebar">
             <DataTable />
+          </div>
+        {/if}
+        <button class="datatable-toggle" onclick={() => showDiagnostics = !showDiagnostics}>
+          {showDiagnostics ? '▾' : '▸'} {t('diag.tab')}
+        </button>
+        {#if showDiagnostics}
+          <div class="diagnostics-sidebar">
+            <ProDiagnosticsTab />
           </div>
         {/if}
       {/if}
@@ -1054,6 +1072,12 @@
   }
 
   .data-table-sidebar {
+    flex: 1;
+    overflow: hidden;
+    min-height: 0;
+  }
+
+  .diagnostics-sidebar {
     flex: 1;
     overflow: hidden;
     min-height: 0;

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -489,9 +489,11 @@
           <EducativePanel />
         </aside>
       {:else}
-        <button class="sidebar-toggle-btn right-toggle" class:sidebar-closed={!uiStore.rightSidebarOpen} onclick={() => uiStore.rightSidebarOpen = !uiStore.rightSidebarOpen} title={uiStore.rightSidebarOpen ? t('app.hideRightPanel') : t('app.showRightPanel')}>
-          {uiStore.rightSidebarOpen ? '▸' : '◂'}
-        </button>
+        {#if !uiStore.aiDrawerOpen}
+          <button class="sidebar-toggle-btn right-toggle" class:sidebar-closed={!uiStore.rightSidebarOpen} onclick={() => uiStore.rightSidebarOpen = !uiStore.rightSidebarOpen} title={uiStore.rightSidebarOpen ? t('app.hideRightPanel') : t('app.showRightPanel')}>
+            {uiStore.rightSidebarOpen ? '▸' : '◂'}
+          </button>
+        {/if}
         {#if uiStore.rightSidebarOpen}
           <aside class="sidebar right" data-tour="right-sidebar" class:wizard-open={dsmStepsStore.isOpen}>
             {#if dsmStepsStore.isOpen}
@@ -532,7 +534,11 @@
   {#if uiStore.isMobile && uiStore.rightDrawerOpen}
     <div class="drawer-backdrop" onclick={() => uiStore.rightDrawerOpen = false}></div>
     <aside class="drawer drawer-right" data-tour="right-sidebar">
-      {#if dsmStepsStore.isOpen}
+      {#if uiStore.appMode === 'pro'}
+        <ProPanel />
+      {:else if uiStore.appMode === 'educativo'}
+        <EducativePanel />
+      {:else if dsmStepsStore.isOpen}
         <StepWizard />
       {:else}
         <PropertyPanel {showResults} />
@@ -551,12 +557,18 @@
   <!-- Mobile bottom bar -->
   {#if uiStore.isMobile}
     <nav class="mobile-bottom-bar">
-      <button class="mobile-bar-btn" onclick={() => uiStore.leftDrawerOpen = !uiStore.leftDrawerOpen} title={t('app.tools')}>
-        ☰
-      </button>
-      <button class="mobile-bar-btn" onclick={() => uiStore.rightDrawerOpen = !uiStore.rightDrawerOpen} title={t('app.properties')}>
-        ⚙
-      </button>
+      {#if uiStore.appMode === 'basico'}
+        <button class="mobile-bar-btn" onclick={() => uiStore.leftDrawerOpen = !uiStore.leftDrawerOpen} title={t('app.tools')}>
+          ☰
+        </button>
+        <button class="mobile-bar-btn" onclick={() => uiStore.rightDrawerOpen = !uiStore.rightDrawerOpen} title={t('app.properties')}>
+          ⚙
+        </button>
+      {:else}
+        <button class="mobile-bar-btn" onclick={() => uiStore.rightDrawerOpen = !uiStore.rightDrawerOpen} title={uiStore.appMode === 'pro' ? 'PRO' : t('app.properties')}>
+          {uiStore.appMode === 'pro' ? '⚡' : '📐'}
+        </button>
+      {/if}
     </nav>
   {/if}
 </div>


### PR DESCRIPTION
## Summary

Surfaces the existing `ProDiagnosticsTab` component in Basic mode so all users get model/solver diagnostics without needing PRO mode.

- **Desktop**: collapsible "Diagnostics" section in the Basic right sidebar (below DataTable)
- **Mobile**: same section in the Basic right drawer

### What this does NOT do

- No solver changes
- No new diagnostics engine logic
- No new i18n keys (reuses existing `diag.tab` key)
- No new components (reuses `ProDiagnosticsTab` as-is)
- PRO mode unchanged — diagnostics already available there
- Education mode intentionally unchanged

## Test plan

- [ ] Open Basic mode on desktop — expand "Diagnostics" in right sidebar
- [ ] Create a model with issues (e.g., unsupported node) — verify pre-solve diagnostics appear
- [ ] Solve — verify solver diagnostics merge with model checks
- [ ] Click a diagnostic row — verify affected element/node is selected and viewport zooms to it
- [ ] Switch to PRO mode — confirm diagnostics tab still works independently
- [ ] Test on mobile — open right drawer in Basic mode, confirm diagnostics section is present

Merge order: after [10] `fix/panel-mobile-modes`.