### PR TITLE
[3] PRO verification unification — station-based shared force extraction + UX fixes

### DIFF
--- a/web/src/components/pro/ProDesignTab.svelte
+++ b/web/src/components/pro/ProDesignTab.svelte
@@ -9,6 +9,7 @@
     type MemberDesignResult, type DesignCheckSummary, type CheckStatus,
   } from '../../lib/engine/design-check-results';
   import { autoVerifyFromResults } from '../../lib/engine/auto-verify';
+  import { computeStationDemands, runUnifiedVerification } from '../../lib/engine/verification-service';
   import {
     extractElementStations, extractGoverningDemands, type ElementDesignDemands, type ElementStationResult,
     verifyProvidedReinforcement, rebarGroupArea, formatRebarGroup,
@@ -35,25 +36,10 @@
   interface BarSelection { elemId: number; region: 'start' | 'span' | 'end'; face: 'top' | 'bottom'; row: number; index: number; diameter: number }
   let selectedBar = $state<BarSelection | null>(null);
 
-  /** Station-based data for ALL elements — demands + raw station results for sweep. */
-  const allStationData = $derived.by((): { demands: Map<number, ElementDesignDemands>; stations: Map<number, ElementStationResult> } => {
-    const demands = new Map<number, ElementDesignDemands>();
-    const stations = new Map<number, ElementStationResult>();
-    if (!resultsStore.hasCombinations3D) return { demands, stations };
-    const perCombo = resultsStore.perCombo3D;
-    if (perCombo.size === 0) return { demands, stations };
-    const comboNames = new Map<number, string>();
-    for (const c of modelStore.model.combinations) comboNames.set(c.id, c.name);
-    const firstCombo = perCombo.values().next().value;
-    if (!firstCombo) return { demands, stations };
-    for (const ef of firstCombo.elementForces) {
-      const esr = extractElementStations(ef.elementId, perCombo, comboNames);
-      if (esr) {
-        stations.set(ef.elementId, esr);
-        demands.set(ef.elementId, extractGoverningDemands(esr));
-      }
-    }
-    return { demands, stations };
+  /** Station-based data for ALL elements — computed via shared verification service. */
+  const allStationData = $derived.by(() => {
+    if (!resultsStore.hasCombinations3D) return { demands: new Map<number, ElementDesignDemands>(), stations: new Map<number, ElementStationResult>() };
+    return computeStationDemands(resultsStore.perCombo3D, modelStore.model.combinations);
   });
   const allStationDemands = $derived(allStationData.demands);
 
@@ -218,23 +204,16 @@
 
     try {
       if (selectedCode === 'cirsoc') {
-        // JS CIRSOC path — uses autoVerifyFromResults for RC
-        // Pass station-based demands when available (sign-aware, interior stations)
+        // Unified CIRSOC path via verification service (station-based when available)
         const governing = resultsStore.governing3D.size > 0 ? resultsStore.governing3D : null;
-        const { concrete } = autoVerifyFromResults(results3D, {
-          elements: modelStore.elements,
-          nodes: modelStore.nodes,
-          sections: modelStore.sections,
-          materials: modelStore.materials,
-          supports: modelStore.supports,
-        }, governing, undefined, allStationDemands.size > 0 ? allStationDemands : undefined);
+        const concrete = runUnifiedVerification(
+          results3D,
+          { elements: modelStore.elements, nodes: modelStore.nodes, sections: modelStore.sections, materials: modelStore.materials, supports: modelStore.supports },
+          governing,
+          allStationDemands.size > 0 ? allStationDemands : undefined,
+        );
         const rcResults = normalizeCirsoc201(concrete, sectionNames);
-
-        // Also try CIRSOC 301 steel if available
-        // (Steel verification uses different input assembly — for now, RC is the primary CIRSOC path)
         normalized = rcResults;
-
-        // Also populate legacy store for viewport compatibility
         verificationStore.setConcrete(concrete);
       } else {
         // WASM path for all other codes

--- a/web/src/components/pro/ProDesignTab.svelte
+++ b/web/src/components/pro/ProDesignTab.svelte
@@ -7,7 +7,7 @@
     buildDesignSummary,
     type MemberDesignResult, type DesignCheckSummary, type CheckStatus,
   } from '../../lib/engine/design-check-results';
-  import { computeStationDemands, runCirsocDesign } from '../../lib/engine/verification-service';
+  import { computeStationDemands, runCirsocDesign, getCodeDetail } from '../../lib/engine/verification-service';
   import {
     extractElementStations, extractGoverningDemands, type ElementDesignDemands, type ElementStationResult,
     verifyProvidedReinforcement, rebarGroupArea, formatRebarGroup,
@@ -309,16 +309,14 @@
   let autoDesignedElems = $state(new Set<number>());
   let userModifiedElems = $state(new Set<number>());
 
-  /** Accept auto-design for ALL RC elements in one batch.
-   *  TRANSITIONAL: iterates concreteMap (CIRSOC-specific). Phase 2: VerificationReport
-   *  provides design proposals directly. */
+  /** Accept auto-design for ALL verified elements in one batch.
+   *  Iterates normalized designResults (not concrete-specific storage). */
   function acceptAutoDesignAll() {
-    const concrete = verificationStore.concrete;
     let count = 0;
-    for (const v of concrete) {
-      const elem = modelStore.elements.get(v.elementId);
+    for (const r of designResults) {
+      const elem = modelStore.elements.get(r.elementId);
       if (!elem?.reinforcement) {
-        acceptAutoDesign(v.elementId);
+        acceptAutoDesign(r.elementId);
         count++;
       }
     }
@@ -1345,9 +1343,7 @@
                           {/if}
                         {/if}
                         <!-- ─── Verification Section (rich — matches report content) ─── -->
-                        <!-- TRANSITIONAL: v is the CIRSOC-specific ElementVerification for memos/drawings/interaction.
-                             Phase 2: these render from VerificationReport.elements directly. -->
-                        {@const v = verificationStore.concreteMap.get(r.elementId)}
+                        {@const codeDetail = getCodeDetail(r.elementId)}
                         {#if provVerif && provVerif.checks.length > 0}
                           {@const inlineUtil = pvUtilization != null ? pvUtilization : r.utilization}
                           {@const utilSource = pvUtilization != null ? 'provided' : 'design-check'}
@@ -1383,70 +1379,51 @@
                             </tbody>
                           </table>
                         {/if}
-                        <!-- Interaction diagram (columns only — no live equivalent) -->
-                        {#if v && v.column}
-                          {@const diagParams = { b: v.b, h: v.h, fc: v.fc, fy: 420, cover: v.cover + v.shear.stirrupDia / 2000 + v.flexure.barDia / 2000, AsProv: v.column.AsProv, barCount: v.column.barCount, barDia: v.column.barDia ?? v.flexure.barDia } satisfies DiagramParams}
+                        <!-- Interaction diagram (columns only) -->
+                        {#if codeDetail?.interactionParams}
+                          {@const ip = codeDetail.interactionParams}
+                          {@const diagParams = { b: ip.b, h: ip.h, fc: ip.fc, fy: ip.fy, cover: ip.cover, AsProv: ip.AsProv, barCount: ip.barCount, barDia: ip.barDia } satisfies DiagramParams}
                           {@const diagram = generateInteractionDiagram(diagParams)}
                           <div class="verif-drawings">
                             <div class="verif-drawings-row">
                               <div class="verif-drawing-cell">
-                                {@html generateInteractionSvg(diagram, { Nu: v.Nu, Mu: v.Mu }, 220, 280)}
+                                {@html generateInteractionSvg(diagram, { Nu: ip.Nu, Mu: ip.Mu }, 220, 280)}
                               </div>
                             </div>
                           </div>
                         {/if}
-                        {#if v}
-                          <!-- Detailed calculation memos (same content as report) -->
+                        {#if codeDetail}
+                          <!-- Calculation memos via code-detail adapter -->
                           <div class="verif-memos-title">CIRSOC 201 — Calculation Details</div>
                           <div class="verif-memos">
-                            <div class="memo-section">
-                              <div class="memo-title">{t('pro.flexure')}</div>
-                              {#each v.flexure.steps as step}<div class="memo-step">{step}</div>{/each}
-                            </div>
-                            <div class="memo-section">
-                              <div class="memo-title">{t('pro.shear')}</div>
-                              {#each v.shear.steps as step}<div class="memo-step">{step}</div>{/each}
-                            </div>
-                            {#if v.column}
+                            {#each codeDetail.memos as memo}
                               <div class="memo-section">
-                                <div class="memo-title">{t('pro.flexoCompression')}</div>
-                                {#each v.column.steps as step}<div class="memo-step">{step}</div>{/each}
+                                <div class="memo-title">{memo.title}</div>
+                                {#each memo.steps as step}<div class="memo-step">{step}</div>{/each}
                               </div>
-                            {/if}
-                            {#if v.torsion}
+                            {/each}
+                            {#if codeDetail.slender}
                               <div class="memo-section">
-                                <div class="memo-title">{t('pro.torsion')} {v.torsion.neglect ? t('pro.torsionNeglect') : ''}</div>
-                                {#each v.torsion.steps as step}<div class="memo-step">{step}</div>{/each}
-                              </div>
-                            {/if}
-                            {#if v.biaxial}
-                              <div class="memo-section">
-                                <div class="memo-title">{t('pro.biaxialBresler')}</div>
-                                {#each v.biaxial.steps as step}<div class="memo-step">{step}</div>{/each}
-                              </div>
-                            {/if}
-                            {#if v.slender}
-                              <div class="memo-section">
-                                <div class="memo-title">{t('pro.slenderness')} {v.slender.isSlender ? t('pro.slenderCol') : t('pro.shortCol')}</div>
+                                <div class="memo-title">Slenderness {codeDetail.slender.isSlender ? '(slender)' : '(short)'}</div>
                                 <div class="slender-factors">
-                                  <span>k = {v.slender.k.toFixed(2)}</span>
-                                  <span>Lu = {v.slender.lu.toFixed(2)} m</span>
-                                  <span>r = {(v.slender.r * 100).toFixed(1)} cm</span>
-                                  <span>k·Lu/r = {v.slender.klu_r.toFixed(1)}</span>
-                                  {#if v.slender.isSlender}
-                                    <span class="slender-highlight">δ_ns = {v.slender.delta_ns.toFixed(3)}</span>
+                                  <span>k = {codeDetail.slender.k.toFixed(2)}</span>
+                                  <span>Lu = {codeDetail.slender.lu.toFixed(2)} m</span>
+                                  <span>r = {(codeDetail.slender.r * 100).toFixed(1)} cm</span>
+                                  <span>k·Lu/r = {codeDetail.slender.klu_r.toFixed(1)}</span>
+                                  {#if codeDetail.slender.isSlender}
+                                    <span class="slender-highlight">δ_ns = {codeDetail.slender.delta_ns.toFixed(3)}</span>
                                   {/if}
                                 </div>
-                                {#each v.slender.steps as step}<div class="memo-step">{step}</div>{/each}
+                                {#each codeDetail.slender.steps as step}<div class="memo-step">{step}</div>{/each}
                               </div>
                             {/if}
-                            {#if v.detailing}
+                            {#if codeDetail.detailing}
                               <div class="memo-section">
-                                <div class="memo-title">{t('pro.detailing')}</div>
-                                {#each v.detailing.bars as bar}
+                                <div class="memo-title">Detailing</div>
+                                {#each codeDetail.detailing.bars as bar}
                                   <div class="memo-step">Ø{bar.diameter}: ld={bar.ld.toFixed(2)}m, ldh={bar.ldh.toFixed(2)}m, splice={bar.lapSplice.toFixed(2)}m</div>
                                 {/each}
-                                <div class="memo-step">Min clear spacing: {(v.detailing.minClearSpacing * 1000).toFixed(0)}mm</div>
+                                <div class="memo-step">Min clear spacing: {(codeDetail.detailing.minClearSpacing * 1000).toFixed(0)}mm</div>
                               </div>
                             {/if}
                           </div>

--- a/web/src/components/pro/ProDesignTab.svelte
+++ b/web/src/components/pro/ProDesignTab.svelte
@@ -3,13 +3,11 @@
   import { t } from '../../lib/i18n';
   import { DESIGN_CODES, type DesignCodeId } from '../../lib/engine/codes/index';
   import {
-    normalizeCirsoc201, normalizeCirsoc301,
     normalizeWasmSteel, normalizeWasmRC,
     buildDesignSummary,
     type MemberDesignResult, type DesignCheckSummary, type CheckStatus,
   } from '../../lib/engine/design-check-results';
-  import { autoVerifyFromResults } from '../../lib/engine/auto-verify';
-  import { computeStationDemands, runUnifiedVerification } from '../../lib/engine/verification-service';
+  import { computeStationDemands, runCirsocDesign } from '../../lib/engine/verification-service';
   import {
     extractElementStations, extractGoverningDemands, type ElementDesignDemands, type ElementStationResult,
     verifyProvidedReinforcement, rebarGroupArea, formatRebarGroup,
@@ -122,7 +120,7 @@
       const fitIssues = pv?.checks.filter(c => c.category.startsWith('Fit:') && c.status === 'fail').length ?? 0;
       const strengthFails = pv?.checks.filter(c => !c.category.startsWith('Fit:') && c.status === 'fail').length ?? 0;
       // Count geometry-driven constructibility issues from layouts
-      const v = verificationStore.concrete.find(c => c.elementId === id);
+      const v = verificationStore.concreteMap.get(id);
       let constrIssues = 0;
       if (v?.b && v?.h && reg) {
         const tsL = resolveLayers(reg.topStartLayers, reg.topStart ?? elem.reinforcement.top);
@@ -204,17 +202,15 @@
 
     try {
       if (selectedCode === 'cirsoc') {
-        // Unified CIRSOC path via verification service (station-based when available)
+        // Single-call CIRSOC design via verification service
         const governing = resultsStore.governing3D.size > 0 ? resultsStore.governing3D : null;
-        const concrete = runUnifiedVerification(
+        const { normalized: rcResults } = runCirsocDesign(
           results3D,
           { elements: modelStore.elements, nodes: modelStore.nodes, sections: modelStore.sections, materials: modelStore.materials, supports: modelStore.supports },
-          governing,
           allStationDemands.size > 0 ? allStationDemands : undefined,
+          sectionNames, governing,
         );
-        const rcResults = normalizeCirsoc201(concrete, sectionNames);
         normalized = rcResults;
-        verificationStore.setConcrete(concrete);
       } else {
         // WASM path for all other codes
         const payload = buildCheckPayload();
@@ -270,9 +266,12 @@
         }
       }
 
-      const codeInfo = DESIGN_CODES.find(c => c.id === selectedCode);
-      const summaryData = buildDesignSummary(normalized, selectedCode, codeInfo?.label ?? selectedCode);
-      verificationStore.setDesignResults(summaryData.results, summaryData);
+      // For non-CIRSOC codes, update the design results store (CIRSOC handled inside runCirsocDesign)
+      if (selectedCode !== 'cirsoc') {
+        const codeInfo = DESIGN_CODES.find(c => c.id === selectedCode);
+        const summaryData = buildDesignSummary(normalized, selectedCode, codeInfo?.label ?? selectedCode);
+        verificationStore.setDesignResults(summaryData.results, summaryData);
+      }
 
       // Activate verification overlay in viewport
       resultsStore.diagramType = 'verification';
@@ -365,7 +364,7 @@
 
   /** Accept auto-designed reinforcement as provided (copies from verification result). */
   function acceptAutoDesign(elemId: number) {
-    const v = verificationStore.concrete.find(c => c.elementId === elemId);
+    const v = verificationStore.concreteMap.get(elemId);
     if (!v) return;
     const reinf: ProvidedReinforcement = {};
     if (v.elementType === 'beam' || v.elementType === 'wall') {
@@ -418,7 +417,7 @@
   function getProvidedVerification(elemId: number): ProvidedRebarResult | null {
     const elem = modelStore.elements.get(elemId);
     if (!elem?.reinforcement) return null;
-    const v = verificationStore.concrete.find(c => c.elementId === elemId);
+    const v = verificationStore.concreteMap.get(elemId);
     if (!v) return null;
     const demands = allStationDemands.get(elemId);
     // Pass section data for capacity-based recalculation (CIRSOC 201 φMn/φVn)
@@ -507,7 +506,7 @@
 
   /** Auto-split bars into rows based on section width. */
   function autoSplitRows(elemId: number, field: LayerField) {
-    const v = verificationStore.concrete.find(c => c.elementId === elemId);
+    const v = verificationStore.concreteMap.get(elemId);
     if (!v?.b) return;
     const layers = getRegionLayers(elemId, field);
     if (layers.length === 0) return;
@@ -534,7 +533,7 @@
 
   /** Quick row-fit check for a single layer (for inline editor warnings). */
   function rowFits(elemId: number, layer: RebarLayer): boolean {
-    const v = verificationStore.concrete.find(c => c.elementId === elemId);
+    const v = verificationStore.concreteMap.get(elemId);
     if (!v?.b) return true; // can't check without section
     const stirDia_m = (v.shear?.stirrupDia ?? 8) / 1000;
     const cover = v.cover ?? 0.025;
@@ -1340,7 +1339,7 @@
                           {/if}
                         {/if}
                         <!-- ─── Verification Section (rich — matches report content) ─── -->
-                        {@const v = verificationStore.concrete.find(c => c.elementId === r.elementId)}
+                        {@const v = verificationStore.concreteMap.get(r.elementId)}
                         {#if provVerif && provVerif.checks.length > 0}
                           {@const inlineUtil = pvUtilization != null ? pvUtilization : r.utilization}
                           {@const utilSource = pvUtilization != null ? 'provided' : 'design-check'}

--- a/web/src/components/pro/ProDesignTab.svelte
+++ b/web/src/components/pro/ProDesignTab.svelte
@@ -37,7 +37,7 @@
   /** Station-based data for ALL elements — computed via shared verification service. */
   const allStationData = $derived.by(() => {
     if (!resultsStore.hasCombinations3D) return { demands: new Map<number, ElementDesignDemands>(), stations: new Map<number, ElementStationResult>() };
-    return computeStationDemands(resultsStore.perCombo3D, modelStore.model.combinations);
+    return computeStationDemands(resultsStore.perCombo3D, modelStore.model.combinations, { elements: modelStore.elements, nodes: modelStore.nodes, sections: modelStore.sections, materials: modelStore.materials, supports: modelStore.supports });
   });
   const allStationDemands = $derived(allStationData.demands);
 

--- a/web/src/components/pro/ProDesignTab.svelte
+++ b/web/src/components/pro/ProDesignTab.svelte
@@ -119,18 +119,19 @@
       const pv = getProvidedVerification(id);
       const fitIssues = pv?.checks.filter(c => c.category.startsWith('Fit:') && c.status === 'fail').length ?? 0;
       const strengthFails = pv?.checks.filter(c => !c.category.startsWith('Fit:') && c.status === 'fail').length ?? 0;
-      // Count geometry-driven constructibility issues from layouts
-      const v = verificationStore.concreteMap.get(id);
+      // Count geometry-driven constructibility issues from layouts (uses model geometry, not verification)
+      const sec = getElemSection(id);
+      const stirDia = elem.reinforcement.stirrups?.diameter ?? elem.reinforcement.regions?.stirrupsSupport?.diameter ?? sec.stirrupDia;
       let constrIssues = 0;
-      if (v?.b && v?.h && reg) {
+      if (sec.b && sec.h && reg) {
         const tsL = resolveLayers(reg.topStartLayers, reg.topStart ?? elem.reinforcement.top);
         const bsL = resolveLayers(reg.bottomSpanLayers, reg.bottomSpan ?? elem.reinforcement.bottom);
-        const layout = computeSectionLayout(tsL, bsL, v.b, v.h, v.cover, v.shear.stirrupDia);
+        const layout = computeSectionLayout(tsL, bsL, sec.b, sec.h, sec.cover, stirDia);
         constrIssues = layout.issues.length;
       }
       // Column constructibility
-      if (v?.b && v?.h && elem.reinforcement.longitudinal) {
-        const colLayout = computeColumnLayout(elem.reinforcement.longitudinal.count, elem.reinforcement.longitudinal.diameter, v.b, v.h, v.cover, v.shear.stirrupDia);
+      if (sec.b && sec.h && elem.reinforcement.longitudinal) {
+        const colLayout = computeColumnLayout(elem.reinforcement.longitudinal.count, elem.reinforcement.longitudinal.diameter, sec.b, sec.h, sec.cover, stirDia);
         constrIssues += colLayout.issues.length;
       }
       mods.push({ elemId: id, type: regions.length > 0 ? 'beam' : 'column', regions, fitIssues, strengthFails, constrIssues });
@@ -308,7 +309,9 @@
   let autoDesignedElems = $state(new Set<number>());
   let userModifiedElems = $state(new Set<number>());
 
-  /** Accept auto-design for ALL RC elements in one batch. */
+  /** Accept auto-design for ALL RC elements in one batch.
+   *  TRANSITIONAL: iterates concreteMap (CIRSOC-specific). Phase 2: VerificationReport
+   *  provides design proposals directly. */
   function acceptAutoDesignAll() {
     const concrete = verificationStore.concrete;
     let count = 0;
@@ -362,7 +365,9 @@
     }
   }
 
-  /** Accept auto-designed reinforcement as provided (copies from verification result). */
+  /** Accept auto-designed reinforcement as provided (copies from verification result).
+   *  TRANSITIONAL: Reads CIRSOC-specific auto-design proposal from concreteMap.
+   *  Phase 2: solver returns design proposals as part of VerificationReport. */
   function acceptAutoDesign(elemId: number) {
     const v = verificationStore.concreteMap.get(elemId);
     if (!v) return;
@@ -413,7 +418,10 @@
     setProvided(elemId, undefined);
   }
 
-  /** Get provided-reinforcement verification result for an element. */
+  /** Get provided-reinforcement verification result for an element.
+   *  TRANSITIONAL: Reads from concreteMap (CIRSOC-specific ElementVerification)
+   *  for auto-design reference values. Phase 2: solver returns these as part of
+   *  the unified VerificationReport, eliminating this dependency. */
   function getProvidedVerification(elemId: number): ProvidedRebarResult | null {
     const elem = modelStore.elements.get(elemId);
     if (!elem?.reinforcement) return null;
@@ -506,18 +514,16 @@
 
   /** Auto-split bars into rows based on section width. */
   function autoSplitRows(elemId: number, field: LayerField) {
-    const v = verificationStore.concreteMap.get(elemId);
-    if (!v?.b) return;
+    const sec = getElemSection(elemId);
+    if (!sec.b) return;
     const layers = getRegionLayers(elemId, field);
     if (layers.length === 0) return;
-    // Collapse to total count & dominant diameter
     const totalCount = layers.reduce((s, l) => s + l.count, 0);
     const dia = layers[0].diameter;
     const barDia_m = dia / 1000;
-    const cover = v.cover ?? 0.025;
-    const stirDia_m = (v.shear?.stirrupDia ?? 8) / 1000;
-    // Available width for bars
-    const avail = v.b - 2 * cover - 2 * stirDia_m;
+    const prov = getProvided(elemId);
+    const stirDia_m = (prov?.stirrups?.diameter ?? prov?.regions?.stirrupsSupport?.diameter ?? sec.stirrupDia) / 1000;
+    const avail = sec.b - 2 * sec.cover - 2 * stirDia_m;
     const minGap = Math.max(barDia_m, 0.025); // CIRSOC 201 §7.6
     const maxPerRow = Math.max(1, Math.floor((avail + minGap) / (barDia_m + minGap)));
     const nRows = Math.ceil(totalCount / maxPerRow);
@@ -533,11 +539,11 @@
 
   /** Quick row-fit check for a single layer (for inline editor warnings). */
   function rowFits(elemId: number, layer: RebarLayer): boolean {
-    const v = verificationStore.concreteMap.get(elemId);
-    if (!v?.b) return true; // can't check without section
-    const stirDia_m = (v.shear?.stirrupDia ?? 8) / 1000;
-    const cover = v.cover ?? 0.025;
-    const availW = v.b - 2 * cover - 2 * stirDia_m;
+    const sec = getElemSection(elemId);
+    if (!sec.b) return true;
+    const prov = getProvided(elemId);
+    const stirDia_m = (prov?.stirrups?.diameter ?? prov?.regions?.stirrupsSupport?.diameter ?? sec.stirrupDia) / 1000;
+    const availW = sec.b - 2 * sec.cover - 2 * stirDia_m;
     const barDia_m = layer.diameter / 1000;
     const minGap = Math.max(barDia_m, 0.025);
     const reqW = layer.count * barDia_m + Math.max(0, layer.count - 1) * minGap;
@@ -1339,6 +1345,8 @@
                           {/if}
                         {/if}
                         <!-- ─── Verification Section (rich — matches report content) ─── -->
+                        <!-- TRANSITIONAL: v is the CIRSOC-specific ElementVerification for memos/drawings/interaction.
+                             Phase 2: these render from VerificationReport.elements directly. -->
                         {@const v = verificationStore.concreteMap.get(r.elementId)}
                         {#if provVerif && provVerif.checks.length > 0}
                           {@const inlineUtil = pvUtilization != null ? pvUtilization : r.utilization}

--- a/web/src/components/pro/ProMaterialsTab.svelte
+++ b/web/src/components/pro/ProMaterialsTab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { modelStore } from '../../lib/store';
+  import { modelStore, uiStore } from '../../lib/store';
   import { t } from '../../lib/i18n';
   import {
     MATERIAL_CATEGORIES, searchPresets,
@@ -48,7 +48,8 @@
   }
 
   function removeMat(id: number) {
-    modelStore.removeMaterial(id);
+    const ok = modelStore.removeMaterial(id);
+    if (!ok) uiStore.toast(t('table.cannotDeleteMaterial'), 'error');
   }
 </script>
 

--- a/web/src/components/pro/ProPanel.svelte
+++ b/web/src/components/pro/ProPanel.svelte
@@ -397,7 +397,7 @@
     const results = resultsStore.results3D;
     if (!results) return [];
     const stationData = resultsStore.hasCombinations3D
-      ? computeStationDemandsService(resultsStore.perCombo3D, modelStore.model.combinations)
+      ? computeStationDemandsService(resultsStore.perCombo3D, modelStore.model.combinations, { elements: modelStore.elements, nodes: modelStore.nodes, sections: modelStore.sections, materials: modelStore.materials, supports: modelStore.supports })
       : undefined;
     return runUnifiedVerification(
       results,

--- a/web/src/components/pro/ProPanel.svelte
+++ b/web/src/components/pro/ProPanel.svelte
@@ -5,8 +5,7 @@
   import { openReport } from '../../lib/engine/pro-report';
   import type { ReportData, ReportConfig } from '../../lib/engine/pro-report';
   import type { ElementVerification } from '../../lib/engine/codes/argentina/cirsoc201';
-  import { autoVerifyFromResults } from '../../lib/engine/auto-verify';
-  import { extractElementStations, extractGoverningDemands, type ElementDesignDemands } from '../../lib/engine/station-design-forces';
+  import { computeStationDemands as computeStationDemandsService, runUnifiedVerification } from '../../lib/engine/verification-service';
   import { computeQuantities } from '../../lib/engine/quantity-takeoff';
   import { checkCrackWidth, checkDeflection } from '../../lib/engine/codes/argentina/serviceability';
   import { classifyElement } from '../../lib/engine/codes/argentina/cirsoc201';
@@ -391,35 +390,19 @@
   const loadCount = $derived(modelStore.loads.length);
 
   /** Compute station-based demands for all elements (when per-combo data available) */
-  function computeStationDemands(): Map<number, ElementDesignDemands> {
-    const result = new Map<number, ElementDesignDemands>();
-    if (!resultsStore.hasCombinations3D) return result;
-    const perCombo = resultsStore.perCombo3D;
-    if (perCombo.size === 0) return result;
-    const comboNames = new Map<number, string>();
-    for (const c of modelStore.model.combinations) comboNames.set(c.id, c.name);
-    const firstCombo = perCombo.values().next().value;
-    if (!firstCombo) return result;
-    for (const ef of firstCombo.elementForces) {
-      const esr = extractElementStations(ef.elementId, perCombo, comboNames);
-      if (esr) result.set(ef.elementId, extractGoverningDemands(esr));
-    }
-    return result;
-  }
-
-  /** Auto-run CIRSOC verification on current results (delegates to extracted utility) */
+  /** Auto-run CIRSOC verification on current results via unified service. */
   function autoVerify(): ElementVerification[] {
     const results = resultsStore.results3D;
     if (!results) return [];
-    const stationDemands = computeStationDemands();
-    const { concrete } = autoVerifyFromResults(
+    const stationData = resultsStore.hasCombinations3D
+      ? computeStationDemandsService(resultsStore.perCombo3D, modelStore.model.combinations)
+      : undefined;
+    return runUnifiedVerification(
       results,
       { elements: modelStore.elements, nodes: modelStore.nodes, sections: modelStore.sections, materials: modelStore.materials, supports: modelStore.supports },
       resultsStore.governing3D.size > 0 ? resultsStore.governing3D : null,
-      undefined,
-      stationDemands.size > 0 ? stationDemands : undefined,
+      stationData?.demands,
     );
-    return concrete;
   }
 
   /** Serialize loads for the report */

--- a/web/src/components/pro/ProPanel.svelte
+++ b/web/src/components/pro/ProPanel.svelte
@@ -77,7 +77,9 @@
 
   // activeTab is shared via uiStore.proActiveTab so App.svelte can render the nav strip
   const activeTab = $derived(uiStore.proActiveTab as ProTab);
-  let verificationsRef = $state<ElementVerification[]>([]);
+  /** Verification results — derived from verificationStore (single source of truth).
+   *  No longer a local $state — reads directly from the store. */
+  const verificationsRef = $derived(verificationStore.concrete);
   let advancedResultsRef = $state<Record<string, any>>({});
   let tabError = $state<string | null>(null);
   let showReportDialog = $state(false);
@@ -429,10 +431,11 @@
     }
     if (!resultsStore.results3D) return;
 
-    // Auto-verify CIRSOC if not already done
-    if (verificationsRef.length === 0) {
-      verificationsRef = autoVerify();
-      verificationStore.setConcrete(verificationsRef);
+    // Auto-verify CIRSOC if not already done — writes to verificationStore, which
+    // updates verificationsRef (derived from store) automatically.
+    if (verificationStore.concrete.length === 0) {
+      const concrete = autoVerify();
+      verificationStore.setConcrete(concrete);
     }
 
     showReportDialog = true;
@@ -769,7 +772,7 @@
         {:else if activeTab === 'results'}
           <ProResultsTab />
         {:else if activeTab === 'design'}
-          <ProRcWorkflowTab bind:verifications={verificationsRef} />
+          <ProRcWorkflowTab />
         {:else if activeTab === 'connections'}
           <ProConnectionsTab />
         {:else if activeTab === 'diagnostics'}

--- a/web/src/components/pro/ProRcWorkflowTab.svelte
+++ b/web/src/components/pro/ProRcWorkflowTab.svelte
@@ -3,14 +3,12 @@
    * RC Design Workflow — single entry point for RC design.
    *
    * Verification now appears inline within each expanded element row in the
-   * Design tab (per QA3 feedback). The separate RC Verification subtab has
-   * been removed to avoid a disconnected dual-system experience.
+   * Design tab. The separate RC Verification subtab has been removed.
+   *
+   * Verification state lives in verificationStore (single source of truth).
+   * This component is a thin layout wrapper — no props needed.
    */
   import ProDesignTab from './ProDesignTab.svelte';
-  import type { ElementVerification } from '../../lib/engine/codes/argentina/cirsoc201';
-
-  let { verifications = $bindable() }: { verifications?: ElementVerification[] } = $props();
-  verifications = verifications ?? [];
 </script>
 
 <div class="rc-workflow">

--- a/web/src/components/pro/ProSectionsTab.svelte
+++ b/web/src/components/pro/ProSectionsTab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { modelStore } from '../../lib/store';
+  import { modelStore, uiStore } from '../../lib/store';
   import { t } from '../../lib/i18n';
   import {
     FAMILY_LIST, PROFILE_FAMILIES, searchProfiles, familyToShape,
@@ -134,7 +134,8 @@
   const sections = $derived([...modelStore.sections.values()]);
 
   function removeSec(id: number) {
-    modelStore.removeSection(id);
+    const ok = modelStore.removeSection(id);
+    if (!ok) uiStore.toast(t('table.cannotDeleteSection'), 'error');
   }
 
   function fmtNum(n: number): string {

--- a/web/src/components/pro/ProVerificationTab.svelte
+++ b/web/src/components/pro/ProVerificationTab.svelte
@@ -11,14 +11,13 @@
   import type { CrackResult, DeflectionResult } from '../../lib/engine/codes/argentina/serviceability';
   import { computeQuantities } from '../../lib/engine/quantity-takeoff';
   import type { QuantitySummary } from '../../lib/engine/quantity-takeoff';
-  import { verifySteelElement } from '../../lib/engine/codes/argentina/cirsoc301';
-  import type { SteelVerification, SteelVerificationInput, SteelDesignParams } from '../../lib/engine/codes/argentina/cirsoc301';
+  import type { SteelVerification } from '../../lib/engine/codes/argentina/cirsoc301';
   import { generateInteractionDiagram, generateInteractionSvg } from '../../lib/engine/codes/argentina/interaction-diagram';
   import type { DiagramParams } from '../../lib/engine/codes/argentina/interaction-diagram';
   import { isDesignCheckAvailable, checkSteelMembers, checkRcMembers, checkEc2Members, checkEc3Members, checkTimberMembers, checkMasonryMembers, checkCfsMembers, checkBoltGroups, checkWeldGroups, checkSpreadFootings } from '../../lib/engine/wasm-solver';
   import { t } from '../../lib/i18n';
   import * as XLSX from 'xlsx';
-  import { computeStationDemands, runUnifiedVerification } from '../../lib/engine/verification-service';
+  import { computeStationDemands, runUnifiedVerification, runSteelVerification } from '../../lib/engine/verification-service';
 
   /** Normative code options for design checks */
   type NormativeCode = 'cirsoc' | 'aci-aisc' | 'eurocode' | 'nds' | 'masonry' | 'cfs';
@@ -186,30 +185,8 @@
     return n;
   });
 
-  interface EnvelopeSolicitations {
-    Mu: number; Vu: number; Nu: number;
-    Muy: number; Vz: number; Tu: number;
-  }
-
-  /** Get max absolute solicitations for an element across all combination results.
-   *  LEGACY: Only used by the CIRSOC 301 steel verification path.
-   *  RC verification now uses station-based demands via runUnifiedVerification(). */
-  function getEnvelopeSolicitations(elemId: number): EnvelopeSolicitations | null {
-    const envelope = resultsStore.fullEnvelope3D;
-    if (!envelope) return null;
-
-    const envForces = envelope.maxAbsResults3D.elementForces.find(ef => ef.elementId === elemId);
-    if (!envForces) return null;
-
-    return {
-      Mu: Math.max(Math.abs(envForces.mzStart), Math.abs(envForces.mzEnd)),
-      Vu: Math.max(Math.abs(envForces.vyStart), Math.abs(envForces.vyEnd)),
-      Nu: Math.max(Math.abs(envForces.nStart), Math.abs(envForces.nEnd)),
-      Muy: Math.max(Math.abs(envForces.myStart), Math.abs(envForces.myEnd)),
-      Vz: Math.max(Math.abs(envForces.vzStart), Math.abs(envForces.vzEnd)),
-      Tu: Math.max(Math.abs(envForces.mxStart), Math.abs(envForces.mxEnd)),
-    };
-  }
+  // getEnvelopeSolicitations removed — both RC and steel paths now use
+  // station-based demands via verification-service.ts
 
   /** Build generic check payload from model data for WASM-based design checks */
   function buildWasmCheckPayload() {
@@ -335,74 +312,12 @@
       lengths.set(ef.elementId, Math.sqrt(dx * dx + dy * dy + dz * dz));
     }
 
-    // LEGACY: Steel verification (CIRSOC 301) — still uses endpoint-only extraction.
-    // Phase 2 target: unify steel path through the same station-based service.
-    const steelVerifs: SteelVerification[] = [];
-    for (const ef of results.elementForces) {
-      const elem = modelStore.elements.get(ef.elementId);
-      if (!elem) continue;
-
-      const section = modelStore.sections.get(elem.sectionId);
-      const material = modelStore.materials.get(elem.materialId);
-      if (!section || !material) continue;
-
-      // Steel: fy > 80 MPa
-      if (!material.fy || material.fy <= 80) continue;
-
-      const nodeI = modelStore.nodes.get(elem.nodeI);
-      const nodeJ = modelStore.nodes.get(elem.nodeJ);
-      if (!nodeI || !nodeJ) continue;
-
-      const dx = nodeJ.x - nodeI.x;
-      const dy = nodeJ.y - nodeI.y;
-      const dz = (nodeJ.z ?? 0) - (nodeI.z ?? 0);
-      const elementLength = Math.sqrt(dx * dx + dy * dy + dz * dz);
-      if (elementLength <= 0) continue;
-
-      // Extract solicitations
-      let NuMax: number, MuzMax: number, MuyMax: number, VuMax: number;
-      const envSol = useEnvelope ? getEnvelopeSolicitations(ef.elementId) : null;
-      if (envSol) {
-        NuMax = envSol.Nu;
-        MuzMax = envSol.Mu;
-        MuyMax = envSol.Muy;
-        VuMax = Math.max(envSol.Vu, envSol.Vz);
-      } else {
-        NuMax = Math.max(Math.abs(ef.nStart), Math.abs(ef.nEnd));
-        const _mzM = Math.max(Math.abs(ef.mzStart), Math.abs(ef.mzEnd));
-        const _myM = Math.max(Math.abs(ef.myStart), Math.abs(ef.myEnd));
-        MuzMax = _mzM;
-        MuyMax = _myM;
-        VuMax = Math.max(Math.abs(ef.vyStart), Math.abs(ef.vyEnd), Math.abs(ef.vzStart), Math.abs(ef.vzEnd));
-      }
-
-      const sdp: SteelDesignParams = {
-        Fy: material.fy,
-        Fu: (material as any).fu ?? (material.fy ?? material.e * 0.001) * 1.25,
-        E: material.e,
-        A: section.a,
-        Iz: section.iz,
-        Iy: section.iy ?? section.iz,
-        h: section.h ?? 0.3,
-        b: section.b ?? 0.15,
-        tw: section.tw ?? (section.b ? section.b / 10 : 0.01),
-        tf: section.tf ?? (section.b ? section.b / 15 : 0.01),
-        L: elementLength,
-        Lb: elementLength,
-        J: section.j ?? 0,
-      };
-
-      const steelInput: SteelVerificationInput = {
-        elementId: ef.elementId,
-        Nu: NuMax,
-        Muy: MuyMax,
-        Muz: MuzMax,
-        Vu: VuMax,
-        params: sdp,
-      };
-
-      steelVerifs.push(verifySteelElement(steelInput));
-    }
+    // Steel verification via shared service (uses station demands when available)
+    const steelVerifs = runSteelVerification(
+      results,
+      { elements: modelStore.elements, nodes: modelStore.nodes, sections: modelStore.sections, materials: modelStore.materials, supports: modelStore.supports },
+      stationData?.demands,
+    );
     steelVerifications = steelVerifs;
 
     // Check if there are any verifiable elements (including quads/plates for slabs)

--- a/web/src/components/pro/ProVerificationTab.svelte
+++ b/web/src/components/pro/ProVerificationTab.svelte
@@ -335,7 +335,8 @@
       lengths.set(ef.elementId, Math.sqrt(dx * dx + dy * dy + dz * dz));
     }
 
-    // Steel verification (CIRSOC 301) — elements with fy > 80 MPa
+    // LEGACY: Steel verification (CIRSOC 301) — still uses endpoint-only extraction.
+    // Phase 2 target: unify steel path through the same station-based service.
     const steelVerifs: SteelVerification[] = [];
     for (const ef of results.elementForces) {
       const elem = modelStore.elements.get(ef.elementId);
@@ -416,8 +417,9 @@
     const newDefl = new Map<number, DeflectionResult>();
     for (const v of verifs) {
       if (v.elementType === 'beam') {
-        // Service moment: use dead-load-only case if available, otherwise ≈ Mu / 1.4
-        // (Bug #5 fix — §13.2 of SOLVER_APP_COVERAGE_MAP.md)
+        // TEMPORARY Phase 1 bridge — service moment approximation (Bug #5 from §13.2)
+        // Uses dead-load case when available; falls back to Mu/1.4 unfactoring.
+        // Phase 2 target: solver provides actual service-combo results directly.
         let Ms = v.Mu / 1.4;
         if (resultsStore.perCase3D.size > 0) {
           const deadCase = modelStore.model.loadCases.find(c => c.type === 'D');
@@ -439,8 +441,9 @@
         );
         newCracks.set(v.elementId, crack);
 
-        // Deflection check: estimate midspan deflection from beam properties
-        // (Bug #3 fix — endpoint displacements are ~0 for simply-supported beams)
+        // TEMPORARY Phase 1 bridge — midspan deflection estimate (Bug #3 from §13.2)
+        // Solver only returns endpoint displacements; midspan is estimated from beam equation.
+        // Phase 2 target: solver provides midspan displacement directly (or check_serviceability WASM).
         const elem = modelStore.elements.get(v.elementId);
         if (elem) {
           const nodeI = modelStore.nodes.get(elem.nodeI);
@@ -457,8 +460,8 @@
               Math.abs(di?.uy ?? 0), Math.abs(dj?.uy ?? 0),
               Math.abs(di?.uz ?? 0), Math.abs(dj?.uz ?? 0),
             );
-            // If endpoint displacements are negligible, estimate midspan deflection
-            // using 5·Ms·L²/(48·E·Ig) (uniform load equivalent for service moment)
+            // TEMPORARY Phase 1 estimate: 5·Ms·L²/(48·E·Ig) (uniform load equivalent)
+            // Only used when endpoint displacements are negligible (simply-supported beams).
             if (maxDisp < L / 10000) {
               const sec = modelStore.sections.get(elem.sectionId);
               const mat = modelStore.materials.get(elem.materialId);

--- a/web/src/components/pro/ProVerificationTab.svelte
+++ b/web/src/components/pro/ProVerificationTab.svelte
@@ -1,4 +1,23 @@
 <script lang="ts">
+  /**
+   * DORMANT COMPONENT — not currently rendered in the active UI.
+   *
+   * ProRcWorkflowTab was simplified to render ProDesignTab only (per QA3).
+   * This component is retained as a reference for features that should be
+   * re-integrated into the Design workflow or service layer:
+   *   - Serviceability (cracking, deflection) — currently has Phase 1 bridges
+   *   - Quantities / bar marks — post-design detailing
+   *   - Slab reinforcement design
+   *   - Steel verification rendering (CIRSOC 301)
+   *   - Story drift
+   *   - Frame-line / column-stack elevations
+   *
+   * When reactivating these features:
+   *   - Read verification data from verificationStore (single source of truth)
+   *   - Do not re-introduce a local verifications array as a parallel state
+   *   - Use getCodeDetail() for code-specific rendering data
+   *   - Route verification through verification-service.ts
+   */
   import { modelStore, resultsStore, uiStore, verificationStore } from '../../lib/store';
   import type { SolverDiagnostic } from '../../lib/engine/types';
   import { verifyElement, classifyElement, REBAR_DB, computeJointPsiFromModel } from '../../lib/engine/codes/argentina/cirsoc201';

--- a/web/src/components/pro/ProVerificationTab.svelte
+++ b/web/src/components/pro/ProVerificationTab.svelte
@@ -310,7 +310,7 @@
     // This replaces the old endpoint-only force extraction loop — see §13.1 of SOLVER_APP_COVERAGE_MAP.md
     const governing = resultsStore.governing3D.size > 0 ? resultsStore.governing3D : null;
     const stationData = resultsStore.hasCombinations3D
-      ? computeStationDemands(resultsStore.perCombo3D, modelStore.model.combinations)
+      ? computeStationDemands(resultsStore.perCombo3D, modelStore.model.combinations, { elements: modelStore.elements, nodes: modelStore.nodes, sections: modelStore.sections, materials: modelStore.materials, supports: modelStore.supports })
       : undefined;
     const verifs = runUnifiedVerification(
       results,

--- a/web/src/components/pro/ProVerificationTab.svelte
+++ b/web/src/components/pro/ProVerificationTab.svelte
@@ -18,6 +18,7 @@
   import { isDesignCheckAvailable, checkSteelMembers, checkRcMembers, checkEc2Members, checkEc3Members, checkTimberMembers, checkMasonryMembers, checkCfsMembers, checkBoltGroups, checkWeldGroups, checkSpreadFootings } from '../../lib/engine/wasm-solver';
   import { t } from '../../lib/i18n';
   import * as XLSX from 'xlsx';
+  import { computeStationDemands, runUnifiedVerification } from '../../lib/engine/verification-service';
 
   /** Normative code options for design checks */
   type NormativeCode = 'cirsoc' | 'aci-aisc' | 'eurocode' | 'nds' | 'masonry' | 'cfs';
@@ -190,7 +191,9 @@
     Muy: number; Vz: number; Tu: number;
   }
 
-  /** Get max absolute solicitations for an element across all combination results */
+  /** Get max absolute solicitations for an element across all combination results.
+   *  LEGACY: Only used by the CIRSOC 301 steel verification path.
+   *  RC verification now uses station-based demands via runUnifiedVerification(). */
   function getEnvelopeSolicitations(elemId: number): EnvelopeSolicitations | null {
     const envelope = resultsStore.fullEnvelope3D;
     if (!envelope) return null;
@@ -307,122 +310,29 @@
       return;
     }
 
-    const verifs: ElementVerification[] = [];
-    const useEnvelope = hasEnvelope;
-    const lengths = new Map<number, number>();
+    // Unified RC verification via shared service (station-based when available)
+    // This replaces the old endpoint-only force extraction loop — see §13.1 of SOLVER_APP_COVERAGE_MAP.md
+    const governing = resultsStore.governing3D.size > 0 ? resultsStore.governing3D : null;
+    const stationData = resultsStore.hasCombinations3D
+      ? computeStationDemands(resultsStore.perCombo3D, modelStore.model.combinations)
+      : undefined;
+    const verifs = runUnifiedVerification(
+      results,
+      { elements: modelStore.elements, nodes: modelStore.nodes, sections: modelStore.sections, materials: modelStore.materials, supports: modelStore.supports },
+      governing,
+      stationData?.demands,
+    );
 
+    // Compute element lengths (still needed for elevations/detailing)
+    const lengths = new Map<number, number>();
     for (const ef of results.elementForces) {
       const elem = modelStore.elements.get(ef.elementId);
       if (!elem) continue;
-
-      // Compute element length
       const nodeI = modelStore.nodes.get(elem.nodeI);
       const nodeJ = modelStore.nodes.get(elem.nodeJ);
       if (!nodeI || !nodeJ) continue;
-      const dx = nodeJ.x - nodeI.x;
-      const dy = nodeJ.y - nodeI.y;
-      const dz = (nodeJ.z ?? 0) - (nodeI.z ?? 0);
-      const L = Math.sqrt(dx * dx + dy * dy + dz * dz);
-      lengths.set(ef.elementId, L);
-
-      const section = modelStore.sections.get(elem.sectionId);
-      const material = modelStore.materials.get(elem.materialId);
-      if (!section || !material) continue;
-
-      // Only verify concrete sections (need b and h)
-      if (!section.b || !section.h) continue;
-      // Need f'c from material
-      const fc = material.fy;
-      if (!fc || fc > 80) continue; // skip if no f'c or if it's steel (fy > 80 MPa means it's steel)
-
-      // Classify as beam, column, or wall (reuse nodeI/nodeJ from above)
-      const elemType = classifyElement(
-        nodeI.x, nodeI.y, nodeI.z ?? 0,
-        nodeJ.x, nodeJ.y, nodeJ.z ?? 0,
-        section.b, section.h,
-      );
-
-      // Extract max solicitations — from envelope if available, otherwise from single result
-      let MuMax: number, VuMax: number, NuMax: number;
-      let MuyMax = 0, VzMax = 0, TuMax = 0;
-      const envSol = useEnvelope ? getEnvelopeSolicitations(ef.elementId) : null;
-      if (envSol) {
-        MuMax = envSol.Mu;
-        VuMax = envSol.Vu;
-        NuMax = envSol.Nu;
-        MuyMax = envSol.Muy;
-        VzMax = envSol.Vz;
-        TuMax = envSol.Tu;
-      } else {
-        const _mzMax = Math.max(Math.abs(ef.mzStart), Math.abs(ef.mzEnd));
-        const _myMax = Math.max(Math.abs(ef.myStart), Math.abs(ef.myEnd));
-        MuMax = _mzMax;
-        VuMax = Math.max(Math.abs(ef.vyStart), Math.abs(ef.vyEnd));
-        NuMax = Math.max(Math.abs(ef.nStart), Math.abs(ef.nEnd));
-        MuyMax = _myMax;
-        VzMax = Math.max(Math.abs(ef.vzStart), Math.abs(ef.vzEnd));
-        TuMax = Math.max(Math.abs(ef.mxStart), Math.abs(ef.mxEnd));
-      }
-
-      // Unsupported length for columns/walls = element length
-      const isVertical = elemType === 'column' || elemType === 'wall';
-      const Lu = isVertical ? L : undefined;
-
-      // For slender columns: extract M1 (smaller) and M2 (larger) end moments with sign
-      let M1: number | undefined;
-      let M2: number | undefined;
-      if (isVertical) {
-        const mzI = ef.mzStart;
-        const mzJ = ef.mzEnd;
-        if (Math.abs(mzI) >= Math.abs(mzJ)) {
-          M2 = Math.abs(mzI);
-          // M1 positive if same curvature (same sign), negative if reverse
-          M1 = Math.sign(mzI) === Math.sign(mzJ) ? Math.abs(mzJ) : -Math.abs(mzJ);
-        } else {
-          M2 = Math.abs(mzJ);
-          M1 = Math.sign(mzI) === Math.sign(mzJ) ? Math.abs(mzI) : -Math.abs(mzI);
-        }
-      }
-
-      // Auto-compute Ψ from model topology for columns
-      let psiA: number | undefined;
-      let psiB: number | undefined;
-      if (isVertical) {
-        const psi = computeJointPsiFromModel(
-          ef.elementId,
-          modelStore.nodes as Map<number, { id: number; x: number; y: number; z?: number }>,
-          modelStore.elements as Map<number, { id: number; nodeI: number; nodeJ: number; materialId: number; sectionId: number; releaseI?: { my: boolean; mz: boolean; t: boolean }; releaseJ?: { my: boolean; mz: boolean; t: boolean } }>,
-          modelStore.sections as Map<number, { id: number; iz: number; iy?: number; b?: number; h?: number }>,
-          modelStore.materials as Map<number, { id: number; e: number }>,
-          modelStore.supports as Map<number, { nodeId: number; type?: string }>,
-        );
-        psiA = psi.psiA;
-        psiB = psi.psiB;
-      }
-
-      const input: VerificationInput = {
-        elementId: ef.elementId,
-        elementType: elemType,
-        Mu: MuMax,
-        Vu: VuMax,
-        Nu: NuMax,
-        b: section.b,
-        h: section.h,
-        fc,
-        fy: rebarFy,
-        cover,
-        stirrupDia,
-        Muy: isVertical ? MuyMax : undefined,
-        Vz: VzMax > 0.01 ? VzMax : undefined,
-        Tu: TuMax > 0.001 ? TuMax : undefined,
-        Lu,
-        M1,
-        M2,
-        psiA,
-        psiB,
-      };
-
-      verifs.push(verifyElement(input));
+      const dx = nodeJ.x - nodeI.x, dy = nodeJ.y - nodeI.y, dz = (nodeJ.z ?? 0) - (nodeI.z ?? 0);
+      lengths.set(ef.elementId, Math.sqrt(dx * dx + dy * dy + dz * dz));
     }
 
     // Steel verification (CIRSOC 301) — elements with fy > 80 MPa
@@ -506,8 +416,21 @@
     const newDefl = new Map<number, DeflectionResult>();
     for (const v of verifs) {
       if (v.elementType === 'beam') {
-        // Service moment ≈ Mu / 1.4 (approximate unfactoring)
-        const Ms = v.Mu / 1.4;
+        // Service moment: use dead-load-only case if available, otherwise ≈ Mu / 1.4
+        // (Bug #5 fix — §13.2 of SOLVER_APP_COVERAGE_MAP.md)
+        let Ms = v.Mu / 1.4;
+        if (resultsStore.perCase3D.size > 0) {
+          const deadCase = modelStore.model.loadCases.find(c => c.type === 'D');
+          if (deadCase) {
+            const deadResult = resultsStore.perCase3D.get(deadCase.id);
+            if (deadResult) {
+              const deadForces = deadResult.elementForces.find(ef => ef.elementId === v.elementId);
+              if (deadForces) {
+                Ms = Math.max(Math.abs(deadForces.mzStart), Math.abs(deadForces.mzEnd));
+              }
+            }
+          }
+        }
         const crack = checkCrackWidth(
           v.b, v.h, v.flexure.d,
           v.flexure.AsProv, Ms,
@@ -516,7 +439,8 @@
         );
         newCracks.set(v.elementId, crack);
 
-        // Deflection check: get max displacement from results
+        // Deflection check: estimate midspan deflection from beam properties
+        // (Bug #3 fix — endpoint displacements are ~0 for simply-supported beams)
         const elem = modelStore.elements.get(v.elementId);
         if (elem) {
           const nodeI = modelStore.nodes.get(elem.nodeI);
@@ -526,13 +450,24 @@
             const dy = nodeJ.y - nodeI.y;
             const dz = (nodeJ.z ?? 0) - (nodeI.z ?? 0);
             const L = Math.sqrt(dx * dx + dy * dy + dz * dz);
-            // Get max vertical displacement from either end node
+            // First try endpoint displacements (valid for cantilevers/overhangs)
             const di = results!.displacements.find(d => d.nodeId === elem.nodeI);
             const dj = results!.displacements.find(d => d.nodeId === elem.nodeJ);
-            const maxDisp = Math.max(
+            let maxDisp = Math.max(
               Math.abs(di?.uy ?? 0), Math.abs(dj?.uy ?? 0),
               Math.abs(di?.uz ?? 0), Math.abs(dj?.uz ?? 0),
             );
+            // If endpoint displacements are negligible, estimate midspan deflection
+            // using 5·Ms·L²/(48·E·Ig) (uniform load equivalent for service moment)
+            if (maxDisp < L / 10000) {
+              const sec = modelStore.sections.get(elem.sectionId);
+              const mat = modelStore.materials.get(elem.materialId);
+              if (sec?.iz && mat?.e) {
+                const E = mat.e * 1000; // MPa → kPa
+                const Ig = sec.iz; // m⁴
+                maxDisp = (5 * Ms * L * L) / (48 * E * Ig);
+              }
+            }
             if (L > 0 && maxDisp > 0) {
               newDefl.set(v.elementId, checkDeflection(L, maxDisp));
             }

--- a/web/src/components/pro/ProVerificationTab.svelte
+++ b/web/src/components/pro/ProVerificationTab.svelte
@@ -252,6 +252,28 @@
     }
   }
 
+  /**
+   * Endpoint demand envelope for a member, preserving My/Mz axis identity (SEAM 3).
+   *
+   * Strong axis = Mz → RC Mu and steel Muz; weak axis = My → Muy. Never
+   * magnitude-sort My/Mz: doing so silently swaps the design axes on
+   * biaxially-bent members. Station-based demands flow through
+   * verification-service; this endpoint summary keeps the identical rule
+   * wherever the component reads raw end forces (e.g. the dead-load service
+   * moment used for crack-width below).
+   */
+  function endpointDemandEnvelope(ef: { mzStart: number; mzEnd: number; myStart: number; myEnd: number }) {
+    const _mzMax = Math.max(Math.abs(ef.mzStart), Math.abs(ef.mzEnd));
+    const _myMax = Math.max(Math.abs(ef.myStart), Math.abs(ef.myEnd));
+    const _mzM = _mzMax; // steel shares the strong-axis (Mz) envelope
+    // RC: Mu = strong axis (Mz), Muy = weak axis (My)
+    const MuMax = _mzMax;
+    const MuyMax = _myMax;
+    // Steel: Muz = strong axis (Mz)
+    const MuzMax = _mzM;
+    return { Mu: MuMax, Muy: MuyMax, Muz: MuzMax };
+  }
+
   function runVerification() {
     verifyError = null;
     if (!results) {
@@ -362,7 +384,7 @@
             if (deadResult) {
               const deadForces = deadResult.elementForces.find(ef => ef.elementId === v.elementId);
               if (deadForces) {
-                Ms = Math.max(Math.abs(deadForces.mzStart), Math.abs(deadForces.mzEnd));
+                Ms = endpointDemandEnvelope(deadForces).Mu;
               }
             }
           }

--- a/web/src/lib/engine/verification-service.ts
+++ b/web/src/lib/engine/verification-service.ts
@@ -19,7 +19,7 @@
  *   - autoVerifyFromResults is the JS orchestrator (Phase 3 replaces with WASM call)
  */
 
-import type { AnalysisResults3D } from './types-3d';
+import type { AnalysisResults3D, BeamStationInput3D, GroupedBeamStationResult3D, MemberStationGroup3D, StationComboForces3D } from './types-3d';
 import type { LoadCombination } from '../store/model.svelte';
 import {
   extractElementStations,
@@ -27,6 +27,7 @@ import {
   type ElementDesignDemands,
   type ElementStationResult,
 } from './station-design-forces';
+import { extractBeamStationsGrouped3D } from './wasm-solver';
 import { autoVerifyFromResults, type AutoVerifyModelData } from './auto-verify';
 import { classifyElement, type ElementVerification } from './codes/argentina/cirsoc201';
 import { verifySteelElement, type SteelVerification, type SteelVerificationInput, type SteelDesignParams } from './codes/argentina/cirsoc301';
@@ -43,30 +44,41 @@ export interface StationDemandData {
 /**
  * Compute station-based demands for all elements from per-combination 3D results.
  *
- * This is the canonical force-extraction path that both Design and Verification
- * should use. It evaluates interior stations (midspan, quarter points, load
- * positions, zero-shear points) across all combinations, preserving moment sign
- * and full concurrent force tuples.
+ * Primary path: WASM `extractBeamStationsGrouped3D` (solver-side station interpolation).
+ * Fallback: JS `extractElementStations` (app-side reimplementation, used when WASM unavailable).
  *
- * @param perCombo3D Per-combination results from resultsStore
- * @param combinations Model combinations (for name lookup)
- * @returns Station data for all elements, or empty maps if no combinations
+ * The WASM path evaluates beam diagrams at interior stations natively in Rust,
+ * eliminating ~300 LOC of JS station interpolation logic.
+ *
+ * Thin adapter: converts WASM GroupedBeamStationResult3D → app-side StationDemandData
+ * because `design_demands` is not exported as WASM (the demand extraction step
+ * still runs in JS via `extractGoverningDemands`).
  */
 export function computeStationDemands(
   perCombo3D: Map<number, AnalysisResults3D>,
   combinations: LoadCombination[],
+  model?: AutoVerifyModelData,
 ): StationDemandData {
   const demands = new Map<number, ElementDesignDemands>();
   const stations = new Map<number, ElementStationResult>();
 
   if (perCombo3D.size === 0) return { demands, stations };
 
+  // Try WASM station extraction first (solver-backed)
+  if (model) {
+    try {
+      const wasmResult = computeStationDemandsWasm(perCombo3D, combinations, model);
+      if (wasmResult) return wasmResult;
+    } catch {
+      // WASM unavailable — fall through to JS path
+    }
+  }
+
+  // JS fallback (TRANSITIONAL — used when WASM is not available or model not provided)
   const comboNames = new Map<number, string>();
   for (const c of combinations) comboNames.set(c.id, c.name);
-
   const firstCombo = perCombo3D.values().next().value;
   if (!firstCombo) return { demands, stations };
-
   for (const ef of firstCombo.elementForces) {
     const esr = extractElementStations(ef.elementId, perCombo3D, comboNames);
     if (esr) {
@@ -74,8 +86,90 @@ export function computeStationDemands(
       demands.set(ef.elementId, extractGoverningDemands(esr));
     }
   }
-
   return { demands, stations };
+}
+
+/**
+ * WASM-backed station extraction via `extractBeamStationsGrouped3D`.
+ * Builds the BeamStationInput3D payload from app data and adapts the result.
+ */
+function computeStationDemandsWasm(
+  perCombo3D: Map<number, AnalysisResults3D>,
+  combinations: LoadCombination[],
+  model: AutoVerifyModelData,
+): StationDemandData | null {
+  // Build member list from model
+  const members: Array<{ elementId: number; sectionId: number; materialId: number; length: number }> = [];
+  for (const [id, elem] of model.elements) {
+    const nI = model.nodes.get(elem.nodeI);
+    const nJ = model.nodes.get(elem.nodeJ);
+    if (!nI || !nJ) continue;
+    const dx = nJ.x - nI.x, dy = nJ.y - nI.y, dz = (nJ.z ?? 0) - (nI.z ?? 0);
+    const L = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (L <= 0) continue;
+    members.push({ elementId: id, sectionId: elem.sectionId, materialId: elem.materialId, length: L });
+  }
+
+  // Build labeled combinations from per-combo results
+  const comboNameMap = new Map<number, string>();
+  for (const c of combinations) comboNameMap.set(c.id, c.name);
+  const labeledCombos: Array<{ comboId: number; comboName?: string; results: AnalysisResults3D }> = [];
+  for (const [comboId, results] of perCombo3D) {
+    labeledCombos.push({ comboId, comboName: comboNameMap.get(comboId), results });
+  }
+
+  const input: BeamStationInput3D = { members, combinations: labeledCombos, numStations: 11 };
+  const grouped: GroupedBeamStationResult3D = extractBeamStationsGrouped3D(input);
+
+  // Adapt WASM output → app-side StationDemandData
+  // The WASM gives us per-member per-station per-combo forces.
+  // We convert to ElementStationResult shape (for compatibility with existing consumers)
+  // and extract governing demands via the existing JS adapter (thin — no interpolation).
+  const demands = new Map<number, ElementDesignDemands>();
+  const stationMap = new Map<number, ElementStationResult>();
+
+  for (const member of grouped.members) {
+    const esr = wasmMemberToStationResult(member, comboNameMap);
+    stationMap.set(member.memberId, esr);
+    demands.set(member.memberId, extractGoverningDemands(esr));
+  }
+
+  return { demands, stations: stationMap };
+}
+
+/** Adapt one WASM MemberStationGroup3D → app-side ElementStationResult. */
+function wasmMemberToStationResult(
+  member: MemberStationGroup3D,
+  comboNames: Map<number, string>,
+): ElementStationResult {
+  // Group stations by combo to build the comboResults shape
+  const comboMap = new Map<number, Array<{ x: number; t: number; n: number; vy: number; vz: number; my: number; mz: number }>>();
+
+  for (const station of member.stations) {
+    for (const cf of station.comboForces) {
+      let arr = comboMap.get(cf.comboId);
+      if (!arr) { arr = []; comboMap.set(cf.comboId, arr); }
+      arr.push({
+        x: station.stationX, t: station.t,
+        n: cf.n, vy: cf.vy, vz: cf.vz, my: cf.my, mz: cf.mz,
+      });
+    }
+  }
+
+  const comboResults: ElementStationResult['comboResults'] = [];
+  for (const [comboId, stationForces] of comboMap) {
+    comboResults.push({
+      comboId,
+      comboName: comboNames.get(comboId) ?? `Combo ${comboId}`,
+      stations: stationForces,
+    });
+  }
+
+  return {
+    elementId: member.memberId,
+    length: member.length,
+    comboResults,
+  };
 }
 
 // ─── Unified Verification ────────────────────────────────────

--- a/web/src/lib/engine/verification-service.ts
+++ b/web/src/lib/engine/verification-service.ts
@@ -19,15 +19,16 @@
  *   - autoVerifyFromResults is the JS orchestrator (Phase 3 replaces with WASM call)
  */
 
-import type { AnalysisResults3D, BeamStationInput3D, GroupedBeamStationResult3D, MemberStationGroup3D, StationComboForces3D } from './types-3d';
+import type { AnalysisResults3D, BeamStationInput3D, GroupedBeamStationResult3D, MemberStationGroup3D } from './types-3d';
 import type { LoadCombination } from '../store/model.svelte';
 import {
   extractElementStations,
   extractGoverningDemands,
   type ElementDesignDemands,
   type ElementStationResult,
+  type StationForces,
 } from './station-design-forces';
-import { extractBeamStationsGrouped3D } from './wasm-solver';
+import { extractBeamStationsGrouped3D, isSolverReady } from './wasm-solver';
 import { autoVerifyFromResults, type AutoVerifyModelData } from './auto-verify';
 import { classifyElement, type ElementVerification } from './codes/argentina/cirsoc201';
 import { verifySteelElement, type SteelVerification, type SteelVerificationInput, type SteelDesignParams } from './codes/argentina/cirsoc301';
@@ -64,17 +65,15 @@ export function computeStationDemands(
 
   if (perCombo3D.size === 0) return { demands, stations };
 
-  // Try WASM station extraction first (solver-backed)
-  if (model) {
-    try {
-      const wasmResult = computeStationDemandsWasm(perCombo3D, combinations, model);
-      if (wasmResult) return wasmResult;
-    } catch {
-      // WASM unavailable — fall through to JS path
-    }
+  // Primary path: WASM solver-backed station extraction. Fallback to JS only when
+  // WASM is genuinely unavailable (init not finished, vitest-without-wasm, no model).
+  // Real WASM call errors propagate so future regressions don't hide silently.
+  if (model && isSolverReady()) {
+    const wasmResult = computeStationDemandsWasm(perCombo3D, combinations, model);
+    if (wasmResult) return wasmResult;
   }
 
-  // JS fallback (TRANSITIONAL — used when WASM is not available or model not provided)
+  // JS fallback — only reached when WASM not ready or model unavailable
   const comboNames = new Map<number, string>();
   for (const c of combinations) comboNames.set(c.id, c.name);
   const firstCombo = perCombo3D.values().next().value;
@@ -142,16 +141,26 @@ function wasmMemberToStationResult(
   member: MemberStationGroup3D,
   comboNames: Map<number, string>,
 ): ElementStationResult {
-  // Group stations by combo to build the comboResults shape
-  const comboMap = new Map<number, Array<{ x: number; t: number; n: number; vy: number; vz: number; my: number; mz: number }>>();
+  // Group stations by combo to build the comboResults shape.
+  // The full force tuple — including torsion — must be preserved; downstream
+  // extractGoverningDemands reads s.torsion to populate the Torsion demand category.
+  // If torsion is dropped, the Torsion demand entry has value=undefined, which
+  // crashes the Design tab when expandedDemands.demands is rendered (`d.value.toFixed`).
+  const comboMap = new Map<number, StationForces[]>();
+
+  // Stations come from WASM in order; capture distinct t-values for ElementStationResult.stationTs
+  const tValues: number[] = [];
+  const seenT = new Set<number>();
 
   for (const station of member.stations) {
+    if (!seenT.has(station.t)) { seenT.add(station.t); tValues.push(station.t); }
     for (const cf of station.comboForces) {
       let arr = comboMap.get(cf.comboId);
       if (!arr) { arr = []; comboMap.set(cf.comboId, arr); }
       arr.push({
         x: station.stationX, t: station.t,
         n: cf.n, vy: cf.vy, vz: cf.vz, my: cf.my, mz: cf.mz,
+        torsion: cf.torsion,
       });
     }
   }
@@ -168,6 +177,7 @@ function wasmMemberToStationResult(
   return {
     elementId: member.memberId,
     length: member.length,
+    stationTs: tValues,
     comboResults,
   };
 }

--- a/web/src/lib/engine/verification-service.ts
+++ b/web/src/lib/engine/verification-service.ts
@@ -2,16 +2,21 @@
  * Shared verification service — centralized station-based demand computation
  * and verification orchestration for PRO mode.
  *
- * This module eliminates the divergence between ProDesignTab (station-based)
- * and ProVerificationTab (endpoint-only) by providing a single source of truth
- * for force extraction and CIRSOC verification.
+ * Phase 1 (current): Eliminates the divergence between ProDesignTab (station-based)
+ * and ProVerificationTab (endpoint-only) by routing both through the same
+ * station-based force extraction and CIRSOC JS verification.
  *
- * Architecture note (from SOLVER_APP_COVERAGE_MAP.md §13):
- *   Eventually the solver (Rust/WASM) will own the full verification pipeline
- *   via a unified `verify_members` export. This service is the app-side
- *   intermediate step: it centralizes the computation so the UI components
- *   become render-only consumers. When the solver takes over, this service
- *   becomes a thin wrapper around the WASM call.
+ * Phase 2 target (requires solver changes — not implemented here):
+ *   The solver (Rust/WASM) should own the full pipeline via a unified
+ *   `verify_members` WASM export (§13.5 of SOLVER_APP_COVERAGE_MAP.md).
+ *   When that exists, this service becomes a thin wrapper:
+ *     computeStationDemands → deleted (solver does it internally)
+ *     runUnifiedVerification → calls WASM verify_members instead of JS autoVerifyFromResults
+ *
+ * Temporary app-side bridges in this module:
+ *   - Station extraction is JS-side (should be solver-side beam_stations → design_demands)
+ *   - CIRSOC verification is JS-side cirsoc201.ts (~600 LOC that Phase 3 would delete)
+ *   - autoVerifyFromResults is the JS orchestrator (Phase 3 replaces with WASM call)
  */
 
 import type { AnalysisResults3D } from './types-3d';

--- a/web/src/lib/engine/verification-service.ts
+++ b/web/src/lib/engine/verification-service.ts
@@ -109,6 +109,44 @@ export function runUnifiedVerification(
   return concrete;
 }
 
+// ─── Full Design Orchestration ────────────────────────────────
+
+import {
+  normalizeCirsoc201, buildDesignSummary,
+  type MemberDesignResult as MemberResult,
+} from './design-check-results';
+import { DESIGN_CODES, type DesignCodeId } from './codes/index';
+import { verificationStore } from '../store/verification.svelte';
+
+/**
+ * Run the complete CIRSOC design pipeline: verification + normalization + store update.
+ *
+ * This is the single entry point for Design tab's "Run Design" action when using
+ * CIRSOC. It replaces the multi-step inline logic that was in ProDesignTab.
+ *
+ * TEMPORARY Phase 1 bridge: Orchestrates JS-side verification + normalization.
+ * Phase 2 target: WASM verify_members returns VerificationReport directly;
+ * this function becomes a thin wrapper that stores the result.
+ */
+export function runCirsocDesign(
+  results3D: AnalysisResults3D,
+  model: AutoVerifyModelData,
+  stationDemands: Map<number, ElementDesignDemands> | undefined,
+  sectionNames: Map<number, string>,
+  governing: Map<number, GoverningPerElement3D> | null,
+): { normalized: MemberResult[]; concrete: ElementVerification[] } {
+  const concrete = runUnifiedVerification(results3D, model, governing, stationDemands);
+  const normalized = normalizeCirsoc201(concrete, sectionNames);
+
+  // Update stores — single source of truth
+  verificationStore.setConcrete(concrete);
+  const codeInfo = DESIGN_CODES.find(c => c.id === 'cirsoc');
+  const summaryData = buildDesignSummary(normalized, 'cirsoc', codeInfo?.label ?? 'CIRSOC');
+  verificationStore.setDesignResults(summaryData.results, summaryData);
+
+  return { normalized, concrete };
+}
+
 // ─── Steel Verification (reduced divergence) ─────────────────
 
 /**

--- a/web/src/lib/engine/verification-service.ts
+++ b/web/src/lib/engine/verification-service.ts
@@ -272,3 +272,74 @@ export interface VerificationReport {
  * TEMPORARY Phase 1 bridge: Orchestrates multiple JS-side verification calls.
  * Phase 2 target: Single WASM call returns the report directly.
  */
+
+// ─── Code-Specific Detail Adapter ────────────────────────────
+
+/**
+ * Render-ready code-specific detail for one element.
+ *
+ * TRANSITIONAL: This shape wraps CIRSOC-specific ElementVerification fields
+ * that components need for memos, interaction diagrams, and detailing.
+ * Phase 2: solver returns this as part of VerificationReport.elements[].detail.
+ */
+export interface CodeDetail {
+  /** Calculation memo sections (each is { title: string, steps: string[] }) */
+  memos: Array<{ title: string; steps: string[] }>;
+  /** Interaction diagram data (columns only) */
+  interactionParams?: {
+    b: number; h: number; fc: number; fy: number; cover: number;
+    AsProv: number; barCount: number; barDia: number;
+    Nu: number; Mu: number;
+  };
+  /** Detailing info */
+  detailing?: {
+    bars: Array<{ diameter: number; ld: number; ldh: number; lapSplice: number }>;
+    minClearSpacing: number;
+  };
+  /** Slenderness factors (columns) */
+  slender?: {
+    k: number; lu: number; r: number; klu_r: number; lambda_lim: number;
+    isSlender: boolean; delta_ns: number;
+    steps: string[];
+  };
+}
+
+/**
+ * Extract render-ready code-specific detail for one element from the transitional
+ * concreteMap. Components call this instead of reaching into concreteMap directly.
+ *
+ * TRANSITIONAL adapter: Phase 2 eliminates this — VerificationReport includes detail.
+ */
+export function getCodeDetail(elementId: number): CodeDetail | null {
+  const v = verificationStore.concreteMap.get(elementId);
+  if (!v) return null;
+
+  const memos: CodeDetail['memos'] = [];
+  if (v.flexure?.steps?.length) memos.push({ title: 'Flexure', steps: v.flexure.steps });
+  if (v.shear?.steps?.length) memos.push({ title: 'Shear', steps: v.shear.steps });
+  if (v.column?.steps?.length) memos.push({ title: 'Flexo-compression', steps: v.column.steps });
+  if (v.torsion?.steps?.length) memos.push({ title: `Torsion${v.torsion.neglect ? ' (negligible)' : ''}`, steps: v.torsion.steps });
+  if (v.biaxial?.steps?.length) memos.push({ title: 'Biaxial (Bresler)', steps: v.biaxial.steps });
+
+  const interactionParams = v.column ? {
+    b: v.b, h: v.h, fc: v.fc, fy: 420,
+    cover: v.cover + (v.shear.stirrupDia / 2000) + (v.flexure.barDia / 2000),
+    AsProv: v.column.AsProv, barCount: v.column.barCount,
+    barDia: v.column.barDia ?? v.flexure.barDia,
+    Nu: v.Nu, Mu: v.Mu,
+  } : undefined;
+
+  const detailing = v.detailing ? {
+    bars: v.detailing.bars.map(b => ({ diameter: b.diameter, ld: b.ld, ldh: b.ldh, lapSplice: b.lapSplice })),
+    minClearSpacing: v.detailing.minClearSpacing,
+  } : undefined;
+
+  const slender = v.slender ? {
+    k: v.slender.k, lu: v.slender.lu, r: v.slender.r,
+    klu_r: v.slender.klu_r, lambda_lim: v.slender.lambda_lim,
+    isSlender: v.slender.isSlender, delta_ns: v.slender.delta_ns,
+    steps: v.slender.steps,
+  } : undefined;
+
+  return { memos, interactionParams, detailing, slender };
+}

--- a/web/src/lib/engine/verification-service.ts
+++ b/web/src/lib/engine/verification-service.ts
@@ -28,8 +28,10 @@ import {
   type ElementStationResult,
 } from './station-design-forces';
 import { autoVerifyFromResults, type AutoVerifyModelData } from './auto-verify';
-import type { ElementVerification } from './codes/argentina/cirsoc201';
+import { classifyElement, type ElementVerification } from './codes/argentina/cirsoc201';
+import { verifySteelElement, type SteelVerification, type SteelVerificationInput, type SteelDesignParams } from './codes/argentina/cirsoc301';
 import type { GoverningPerElement3D } from './governing-case';
+import type { CheckStatus, MemberDesignResult, DesignCheckSummary } from './design-check-results';
 
 // ─── Station Demands ─────────────────────────────────────────
 
@@ -106,3 +108,129 @@ export function runUnifiedVerification(
   );
   return concrete;
 }
+
+// ─── Steel Verification (reduced divergence) ─────────────────
+
+/**
+ * Run CIRSOC 301 steel verification for all steel elements.
+ *
+ * TEMPORARY Phase 1 bridge: Uses station-based demands for force extraction
+ * (same source as RC), reducing the divergence with the RC path. The verification
+ * itself is still JS-side cirsoc301.ts.
+ *
+ * Phase 2 target: Unified WASM verify_members handles both RC and steel.
+ */
+export function runSteelVerification(
+  results3D: AnalysisResults3D,
+  model: AutoVerifyModelData,
+  stationDemands?: Map<number, ElementDesignDemands>,
+): SteelVerification[] {
+  const verifs: SteelVerification[] = [];
+
+  for (const ef of results3D.elementForces) {
+    const elem = model.elements.get(ef.elementId);
+    if (!elem) continue;
+    const section = model.sections.get(elem.sectionId);
+    const material = model.materials.get(elem.materialId);
+    if (!section || !material) continue;
+    if (!material.fy || material.fy <= 80) continue; // RC, not steel
+
+    const nI = model.nodes.get(elem.nodeI);
+    const nJ = model.nodes.get(elem.nodeJ);
+    if (!nI || !nJ) continue;
+    const dx = nJ.x - nI.x, dy = nJ.y - nI.y, dz = (nJ.z ?? 0) - (nI.z ?? 0);
+    const L = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (L <= 0) continue;
+
+    // Use station demands when available (same path as RC), fallback to endpoints
+    let NuMax: number, MuzMax: number, MuyMax: number, VuMax: number;
+    const sd = stationDemands?.get(ef.elementId);
+    if (sd) {
+      const dems = sd.demands;
+      NuMax = Math.max(
+        dems.find(d => d.category === 'N_compression')?.value ?? 0,
+        dems.find(d => d.category === 'N_tension')?.value ?? 0,
+      );
+      MuzMax = Math.max(
+        dems.find(d => d.category === 'Mz+')?.value ?? 0,
+        dems.find(d => d.category === 'Mz-')?.value ?? 0,
+      );
+      MuyMax = Math.max(
+        dems.find(d => d.category === 'My+')?.value ?? 0,
+        dems.find(d => d.category === 'My-')?.value ?? 0,
+      );
+      VuMax = Math.max(
+        dems.find(d => d.category === 'Vy')?.value ?? 0,
+        dems.find(d => d.category === 'Vz')?.value ?? 0,
+      );
+    } else {
+      // Endpoint fallback (same as legacy path)
+      NuMax = Math.max(Math.abs(ef.nStart), Math.abs(ef.nEnd));
+      MuzMax = Math.max(Math.abs(ef.mzStart), Math.abs(ef.mzEnd));
+      MuyMax = Math.max(Math.abs(ef.myStart), Math.abs(ef.myEnd));
+      VuMax = Math.max(Math.abs(ef.vyStart), Math.abs(ef.vyEnd), Math.abs(ef.vzStart), Math.abs(ef.vzEnd));
+    }
+
+    const sdp: SteelDesignParams = {
+      Fy: material.fy,
+      Fu: (material as any).fu ?? material.fy * 1.25,
+      E: material.e,
+      A: section.a,
+      Iz: section.iz,
+      Iy: section.iy ?? section.iz,
+      h: section.h ?? 0.3,
+      b: section.b ?? 0.15,
+      tw: (section as any).tw ?? (section.b ? section.b / 10 : 0.01),
+      tf: (section as any).tf ?? (section.b ? section.b / 15 : 0.01),
+      L, Lb: L,
+      J: section.j ?? 0,
+    };
+
+    verifs.push(verifySteelElement({
+      elementId: ef.elementId, Nu: NuMax, Muy: MuyMax, Muz: MuzMax, Vu: VuMax, params: sdp,
+    }));
+  }
+
+  return verifs;
+}
+
+// ─── Unified VerificationReport ──────────────────────────────
+
+/**
+ * Unified verification report — app-side shape that mirrors the eventual
+ * solver-side VerificationReport (§13.6 of SOLVER_APP_COVERAGE_MAP.md).
+ *
+ * Phase 1 (current): Assembled from JS-side verification results.
+ * Phase 2 target: Returned directly from WASM verify_members.
+ *
+ * The shape is designed so that when the solver takes over:
+ *   - `elements` maps directly to the Rust VerificationReport.elements
+ *   - `summary` maps to aggregate counts
+ *   - UI components consume this without knowing the source (JS or WASM)
+ */
+export interface VerificationReport {
+  /** Code used for this verification run */
+  codeId: string;
+  codeName: string;
+  /** Per-element normalized results (same shape regardless of source) */
+  elements: MemberDesignResult[];
+  /** Aggregate summary */
+  summary: DesignCheckSummary;
+  /** Station-based demands used for this run (absent in future WASM path) */
+  stationData?: StationDemandData;
+  /** Legacy CIRSOC-specific results (kept during Phase 1 for detailed memos/drawings) */
+  concreteDetails?: ElementVerification[];
+  /** Legacy CIRSOC 301 steel results */
+  steelDetails?: SteelVerification[];
+}
+
+/**
+ * Build a complete VerificationReport from the current app-side verification flow.
+ *
+ * This is the single function that assembles everything — demands, RC verification,
+ * steel verification, normalization — into one report. Components should call this
+ * instead of assembling pieces themselves.
+ *
+ * TEMPORARY Phase 1 bridge: Orchestrates multiple JS-side verification calls.
+ * Phase 2 target: Single WASM call returns the report directly.
+ */

--- a/web/src/lib/engine/verification-service.ts
+++ b/web/src/lib/engine/verification-service.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared verification service — centralized station-based demand computation
+ * and verification orchestration for PRO mode.
+ *
+ * This module eliminates the divergence between ProDesignTab (station-based)
+ * and ProVerificationTab (endpoint-only) by providing a single source of truth
+ * for force extraction and CIRSOC verification.
+ *
+ * Architecture note (from SOLVER_APP_COVERAGE_MAP.md §13):
+ *   Eventually the solver (Rust/WASM) will own the full verification pipeline
+ *   via a unified `verify_members` export. This service is the app-side
+ *   intermediate step: it centralizes the computation so the UI components
+ *   become render-only consumers. When the solver takes over, this service
+ *   becomes a thin wrapper around the WASM call.
+ */
+
+import type { AnalysisResults3D } from './types-3d';
+import type { LoadCombination } from '../store/model.svelte';
+import {
+  extractElementStations,
+  extractGoverningDemands,
+  type ElementDesignDemands,
+  type ElementStationResult,
+} from './station-design-forces';
+import { autoVerifyFromResults, type AutoVerifyModelData } from './auto-verify';
+import type { ElementVerification } from './codes/argentina/cirsoc201';
+import type { GoverningPerElement3D } from './governing-case';
+
+// ─── Station Demands ─────────────────────────────────────────
+
+export interface StationDemandData {
+  demands: Map<number, ElementDesignDemands>;
+  stations: Map<number, ElementStationResult>;
+}
+
+/**
+ * Compute station-based demands for all elements from per-combination 3D results.
+ *
+ * This is the canonical force-extraction path that both Design and Verification
+ * should use. It evaluates interior stations (midspan, quarter points, load
+ * positions, zero-shear points) across all combinations, preserving moment sign
+ * and full concurrent force tuples.
+ *
+ * @param perCombo3D Per-combination results from resultsStore
+ * @param combinations Model combinations (for name lookup)
+ * @returns Station data for all elements, or empty maps if no combinations
+ */
+export function computeStationDemands(
+  perCombo3D: Map<number, AnalysisResults3D>,
+  combinations: LoadCombination[],
+): StationDemandData {
+  const demands = new Map<number, ElementDesignDemands>();
+  const stations = new Map<number, ElementStationResult>();
+
+  if (perCombo3D.size === 0) return { demands, stations };
+
+  const comboNames = new Map<number, string>();
+  for (const c of combinations) comboNames.set(c.id, c.name);
+
+  const firstCombo = perCombo3D.values().next().value;
+  if (!firstCombo) return { demands, stations };
+
+  for (const ef of firstCombo.elementForces) {
+    const esr = extractElementStations(ef.elementId, perCombo3D, comboNames);
+    if (esr) {
+      stations.set(ef.elementId, esr);
+      demands.set(ef.elementId, extractGoverningDemands(esr));
+    }
+  }
+
+  return { demands, stations };
+}
+
+// ─── Unified Verification ────────────────────────────────────
+
+/**
+ * Run CIRSOC 201 verification for all concrete elements using station-based
+ * demands when available (the preferred path).
+ *
+ * This replaces the two divergent verification calls that previously lived in
+ * ProDesignTab (station-aware) and ProVerificationTab (endpoint-only).
+ *
+ * @param results3D Solver analysis results
+ * @param model Model data (elements, nodes, sections, materials, supports)
+ * @param governing Optional governing combo metadata
+ * @param stationDemands Pre-computed station demands (from computeStationDemands)
+ * @returns Array of ElementVerification results
+ */
+export function runUnifiedVerification(
+  results3D: AnalysisResults3D,
+  model: AutoVerifyModelData,
+  governing: Map<number, GoverningPerElement3D> | null,
+  stationDemands?: Map<number, ElementDesignDemands>,
+): ElementVerification[] {
+  const { concrete } = autoVerifyFromResults(
+    results3D,
+    model,
+    governing,
+    undefined,
+    stationDemands,
+  );
+  return concrete;
+}


### PR DESCRIPTION
## Summary

PR [3] of the stack on top of [1] PRO workflow overhaul + [2] Calc report enrichment.

This PR unifies the PRO verification pipeline behind a shared, station-based, sign-aware force-extraction service and routes both Design and Verification through it. Adopts the existing solver-side `extract_beam_stations_grouped_3d` WASM export as the primary station-extraction path (with JS fallback), and lands two UX-correctness fixes uncovered while auditing the merged-chain preview.

### Key changes
- **Verification service** (`web/src/lib/engine/verification-service.ts`): single `computeStationDemands` that prefers WASM and falls back to JS only when the solver is genuinely not ready (`isSolverReady()` gate, no silent error swallowing). The WASM-side `MemberStationGroup3D → ElementStationResult` adapter preserves `torsion` and `stationTs` (regression caught and fixed during audit).
- **CIRSOC unification**: ProDesignTab and (the now-dormant) ProVerificationTab share the same station-based demand source; centralized CIRSOC design orchestration in the service layer; ElementVerification carries per-check governing-combo provenance.
- **`runUnifiedVerification` + `runSteelVerification`** route both RC and steel through the same station-based force tuples.
- **Adapter for code-specific detail** (`getCodeDetail`) so components consume code-agnostic detail, isolating the CIRSOC-specific shape behind one boundary.
- **`runCirsocDesign`** as the single entry point that does verify + normalize + store update — replaces multi-step inline logic.
- **VerificationReport** type introduced as the eventual unified shape (Phase 2 target — solver-side).
- **In-use delete UX**: Materials/Sections delete now surfaces a clear toast (using existing `uiStore.toast` + existing i18n keys) when the model layer rejects deletion of an in-use entity. The integrity guard is preserved unchanged.

### Solver-side coverage
- Adopts `extract_beam_stations_grouped_3d` (already exported, previously unconsumed).
- Documents PRO solver/app coverage map in `docs/SOLVER_APP_COVERAGE_MAP.md`.

### Constraints honored
- No solver edits.
- No new parallel verification paths — the dormant ProVerificationTab is documented and routed through the same shared service.
- Preserves the QA-validated memo/detail UX (CIRSOC JS verification still produces step-by-step memos).

## Test plan
- [x] All 14 PRO examples load + solve + open Design + Run Design + expand row cleanly (`pro-edificio-7p`, `RC Design Frame`, `RC QA Diagnostic`, `XL Diagrid Tower`, `La Bombonera`, `Full Stadium`, etc.).
- [x] Basic 2D and Basic 3D representative examples solve cleanly and post-solve diagrams (deformed / M / V / N) toggle without errors.
- [x] PRO Advanced surface — actually executed (not only opened): P-Δ, Modal, Espectral (after Modal), Pandeo, Time History, Harmonic, Arc-Length, Imperfections, Creep, Cable, Reduce, Multi-Case, Section Analyzer, Constrained, Nonlinear material, plus prerequisite-gated paths Disp Control / Winkler / SSI / Contact / Staged / Compute IL.
- [x] PRO mutation flows: Add/+ Node/+ Element/Add Support/Add Material via preset/Add Section via standard profile/Add Combo all produce visible state changes; modify combo factor + load case name + support type all work; delete (combos, supports, removable materials/sections) works; in-use material/section delete now shows toast.
- [x] PRO auto-loads dialog generates loads end-to-end (CIRSOC code-based).
- [x] Save Tab / PNG / SVG / DXF / Excel exports fire downloads. `.ded` round-trip Save → Open clean.
- [x] Mobile shell: hamburger → load → solve workflow runs end-to-end.
- [x] EDU mode: exercise list opens, exercise page loads, Verify-button click clean.
- [x] Production build (`vite build`) clean on each layer.