### PR TITLE
fix: correctness quick-wins (batch A) — prod WASM opt, error surfacin…

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -38,7 +38,9 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Build WASM engine
-        run: wasm-pack build --target web --out-dir ../web/src/lib/wasm --no-opt
+        # NOTE: no --no-opt here — the PRODUCTION binary must run wasm-opt
+        # (binaryen) for a smaller, faster solver. CI keeps --no-opt for build speed.
+        run: wasm-pack build --target web --out-dir ../web/src/lib/wasm
         working-directory: engine
 
       - name: Install dependencies

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -951,7 +951,14 @@
 {#if uiStore.toasts.length > 0}
   <div class="toast-container">
     {#each uiStore.toasts as toast}
-      <div class="toast toast-{toast.type}">
+      <!-- Screen-reader announce: errors interrupt (alert/assertive), the rest
+           are polite (status). Per-toast live regions avoid a nested-region clash. -->
+      <div
+        class="toast toast-{toast.type}"
+        role={toast.type === 'error' ? 'alert' : 'status'}
+        aria-live={toast.type === 'error' ? 'assertive' : 'polite'}
+        aria-atomic="true"
+      >
         <span>{toast.message}</span>
         {#if toast.actionId === 'kinematic'}
           <button class="toast-action" onclick={() => { uiStore.showKinematicPanel = true; uiStore.dismissToast(toast.id); }}>

--- a/web/src/components/Toolbar.svelte
+++ b/web/src/components/Toolbar.svelte
@@ -156,6 +156,10 @@
         if (comboResult && typeof comboResult !== 'string') {
           resultsStore.setCombinationResults(comboResult.perCase, comboResult.perCombo, comboResult.envelope);
           comboText = t('toast.plusCombinations').replace('{n}', String(comboResult.perCombo.size));
+        } else if (typeof comboResult === 'string') {
+          // Combinations failed (e.g. a load case is a mechanism) — surface it
+          // instead of silently firing the success toast as if they all solved.
+          uiStore.toast(comboResult, 'error');
         }
       }
       uiStore.toast(`${t('results.calcSuccess')}${classText} — ${results.elementForces.length} ${t('results.bars')}, ${results.reactions.length} ${t('results.reactions')}${comboText}`, 'success');
@@ -215,6 +219,9 @@
         if (comboResult && typeof comboResult !== 'string') {
           resultsStore.setCombinationResults3D(comboResult.perCase, comboResult.perCombo, comboResult.envelope);
           comboText = t('toast.plusCombinations').replace('{n}', String(comboResult.perCombo.size));
+        } else if (typeof comboResult === 'string') {
+          // Combinations failed — surface it instead of silently reporting success.
+          uiStore.toast(comboResult, 'error');
         }
       }
       uiStore.toast(

--- a/web/src/components/WhatIfPanel.svelte
+++ b/web/src/components/WhatIfPanel.svelte
@@ -16,6 +16,10 @@
   let aFactor = $state(1.0);
   let izFactor = $state(1.0);
 
+  // Last re-solve error (shown inline; what-if re-solves on a 60ms debounce, so
+  // a toast per tick would spam — surface it in the panel instead of swallowing).
+  let whatIfError = $state<string | null>(null);
+
   // Baseline values for display
   let baselineE = $state(0);
   let baselineA = $state(0);
@@ -120,21 +124,25 @@
         }
       }
 
-      // Re-solve
+      // Re-solve — capture failures (string return or thrown) so the panel can
+      // show them instead of silently leaving stale results on screen.
+      let solveErr: string | null = null;
       if (uiStore.analysisMode === '3d' || uiStore.analysisMode === 'pro') {
         try {
           const isPro = uiStore.analysisMode === 'pro';
           const r3d = modelStore.solve3D(uiStore.includeSelfWeight, uiStore.axisConvention3D === 'leftHand', isPro);
-          if (r3d && typeof r3d !== 'string') resultsStore.setResults3D(r3d);
-        } catch { /* ignore */ }
+          if (typeof r3d === 'string') solveErr = r3d;            // already localized by the store
+          else if (r3d) resultsStore.setResults3D(r3d);
+        } catch (e) { solveErr = (e as Error)?.message ?? t('results.numericError3d'); }
       } else {
         const input = modelStore.buildSolverInput(uiStore.includeSelfWeight);
-        if (!input) return;
+        if (!input) { whatIfError = null; return; }
         try {
           const results = solve(input);
           resultsStore.setResults(results);
-        } catch { /* ignore */ }
+        } catch (e) { solveErr = (e as Error)?.message ?? t('results.numericError'); }
       }
+      whatIfError = solveErr;
     }, 60) as unknown as number;
   }
 
@@ -159,6 +167,7 @@
       }
       baseline = null;
     }
+    whatIfError = null;
     uiStore.showWhatIf = false;
   }
 
@@ -220,6 +229,10 @@
       <button class="wif-reset" onclick={resetAll} title={t('whatif.restoreOriginals')}>Reset</button>
       <button class="wif-close" onclick={close} title={t('whatif.closeAndRestore')}>✕</button>
     </div>
+
+    {#if whatIfError}
+      <div class="wif-error" role="alert">{whatIfError}</div>
+    {/if}
 
     <div class="wif-body">
       <!-- Load factors -->
@@ -429,5 +442,15 @@
     margin-bottom: 4px;
     font-family: 'Courier New', monospace;
     padding-left: 32px;
+  }
+  .wif-error {
+    margin: 8px 12px 0;
+    padding: 7px 9px;
+    border-radius: 4px;
+    background: rgba(233, 69, 96, 0.15);
+    border: 1px solid rgba(233, 69, 96, 0.5);
+    color: #ff8fa3;
+    font-size: 11.5px;
+    line-height: 1.35;
   }
 </style>

--- a/web/src/lib/engine/auto-verify.ts
+++ b/web/src/lib/engine/auto-verify.ts
@@ -23,8 +23,11 @@ import type { ElementVerification, VerificationInput } from './codes/argentina/c
 export interface AutoVerifyModelData {
   elements: Map<number, { id: number; nodeI: number; nodeJ: number; sectionId: number; materialId: number; type: string }>;
   nodes: Map<number, { id: number; x: number; y: number; z?: number }>;
-  sections: Map<number, { id: number; name: string; b?: number; h?: number }>;
-  materials: Map<number, { id: number; name: string; fy?: number }>;
+  // Steel verification (runSteelVerification) reads a/iz/iy/j/tw/tf and e; the RC
+  // path uses b/h/fy. All optional here so RC-only fixtures (no `a`) still type;
+  // the steel path guards presence before use.
+  sections: Map<number, { id: number; name: string; a?: number; iz?: number; iy?: number; j?: number; b?: number; h?: number; tw?: number; tf?: number }>;
+  materials: Map<number, { id: number; name: string; e?: number; fy?: number; fu?: number }>;
   supports: Map<number, { id: number; nodeId: number; type: string }>;
 }
 

--- a/web/src/lib/engine/calc-report.ts
+++ b/web/src/lib/engine/calc-report.ts
@@ -232,7 +232,9 @@ function buildModelSection(data: CalcReportData): string {
   const showElems = elemCondensed ? [...data.elements.slice(0, 20), null, ...data.elements.slice(-5)] : data.elements;
   for (const e of showElems) {
     if (!e) { h.push(`<tr><td colspan="7" style="text-align:center;color:#888">... ${elemCount - 25} more elements ...</td></tr>`); continue; }
-    const hinges = (e.hingeStart ? 'I' : '') + (e.hingeEnd ? 'J' : '') || '—';
+    // Moment release per end (the typed-Release migration replaced the old
+    // hingeStart/hingeEnd booleans with releaseI/releaseJ.mz).
+    const hinges = (e.releaseI?.mz ? 'I' : '') + (e.releaseJ?.mz ? 'J' : '') || '—';
     h.push(`<tr><td>${e.id}</td><td>${e.type}</td><td>${e.nodeI}</td><td>${e.nodeJ}</td><td>${e.materialId}</td><td>${e.sectionId}</td><td>${hinges}</td></tr>`);
   }
   h.push('</table>');

--- a/web/src/lib/engine/verification-service.ts
+++ b/web/src/lib/engine/verification-service.ts
@@ -283,6 +283,10 @@ export function runSteelVerification(
     const material = model.materials.get(elem.materialId);
     if (!section || !material) continue;
     if (!material.fy || material.fy <= 80) continue; // RC, not steel
+    // Steel design needs E/A/Iz; real sections/materials always carry them, but
+    // guard (and narrow the optional types) so a malformed entry is skipped
+    // rather than fed undefined into the capacity checks.
+    if (material.e == null || section.a == null || section.iz == null) continue;
 
     const nI = model.nodes.get(elem.nodeI);
     const nJ = model.nodes.get(elem.nodeJ);
@@ -326,15 +330,15 @@ export function runSteelVerification(
 
     const sdp: SteelDesignParams = {
       Fy: material.fy,
-      Fu: (material as any).fu ?? material.fy * 1.25,
+      Fu: material.fu ?? material.fy * 1.25,
       E: material.e,
       A: section.a,
       Iz: section.iz,
       Iy: section.iy ?? section.iz,
       h: section.h ?? 0.3,
       b: section.b ?? 0.15,
-      tw: (section as any).tw ?? (section.b ? section.b / 10 : 0.01),
-      tf: (section as any).tf ?? (section.b ? section.b / 15 : 0.01),
+      tw: section.tw ?? (section.b ? section.b / 10 : 0.01),
+      tf: section.tf ?? (section.b ? section.b / 15 : 0.01),
       L, Lb: L,
       J: section.j ?? 0,
     };


### PR DESCRIPTION
…g, a11y, type/report bugs

Six independent fixes, all present on current main:

- deploy-gh-pages.yml: drop --no-opt so the PRODUCTION WASM solver runs wasm-opt (binaryen) — the shipped binary was unoptimized (~15-40% slower/larger). CI keeps --no-opt for build speed.
- Toolbar.svelte (2D + 3D): solveCombinations{,3D} returning a string error (e.g. a load case is a mechanism) was silently dropped while the success toast fired anyway. Now surface the error.
- WhatIfPanel.svelte: four catch {/*ignore*/} blocks + silent string-error returns hid every singular/instability during what-if exploration, leaving stale results with no feedback. Capture and show it inline (a toast per 60ms re-solve tick would spam); clear on close.
- App.svelte: toast container had no live-region semantics. Each toast now announces to screen readers — errors assertive (role=alert), rest polite (role=status), aria-atomic.
- auto-verify.ts / verification-service.ts: AutoVerifyModelData declared its section/material maps too narrowly (no a/iz/iy/j/e), so the steel path read material.e / section.a etc. as TS2339 (runtime was fine — callers pass full objects). Widen the type to the optional fields actually read, add a presence guard in the steel path (narrows the types + skips malformed input), and drop three `as any` casts (fu/tw/tf).
- calc-report.ts: the element table read e.hingeStart/hingeEnd (removed in the typed-Release migration) → the hinge column was always "—". Use releaseI/releaseJ.mz.

Verified: vite build passes; auto-verify + calc-report suites green; the #2 TS2339s are resolved with no new errors. (Pre-existing, left as-is: harmless d.uy/d.rz legacy-field fallbacks in the calc-report 2D table, and some unused imports.)