### PR TITLE
fix(pro): safe correctness fixes from PR #47 review (report, combos, …

### DIFF
--- a/web/src/components/pro/ProDesignTab.svelte
+++ b/web/src/components/pro/ProDesignTab.svelte
@@ -356,6 +356,16 @@
     return '#ee2222';
   }
 
+  /** Bar color that respects the member's overall status. The displayed ratio is
+   *  the strength utilization (which excludes anchorage/fit checks), so a member
+   *  that fails/warns only on a detailing check would otherwise show a green bar
+   *  under a red badge. Floor the color to the status so badge and bar agree. */
+  function statusBarColor(r: number, status: CheckStatus): string {
+    if (status === 'fail') return '#ee2222';
+    if (status === 'warn' && r <= 1.0) return '#ddaa00';
+    return ratioBarColor(r);
+  }
+
   // ─── Provided Reinforcement helpers ────────────────────────────
   const LONG_DIAS = REBAR_DB.filter(r => r.diameter >= 10).map(r => r.diameter); // 10, 12, 16, 20, 25, 32
   const STIRRUP_DIAS = REBAR_DB.filter(r => r.diameter <= 12).map(r => r.diameter); // 6, 8, 10, 12
@@ -766,7 +776,7 @@
                 <div class="ratio-cell">
                   <span class="ratio-value">{fmtRatio(govRatio)}</span>
                   <div class="ratio-bar">
-                    <div class="ratio-fill" style="width:{ratioBarWidth(govRatio)};background:{ratioBarColor(govRatio)}"></div>
+                    <div class="ratio-fill" style="width:{ratioBarWidth(govRatio)};background:{statusBarColor(govRatio, effectiveStatus)}"></div>
                   </div>
                 </div>
               </td>

--- a/web/src/components/pro/ProLoadsTab.svelte
+++ b/web/src/components/pro/ProLoadsTab.svelte
@@ -435,9 +435,14 @@
     const toAdd = candidateCombos.filter(c => c.selected);
     if (toAdd.length === 0) { showComboModal = false; return; }
     const prefix = activeTemplate === 'service' ? 'S' : 'U';
-    // Count only combos with matching prefix for independent numbering
-    const pattern = new RegExp(`^${prefix}\\d+:`);
-    let n = combinations.filter(c => pattern.test(c.name)).length;
+    // Continue numbering from the highest existing index for this prefix (not a
+    // count): counting reuses a number after an earlier combo is deleted, which
+    // produces duplicate names like two "U3: …".
+    const pattern = new RegExp(`^${prefix}(\\d+):`);
+    let n = combinations.reduce((max, c) => {
+      const m = c.name.match(pattern);
+      return m ? Math.max(max, parseInt(m[1], 10)) : max;
+    }, 0);
     modelStore.batch(() => {
       for (const c of toAdd) {
         n++;

--- a/web/src/lib/engine/pro-report.ts
+++ b/web/src/lib/engine/pro-report.ts
@@ -439,8 +439,9 @@ export function generateReportHtml(data: ReportData): string {
   if (showSection('storyDrift') && data.storyDrifts && data.storyDrifts.length > 0) tocEntries.push({ label: '5. ' + (tr('report.storyDrift') || 'Story Drift'), anchor: 'sec-drift' });
   if (showSection('diagnostics') && data.diagnostics && data.diagnostics.length > 0) tocEntries.push({ label: '6. ' + (tr('report.diagnostics') || 'Diagnostics'), anchor: 'sec-diagnostics' });
   if (showSection('quantities') && quantities) tocEntries.push({ label: '7. ' + (tr('report.quantities') || 'Quantities'), anchor: 'sec-quantities' });
-  // Insert Design Summary into TOC if verification data exists
-  if (verifications.length > 0) {
+  // Insert Design Summary into TOC if verification data exists AND the user
+  // didn't opt out of the verification section in the report config.
+  if (showSection('verification') && verifications.length > 0) {
     tocEntries.unshift({ label: tr('report.designSummary') || 'Design Summary', anchor: 'sec-design-summary' });
     // Renumber all subsequent entries
     for (let i = 1; i < tocEntries.length; i++) {
@@ -456,8 +457,8 @@ export function generateReportHtml(data: ReportData): string {
   }
   html.push(`</div>`);
 
-  // ─── Design Summary (when verification data exists) ───
-  if (verifications.length > 0) {
+  // ─── Design Summary (when verification data exists and section is enabled) ───
+  if (showSection('verification') && verifications.length > 0) {
     html.push(`<div class="page-break"></div>`);
     html.push(`<h1 id="sec-design-summary">${escHtml(tr('report.designSummary') || 'Design Summary')}</h1>`);
 


### PR DESCRIPTION
…design-tab UI)

Bounded, non-domain fixes from the review. Web suite: 2125 passing (5 skipped); vite build clean.

- pro-report: the "Design Summary" section and its TOC entry rendered whenever verifications existed, ignoring showSection('verification'). Now gated on showSection('verification') like every other section, so opting out of Verification in the report config also drops the summary (and its TOC renumbering).
- ProLoadsTab: LRFD/service combo numbering used the *count* of matching combos, so after deleting an earlier combo the next generation reused an index and produced duplicate names ("U3" twice). Number from the highest existing index instead.
- ProDesignTab: the utilization bar was colored from the strength ratio (which excludes anchorage/fit checks) while the status badge used the overall status, so a member failing only on a detailing check showed a red FAIL badge above a green bar. New statusBarColor() floors the bar color to the member status; the numeric ratio (strength utilization) is unchanged.

Deliberately NOT fixed — these are structural-design correctness issues that need a PE/domain decision or a data-model change, not a mechanical patch (documented in the review):
- auto-verify feeds independently-enveloped Mz/Nu/Vy from different combos into one verifyElement call (non-concurrent P-M pairing), and collapses axial to an unsigned magnitude so net-tension members are checked with the compression Vc term (unconservative). cirsoc201 wants Nu +=compression while station extraction tags n<0 as compression. A correct fix needs concurrent per-combo force tuples + a confirmed solver sign convention; a scalar-Nu patch can't be correct for both shear and P-M at once.
- fc = material.fy (Material has no fc field); concrete with fy>80 is silently skipped. Needs a material category / fc on the model.
- M1/M2 slenderness still endpoint-based on the station path; biaxial Nu-scaling and Vy-only (no Vz) tie shear need PE validation.