### PR TITLE
fix(pro): fixes from PR #51 review (2D constraint wire, wireframe hea…

### DIFF
--- a/web/src/lib/engine/solver-service.ts
+++ b/web/src/lib/engine/solver-service.ts
@@ -169,6 +169,8 @@ export function validateAndSolve2D(
   // connectors (ConnectorElement), and constraints (rigidLink, equalDOF,
   // eccentricConnection, diaphragm, linearMPC). A node coupled only via any
   // of those is NOT orphaned. See constraint-connectivity.ts for the rule.
+  // (These primitives are carried into the 2D solver input below, so crediting
+  // them here is honest — they actually contribute stiffness.)
   const connectedNodes = new Set<number>();
   for (const elem of model.elements.values()) {
     connectedNodes.add(elem.nodeI);
@@ -556,6 +558,12 @@ export function validateAndSolve2D(
     }])),
     supports: buildSolverSupports2D(model),
     loads: solverLoads,
+    // Carry constraints + connectors into the 2D wire (mirrors buildSolverInput3D)
+    // so a node coupled only via a constraint/connector — which the preflight
+    // credits as connected — actually receives stiffness and the 2D constrained
+    // solver can solve it, instead of being handed a singular system.
+    constraints: model.constraints ?? [],
+    connectors: model.connectors,
   };
 
   // Kinematic analysis
@@ -745,6 +753,12 @@ export function buildSolverInput2D(model: ModelData, includeSelfWeight = false):
     }])),
     supports: buildSolverSupports2D(model),
     loads: solverLoads,
+    // Carry constraints + connectors into the 2D wire (mirrors buildSolverInput3D)
+    // so a node coupled only via a constraint/connector — which the preflight
+    // credits as connected — actually receives stiffness and the 2D constrained
+    // solver can solve it, instead of being handed a singular system.
+    constraints: model.constraints ?? [],
+    connectors: model.connectors,
   };
 }
 

--- a/web/src/lib/viewport3d/lod.ts
+++ b/web/src/lib/viewport3d/lod.ts
@@ -66,7 +66,14 @@ export function applyLowDetail(
   if (g.elementsParent) g.elementsParent.visible = !on || keepElementsForResults;
 
   if (g.elementsBatchedMesh) {
-    g.elementsBatchedMesh.visible = on ? true : g.renderMode === 'wireframe';
+    // During orbit the batched mesh is the cheap stand-in for the hidden solid
+    // elementsParent. But when result coloring keeps elementsParent visible
+    // (solid/sections), forcing the batched mesh on too draws a redundant
+    // wireframe overlay over the solids and doubles the element draw — so
+    // suppress it there. In wireframe render mode the batched mesh IS the
+    // element rendering, so keep it regardless.
+    const keepBatchedForOrbit = on && !keepElementsForResults;
+    g.elementsBatchedMesh.visible = keepBatchedForOrbit || g.renderMode === 'wireframe';
   }
 }
 

--- a/web/src/lib/viewport3d/results-sync.ts
+++ b/web/src/lib/viewport3d/results-sync.ts
@@ -10,7 +10,7 @@ import * as THREE from 'three';
 import { modelStore, uiStore, resultsStore } from '../store';
 import { createDeformedLines, type ElementEI } from '../three/deformed-shape-3d';
 import { createDiagramGroup3D, createEnvelopeDiagramGroup3D } from '../three/diagram-render-3d';
-import { COLORS, setGroupColor, disposeObject, axialForceColor, verificationColor, createTextSprite } from '../three/selection-helpers';
+import { COLORS, setGroupColor, disposeObject, axialForceColor, verificationColor, createTextSprite, heatmapColor } from '../three/selection-helpers';
 import { verificationStore } from '../store/verification.svelte';
 import { createReactionArrow, createConstraintForceArrow } from '../three/create-load-arrow';
 import type { Diagram3DKind } from '../engine/diagrams-3d';
@@ -380,22 +380,11 @@ export function syncColorMap3D(ctx: ResultsSyncContext): void {
       eb.flush();
       applyShellHeatmap(ctx, r3d);
     } else {
-      // Continuous heatmap on frame elements
+      // Continuous heatmap on frame elements. applyFrameHeatmap also mirrors
+      // the SELECTED variable's color onto the batched wireframe mesh (and
+      // flushes), so wireframe mode shows the right gradient — not axial force.
       resetShellColors(ctx);
       applyFrameHeatmap(ctx, forcesMap, cmKind as HeatmapVariable);
-      // Mirror the heatmap end-color onto the batched mesh so wireframe
-      // mode still shows the gradient instead of falling back to base.
-      for (const [id, _group] of ctx.elementGroups) {
-        const ef = forcesMap.get(id);
-        if (!ef) continue;
-        // Use axialForceColor as a representative heatmap color; the
-        // detailed gradient lives in applyFrameHeatmap's textured cylinders
-        // (only visible in solid mode). For wireframe, the base color
-        // is the best single-color representative we have.
-        const nAvg = (ef.nStart + ef.nEnd) / 2;
-        eb.setBaseColor(id, axialForceColor(nAvg));
-      }
-      eb.flush();
     }
 
     ctx.colorMapApplied = true;
@@ -600,6 +589,23 @@ function applyFrameHeatmap(
     heatMesh.renderOrder = 2;
     group.add(heatMesh);
   }
+
+  // Mirror the heatmap color onto the batched wireframe mesh so wireframe mode
+  // shows the SELECTED variable's gradient (one representative color per element)
+  // instead of always axial force. Uses the same heatmapColor/globalMax mapping
+  // as the textured cylinders above.
+  for (const [id] of ctx.elementGroups) {
+    const values = elemSamples.get(id);
+    if (!values || values.length === 0) {
+      ctx.elementsBatched.setBaseColor(id, 0x555555);
+      continue;
+    }
+    let peak = 0;
+    for (const v of values) if (v > peak) peak = v;
+    const norm = globalMax > 0 ? Math.min(peak / globalMax, 1) : 0;
+    ctx.elementsBatched.setBaseColor(id, heatmapColor(norm));
+  }
+  ctx.elementsBatched.flush();
 }
 
 /** Apply Von Mises heatmap on plates and quads */


### PR DESCRIPTION
…tmap, LOD double-draw)

Web suite: 2155 passing (5 skipped); vite build clean.

- solver-service (2D): validateAndSolve2D's preflight credits connectivity from connectors + constraints (and constraint-connectivity.test.ts pins that), but the 2D SolverInput omitted both fields — so a node coupled only via a constraint/connector passed the disconnected-node check and was then handed to the solver with zero stiffness → singular system, masking the diagnostic. Carry `constraints`/`connectors` into both 2D input objects (inline validateAndSolve2D and buildSolverInput2D), mirroring buildSolverInput3D, so the preflight is honest and the 2D constrained solver actually receives them.
- results-sync (colorMap wireframe): the batched wireframe mesh was always colored by mean axial force regardless of the selected heatmap variable, so wireframe mode showed axial colors while the legend said shear/moment. applyFrameHeatmap now mirrors the SELECTED variable's color onto the batched mesh using the same heatmapColor()/globalMax mapping as the cylinders.
- lod (double-draw): during orbit with result coloring active in solid/sections mode, both elementsParent (kept visible for colored solids) and the batched wireframe were forced on → redundant wireframe overlay + doubled element draw. Suppress the batched mesh when elementsParent is kept for results; wireframe render mode (where the batched mesh IS the rendering) is unchanged.

Deliberately NOT fixed (need domain validation — documented in review):
- Partial-DOF couplings (single-DOF equalDOF / single-term linearMPC) are credited as full connectivity, so a partial mechanism passes preflight.
- Constraint discriminators renamed (equalDof→equalDOF, linearMpc→linearMPC, rhs removed, dofs string→int) with no load migration → old saved/shared models with the old names render as unknown and the solver rejects the variant.
- EccentricConnection 2D `releases` length (UI always emits the 6-element 3D array; 2D expects [ux,uz,ry]). These are solver/DOF-semantics decisions for a structural engineer — and gate fully trusting the new 2D constraint wire above.