### PR TITLE
perf(engine): assemble + factorize once for multi-case static solves

### DIFF
--- a/engine/benches/solver_bench.rs
+++ b/engine/benches/solver_bench.rs
@@ -1155,6 +1155,89 @@ fn bench_staged(c: &mut Criterion) {
     group.finish();
 }
 
+// ─── Multi-case load-case factorization reuse (3D frame, sparse path) ─────
+
+fn make_multi_case_input_3d(base: &SolverInput3D, n_cases: usize) -> dedaliano_engine::solver::load_cases::MultiCaseInput3D {
+    use dedaliano_engine::solver::load_cases::*;
+    let load_cases: Vec<LoadCase3D> = (0..n_cases)
+        .map(|k| {
+            let scale = 1.0 + k as f64 * 0.25;
+            let loads: Vec<SolverLoad3D> = base
+                .loads
+                .iter()
+                .map(|l| match l {
+                    SolverLoad3D::Nodal(nl) => SolverLoad3D::Nodal(SolverNodalLoad3D {
+                        node_id: nl.node_id,
+                        fx: nl.fx * scale,
+                        fy: nl.fy * scale,
+                        fz: nl.fz * scale,
+                        mx: nl.mx,
+                        my: nl.my,
+                        mz: nl.mz,
+                        bw: nl.bw,
+                    }),
+                    other => other.clone(),
+                })
+                .collect();
+            LoadCase3D { name: format!("Case{}", k + 1), loads }
+        })
+        .collect();
+    let factors: HashMap<String, f64> = load_cases
+        .iter()
+        .map(|lc| (lc.name.clone(), 1.0))
+        .collect();
+    MultiCaseInput3D {
+        solver: SolverInput3D { loads: vec![], ..base.clone() },
+        load_cases,
+        combinations: vec![CombinationDef { name: "All".to_string(), factors }],
+    }
+}
+
+fn bench_multi_case(c: &mut Criterion) {
+    let mut group = c.benchmark_group("multi_case");
+    let base = make_frame_3d(10, 3);
+
+    for n_cases in [1usize, 4, 16] {
+        let input = make_multi_case_input_3d(&base, n_cases);
+
+        // Baseline: N independent full solves (old multi-case behavior)
+        group.bench_with_input(BenchmarkId::new("naive_full_solves", n_cases), &input, |b, input| {
+            b.iter(|| {
+                for lc in &input.load_cases {
+                    let case_input = SolverInput3D {
+                        nodes: input.solver.nodes.clone(),
+                        materials: input.solver.materials.clone(),
+                        sections: input.solver.sections.clone(),
+                        elements: input.solver.elements.clone(),
+                        supports: input.solver.supports.clone(),
+                        loads: lc.loads.clone(),
+                        left_hand: input.solver.left_hand,
+                        plates: input.solver.plates.clone(),
+                        quads: input.solver.quads.clone(),
+                        quad9s: input.solver.quad9s.clone(),
+                        solid_shells: input.solver.solid_shells.clone(),
+                        curved_shells: input.solver.curved_shells.clone(),
+                        curved_beams: input.solver.curved_beams.clone(),
+                        constraints: vec![],
+                        connectors: HashMap::new(),
+                    };
+                    criterion::black_box(linear::solve_3d(&case_input).unwrap());
+                }
+            });
+        });
+
+        // New: prepared multi-case (assemble + factorize once, rebuild only f per case)
+        group.bench_with_input(BenchmarkId::new("prepared_multi_case", n_cases), &input, |b, input| {
+            b.iter(|| {
+                criterion::black_box(
+                    dedaliano_engine::solver::load_cases::solve_multi_case_3d(input).unwrap(),
+                );
+            });
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_json_roundtrip,
@@ -1169,6 +1252,7 @@ criterion_group!(
     bench_linear_frame_3d,
     bench_modal_3d,
     bench_pdelta_3d,
+    bench_multi_case,
     bench_moving_loads,
     bench_cable,
     bench_constraints,

--- a/engine/src/linalg/lu.rs
+++ b/engine/src/linalg/lu.rs
@@ -1,6 +1,7 @@
-/// LU decomposition with partial pivoting.
-/// Solves A*x = b. Returns None if singular.
-pub fn lu_solve(a: &mut [f64], b: &mut [f64], n: usize) -> Option<Vec<f64>> {
+/// LU factorization with partial pivoting (in-place).
+/// Returns the row permutation on success, None if singular.
+/// After the call, `a` holds the combined L-U factors (L below diagonal, unit diagonal implied).
+pub fn lu_factor(a: &mut [f64], n: usize) -> Option<Vec<usize>> {
     let mut piv = vec![0usize; n];
     for i in 0..n {
         piv[i] = i;
@@ -36,6 +37,12 @@ pub fn lu_solve(a: &mut [f64], b: &mut [f64], n: usize) -> Option<Vec<f64>> {
         }
     }
 
+    Some(piv)
+}
+
+/// Solve A*x = b given the in-place LU factors from `lu_factor`.
+/// Returns None if the solution contains NaN/Inf.
+pub fn lu_apply(a: &[f64], piv: &[usize], b: &[f64], n: usize) -> Option<Vec<f64>> {
     // Forward substitution (Ly = Pb)
     let mut y = vec![0.0; n];
     for i in 0..n {
@@ -63,6 +70,13 @@ pub fn lu_solve(a: &mut [f64], b: &mut [f64], n: usize) -> Option<Vec<f64>> {
     }
 
     Some(x)
+}
+
+/// LU decomposition with partial pivoting.
+/// Solves A*x = b. Returns None if singular.
+pub fn lu_solve(a: &mut [f64], b: &mut [f64], n: usize) -> Option<Vec<f64>> {
+    let piv = lu_factor(a, n)?;
+    lu_apply(a, &piv, b, n)
 }
 
 /// Compute rank of matrix via LU with partial pivoting.

--- a/engine/src/postprocess/combinations.rs
+++ b/engine/src/postprocess/combinations.rs
@@ -99,8 +99,16 @@ const N_POINTS: usize = 21;
 
 /// Linearly combine AnalysisResults from multiple load cases.
 pub fn combine_results(input: &CombinationInput) -> Option<AnalysisResults> {
-    let template = input.cases.first()?;
-    let tr = &template.results;
+    let cases: Vec<(usize, &AnalysisResults)> =
+        input.cases.iter().map(|c| (c.case_id, &c.results)).collect();
+    combine_results_refs(&input.factors, &cases)
+}
+
+/// `combine_results` over borrowed case results: `(case_id, &results)` pairs,
+/// avoiding per-combination clones of every case.
+pub fn combine_results_refs(factors: &[CombinationFactor], cases: &[(usize, &AnalysisResults)]) -> Option<AnalysisResults> {
+    let template = cases.first()?;
+    let tr = template.1;
 
     let mut displacements: Vec<Displacement> = tr.displacements.iter()
         .map(|d| Displacement { node_id: d.node_id, ux: 0.0, uz: 0.0, ry: 0.0 })
@@ -119,10 +127,10 @@ pub fn combine_results(input: &CombinationInput) -> Option<AnalysisResults> {
         })
         .collect();
 
-    for cf in &input.factors {
-        let case = input.cases.iter().find(|c| c.case_id == cf.case_id);
+    for cf in factors {
+        let case = cases.iter().find(|c| c.0 == cf.case_id);
         let r = match case {
-            Some(c) => &c.results,
+            Some(c) => c.1,
             None => continue,
         };
         let f = cf.factor;
@@ -251,8 +259,16 @@ pub fn compute_envelope(results: &[AnalysisResults]) -> Option<FullEnvelope> {
 
 /// Linearly combine 3D results.
 pub fn combine_results_3d(input: &CombinationInput3D) -> Option<AnalysisResults3D> {
-    let template = input.cases.first()?;
-    let tr = &template.results;
+    let cases: Vec<(usize, &AnalysisResults3D)> =
+        input.cases.iter().map(|c| (c.case_id, &c.results)).collect();
+    combine_results_3d_refs(&input.factors, &cases)
+}
+
+/// `combine_results_3d` over borrowed case results: `(case_id, &results)` pairs,
+/// avoiding per-combination clones of every case.
+pub fn combine_results_3d_refs(factors: &[CombinationFactor], cases: &[(usize, &AnalysisResults3D)]) -> Option<AnalysisResults3D> {
+    let template = cases.first()?;
+    let tr = template.1;
 
     let mut displacements: Vec<Displacement3D> = tr.displacements.iter()
         .map(|d| Displacement3D { node_id: d.node_id, ux: 0.0, uy: 0.0, uz: 0.0, rx: 0.0, ry: 0.0, rz: 0.0, warping: None })
@@ -274,9 +290,9 @@ pub fn combine_results_3d(input: &CombinationInput3D) -> Option<AnalysisResults3
             distributed_loads_z: Vec::new(), point_loads_z: Vec::new(), bimoment_start: None, bimoment_end: None })
         .collect();
 
-    for cf in &input.factors {
-        let case = input.cases.iter().find(|c| c.case_id == cf.case_id);
-        let r = match case { Some(c) => &c.results, None => continue };
+    for cf in factors {
+        let case = cases.iter().find(|c| c.0 == cf.case_id);
+        let r = match case { Some(c) => c.1, None => continue };
         let f = cf.factor;
 
         for (i, d) in r.displacements.iter().enumerate() {

--- a/engine/src/solver/assembly.rs
+++ b/engine/src/solver/assembly.rs
@@ -54,10 +54,8 @@ pub fn inclined_rotation_matrix_2d(theta: f64) -> [[f64; 2]; 2] {
     [[-c, s], [s, c]]
 }
 
-/// Apply 2D inclined support rotation to K and F at the given translational DOFs.
-/// Rotates rows/columns of K and entries of F using 2×2 R.
-fn apply_inclined_transform_2d(k: &mut [f64], f: &mut [f64], n: usize,
-                               dofs: &[usize; 2], r: &[[f64; 2]; 2]) {
+/// Rotate rows/columns of K at the given translational DOFs using 2×2 R (2D inclined support).
+fn rotate_inclined_k_2d(k: &mut [f64], n: usize, dofs: &[usize; 2], r: &[[f64; 2]; 2]) {
     // Rotate columns: for each row i, K[i, dofs] = K[i, dofs_orig] * R^T
     for i in 0..n {
         let mut vals = [0.0; 2];
@@ -86,7 +84,10 @@ fn apply_inclined_transform_2d(k: &mut [f64], f: &mut [f64], n: usize,
             k[dofs[a] * n + j] = sum;
         }
     }
-    // Rotate force: F[dofs] = R * F[dofs_orig]
+}
+
+/// Rotate force vector at the given DOFs: F[dofs] = R * F[dofs_orig] (2D inclined support).
+pub fn rotate_inclined_f_2d(f: &mut [f64], dofs: &[usize; 2], r: &[[f64; 2]; 2]) {
     let mut fv = [0.0; 2];
     for a in 0..2 {
         fv[a] = f[dofs[a]];
@@ -138,10 +139,8 @@ pub fn inclined_rotation_matrix(nx: f64, ny: f64, nz: f64) -> [[f64; 3]; 3] {
     [e1, e2, e3] // rows of R
 }
 
-/// Apply inclined support rotation to K and F at the given translational DOFs.
-/// Rotates rows/columns of K and entries of F using R.
-fn apply_inclined_transform(k: &mut [f64], f: &mut [f64], n: usize,
-                            dofs: &[usize; 3], r: &[[f64; 3]; 3]) {
+/// Rotate rows/columns of K at the given translational DOFs using R (3D inclined support).
+fn rotate_inclined_k_3d(k: &mut [f64], n: usize, dofs: &[usize; 3], r: &[[f64; 3]; 3]) {
     // Rotate columns: for each row i, K[i, dofs] = K[i, dofs_orig] * R^T
     for i in 0..n {
         let mut vals = [0.0; 3];
@@ -170,7 +169,10 @@ fn apply_inclined_transform(k: &mut [f64], f: &mut [f64], n: usize,
             k[dofs[a] * n + j] = sum;
         }
     }
-    // Rotate force: F[dofs] = R * F[dofs_orig]
+}
+
+/// Rotate force vector at the given DOFs: F[dofs] = R * F[dofs_orig] (3D inclined support).
+pub fn rotate_inclined_f_3d(f: &mut [f64], dofs: &[usize; 3], r: &[[f64; 3]; 3]) {
     let mut fv = [0.0; 3];
     for a in 0..3 {
         fv[a] = f[dofs[a]];
@@ -199,11 +201,19 @@ pub fn reverse_inclined_transform(u: &mut [f64], dofs: &[usize; 3], r: &[[f64; 3
     }
 }
 
-/// Assemble global stiffness matrix and force vector for 2D.
-pub fn assemble_2d(input: &SolverInput, dof_num: &DofNumbering) -> AssemblyResult {
+/// Stiffness-only assembly result for 2D (K with inclined support transforms applied).
+pub struct StiffnessAssembly2D {
+    pub k: Vec<f64>,
+    pub max_diag_k: f64,
+    pub artificial_dofs: Vec<usize>,
+    pub inclined_transforms_2d: Vec<InclinedTransformData2D>,
+}
+
+/// Assemble the global stiffness matrix for 2D (load-independent).
+/// The force vector is assembled separately by `assemble_load_vector_2d`.
+pub fn assemble_stiffness_2d(input: &SolverInput, dof_num: &DofNumbering) -> StiffnessAssembly2D {
     let n = dof_num.n_total;
     let mut k_global = vec![0.0; n * n];
-    let mut f_global = vec![0.0; n];
 
     // Pre-build O(1) lookup maps
     let node_map: std::collections::HashMap<usize, &SolverNode> =
@@ -244,22 +254,6 @@ pub fn assemble_2d(input: &SolverInput, dof_num: &DofNumbering) -> AssemblyResul
                     k_global[truss_dofs[i] * n + truss_dofs[j]] += k_elem[i * ndof + j];
                 }
             }
-
-            // Assemble thermal FEF for 2D truss elements.
-            // Convention matches fef_thermal_2d: node I gets -fx, node J gets +fx (local axial).
-            // Transform to global: node I gets -fx*[cos, sin], node J gets +fx*[cos, sin].
-            for load in &input.loads {
-                if let SolverLoad::Thermal(tl) = load {
-                    if tl.element_id == elem.id {
-                        let alpha = 12e-6; // Steel default
-                        let fx = e * sec.a * alpha * tl.dt_uniform;
-                        f_global[truss_dofs[0]] += -fx * cos;  // node I, x
-                        f_global[truss_dofs[1]] += -fx * sin;  // node I, z
-                        f_global[truss_dofs[2]] +=  fx * cos;  // node J, x
-                        f_global[truss_dofs[3]] +=  fx * sin;  // node J, z
-                    }
-                }
-            }
         } else {
             // Frame element
             let phi = if let Some(as_y) = sec.as_y {
@@ -280,11 +274,6 @@ pub fn assemble_2d(input: &SolverInput, dof_num: &DofNumbering) -> AssemblyResul
                     k_global[elem_dofs[i] * n + elem_dofs[j]] += k_glob[i * ndof + j];
                 }
             }
-
-            // Assemble element loads (FEF)
-            assemble_element_loads_2d(
-                input, elem, &k_local, &t, l, e, sec, node_i, &elem_dofs, &mut f_global,
-            );
         }
     }
 
@@ -293,23 +282,6 @@ pub fn assemble_2d(input: &SolverInput, dof_num: &DofNumbering) -> AssemblyResul
         crate::element::connector::assemble_connectors_2d(
             &input.connectors, &input.nodes, dof_num, &mut k_global, n,
         );
-    }
-
-    // Assemble nodal loads
-    for load in &input.loads {
-        if let SolverLoad::Nodal(nl) = load {
-            if let Some(&d) = dof_num.map.get(&(nl.node_id, 0)) {
-                f_global[d] += nl.fx;
-            }
-            if let Some(&d) = dof_num.map.get(&(nl.node_id, 1)) {
-                f_global[d] += nl.fz;
-            }
-            if dof_num.dofs_per_node >= 3 {
-                if let Some(&d) = dof_num.map.get(&(nl.node_id, 2)) {
-                    f_global[d] += nl.my;
-                }
-            }
-        }
     }
 
     // Add spring stiffness (with rotation support for springs with angle)
@@ -468,7 +440,8 @@ pub fn assemble_2d(input: &SolverInput, dof_num: &DofNumbering) -> AssemblyResul
         }
     }
 
-    // Apply 2D inclined support transformations
+    // Apply 2D inclined support transformations (stiffness only; the force
+    // vector rotation happens in `assemble_load_vector_2d`)
     let mut inclined_transforms_2d = Vec::new();
     for sup in input.supports.values() {
         if sup.support_type == "inclinedRoller" {
@@ -484,7 +457,7 @@ pub fn assemble_2d(input: &SolverInput, dof_num: &DofNumbering) -> AssemblyResul
                     dof_num.map.get(&(sup.node_id, 1)),
                 ) {
                     let dofs = [d0, d1];
-                    apply_inclined_transform_2d(&mut k_global, &mut f_global, n, &dofs, &r);
+                    rotate_inclined_k_2d(&mut k_global, n, &dofs, &r);
                     inclined_transforms_2d.push(InclinedTransformData2D {
                         node_id: sup.node_id,
                         dofs,
@@ -495,30 +468,141 @@ pub fn assemble_2d(input: &SolverInput, dof_num: &DofNumbering) -> AssemblyResul
         }
     }
 
-    AssemblyResult {
+    StiffnessAssembly2D {
         k: k_global,
-        f: f_global,
         max_diag_k: max_diag,
         artificial_dofs,
-        inclined_transforms: Vec::new(),
         inclined_transforms_2d,
+    }
+}
+
+/// Assemble the global force vector for 2D for a given set of loads
+/// (with inclined support rotations applied). Produces exactly the same `f`
+/// as `assemble_2d` would on the same loads.
+pub fn assemble_load_vector_2d(
+    input: &SolverInput,
+    loads: &[SolverLoad],
+    dof_num: &DofNumbering,
+    inclined_transforms_2d: &[InclinedTransformData2D],
+) -> Vec<f64> {
+    let n = dof_num.n_total;
+    let mut f_global = vec![0.0; n];
+
+    // Pre-build O(1) lookup maps
+    let node_map: std::collections::HashMap<usize, &SolverNode> =
+        input.nodes.values().map(|n| (n.id, n)).collect();
+    let mat_map: std::collections::HashMap<usize, &SolverMaterial> =
+        input.materials.values().map(|m| (m.id, m)).collect();
+    let sec_map: std::collections::HashMap<usize, &SolverSection> =
+        input.sections.values().map(|s| (s.id, s)).collect();
+
+    // Index elements carrying element-bound loads so unloaded elements are skipped
+    let mut loaded_elems: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    for load in loads {
+        match load {
+            SolverLoad::Distributed(dl) => { loaded_elems.insert(dl.element_id); }
+            SolverLoad::PointOnElement(pl) => { loaded_elems.insert(pl.element_id); }
+            SolverLoad::Thermal(tl) => { loaded_elems.insert(tl.element_id); }
+            _ => {}
+        }
+    }
+
+    // Assemble element loads (FEF) — same element iteration order as assemble_stiffness_2d
+    for elem in input.elements.values() {
+        if !loaded_elems.contains(&elem.id) { continue; }
+
+        let node_i = node_map[&elem.node_i];
+        let node_j = node_map[&elem.node_j];
+        let mat = mat_map[&elem.material_id];
+        let sec = sec_map[&elem.section_id];
+
+        let dx = node_j.x - node_i.x;
+        let dy = node_j.z - node_i.z;
+        let l = (dx * dx + dy * dy).sqrt();
+        let cos = dx / l;
+        let sin = dy / l;
+        let e = mat.e * 1000.0; // MPa → kN/m²
+
+        if elem.elem_type == "truss" || elem.elem_type == "cable" {
+            // Assemble thermal FEF for 2D truss elements.
+            // Convention matches fef_thermal_2d: node I gets -fx, node J gets +fx (local axial).
+            // Transform to global: node I gets -fx*[cos, sin], node J gets +fx*[cos, sin].
+            let truss_dofs = [
+                dof_num.global_dof(elem.node_i, 0).unwrap(),
+                dof_num.global_dof(elem.node_i, 1).unwrap(),
+                dof_num.global_dof(elem.node_j, 0).unwrap(),
+                dof_num.global_dof(elem.node_j, 1).unwrap(),
+            ];
+            for load in loads {
+                if let SolverLoad::Thermal(tl) = load {
+                    if tl.element_id == elem.id {
+                        let alpha = 12e-6; // Steel default
+                        let fx = e * sec.a * alpha * tl.dt_uniform;
+                        f_global[truss_dofs[0]] += -fx * cos;  // node I, x
+                        f_global[truss_dofs[1]] += -fx * sin;  // node I, z
+                        f_global[truss_dofs[2]] +=  fx * cos;  // node J, x
+                        f_global[truss_dofs[3]] +=  fx * sin;  // node J, z
+                    }
+                }
+            }
+        } else {
+            let t = frame_transform_2d(cos, sin);
+            let elem_dofs = dof_num.element_dofs(elem.node_i, elem.node_j);
+            assemble_element_loads_2d(loads, elem, &t, l, e, sec, &elem_dofs, &mut f_global);
+        }
+    }
+
+    // Assemble nodal loads
+    for load in loads {
+        if let SolverLoad::Nodal(nl) = load {
+            if let Some(&d) = dof_num.map.get(&(nl.node_id, 0)) {
+                f_global[d] += nl.fx;
+            }
+            if let Some(&d) = dof_num.map.get(&(nl.node_id, 1)) {
+                f_global[d] += nl.fz;
+            }
+            if dof_num.dofs_per_node >= 3 {
+                if let Some(&d) = dof_num.map.get(&(nl.node_id, 2)) {
+                    f_global[d] += nl.my;
+                }
+            }
+        }
+    }
+
+    // Apply 2D inclined support rotations to the force vector
+    for it in inclined_transforms_2d {
+        rotate_inclined_f_2d(&mut f_global, &it.dofs, &it.r);
+    }
+
+    f_global
+}
+
+/// Assemble global stiffness matrix and force vector for 2D.
+pub fn assemble_2d(input: &SolverInput, dof_num: &DofNumbering) -> AssemblyResult {
+    let stiff = assemble_stiffness_2d(input, dof_num);
+    let f = assemble_load_vector_2d(input, &input.loads, dof_num, &stiff.inclined_transforms_2d);
+    AssemblyResult {
+        k: stiff.k,
+        f,
+        max_diag_k: stiff.max_diag_k,
+        artificial_dofs: stiff.artificial_dofs,
+        inclined_transforms: Vec::new(),
+        inclined_transforms_2d: stiff.inclined_transforms_2d,
         diagnostics: Vec::new(),
     }
 }
 
 pub fn assemble_element_loads_2d(
-    input: &SolverInput,
+    loads: &[SolverLoad],
     elem: &SolverElement,
-    _k_local: &[f64],
     t: &[f64],
     l: f64,
     e: f64,
     sec: &SolverSection,
-    _node_i: &SolverNode,
     elem_dofs: &[usize],
     f_global: &mut [f64],
 ) {
-    for load in &input.loads {
+    for load in loads {
         match load {
             SolverLoad::Distributed(dl) if dl.element_id == elem.id => {
                 let a = dl.a.unwrap_or(0.0);
@@ -573,11 +657,20 @@ pub fn assemble_element_loads_2d(
     }
 }
 
-/// Assemble global stiffness matrix and force vector for 3D.
-pub fn assemble_3d(input: &SolverInput3D, dof_num: &DofNumbering) -> AssemblyResult {
+/// Stiffness-only assembly result for 3D (K with inclined support transforms applied).
+pub struct StiffnessAssembly3D {
+    pub k: Vec<f64>,
+    pub max_diag_k: f64,
+    pub artificial_dofs: Vec<usize>,
+    pub inclined_transforms: Vec<InclinedTransformData>,
+    pub diagnostics: Vec<crate::types::AssemblyDiagnostic>,
+}
+
+/// Assemble the global stiffness matrix for 3D (load-independent).
+/// The force vector is assembled separately by `assemble_load_vector_3d_dense`.
+pub fn assemble_stiffness_3d(input: &SolverInput3D, dof_num: &DofNumbering) -> StiffnessAssembly3D {
     let n = dof_num.n_total;
     let mut k_global = vec![0.0; n * n];
-    let mut f_global = vec![0.0; n];
     let left_hand = input.left_hand.unwrap_or(false);
 
     // Pre-build O(1) lookup maps
@@ -587,10 +680,6 @@ pub fn assemble_3d(input: &SolverInput3D, dof_num: &DofNumbering) -> AssemblyRes
         input.materials.values().map(|m| (m.id, m)).collect();
     let sec_map: std::collections::HashMap<usize, &SolverSection3D> =
         input.sections.values().map(|s| (s.id, s)).collect();
-    let plate_map: std::collections::HashMap<usize, &SolverPlateElement> =
-        input.plates.values().map(|p| (p.id, p)).collect();
-    let quad_map: std::collections::HashMap<usize, &SolverQuadElement> =
-        input.quads.values().map(|q| (q.id, q)).collect();
 
     // Sort elements for deterministic assembly (HashMap iteration order is randomized)
     let mut sorted_dense_elems: Vec<&SolverElement3D> = input.elements.values().collect();
@@ -615,22 +704,6 @@ pub fn assemble_3d(input: &SolverInput3D, dof_num: &DofNumbering) -> AssemblyRes
             let ea_l = e * sec.a / l;
             let dir = [dx / l, dy / l, dz / l];
             scatter_truss_3d(&mut k_global, n, ea_l, &dir, elem.node_i, elem.node_j, &dof_num.map);
-
-            // Assemble thermal FEF for truss elements
-            let dpn = dof_num.dofs_per_node;
-            for load in &input.loads {
-                if let SolverLoad3D::Thermal(tl) = load {
-                    if tl.element_id == elem.id {
-                        let alpha = 12e-6; // Steel default
-                        let fx = e * sec.a * alpha * tl.dt_uniform;
-                        // Equivalent nodal loads: node I ← -fx along axis, node J ← +fx along axis
-                        for k in 0..3 {
-                            f_global[elem_dofs[k]]       += -fx * dir[k]; // node I
-                            f_global[elem_dofs[dpn + k]] +=  fx * dir[k]; // node J
-                        }
-                    }
-                }
-            }
         } else {
             // 3D frame element
             let (ex, ey, ez) = compute_local_axes_3d(
@@ -641,7 +714,7 @@ pub fn assemble_3d(input: &SolverInput3D, dof_num: &DofNumbering) -> AssemblyRes
                 left_hand,
             );
 
-            let has_cw = sec.cw.map_or(false, |cw| cw > 0.0);
+            let has_cw = sec.cw.is_some_and(|cw| cw > 0.0);
 
             // Compute Timoshenko shear parameters for each bending plane
             let (phi_y, phi_z) = if sec.as_y.is_some() || sec.as_z.is_some() {
@@ -669,9 +742,6 @@ pub fn assemble_3d(input: &SolverInput3D, dof_num: &DofNumbering) -> AssemblyRes
                         k_global[elem_dofs[i] * n + elem_dofs[j]] += k_glob[i * ndof + j];
                     }
                 }
-
-                // Assemble element loads with 14-DOF transform
-                assemble_element_loads_3d_warping(input, elem, &t, l, e, sec, &elem_dofs, &mut f_global, phi_y, phi_z);
             } else if dof_num.dofs_per_node >= 7 {
                 // Non-warping element in a warping model: 12×12 math mapped via DOF_MAP_12_TO_14
                 let k_local = frame_local_stiffness_3d(
@@ -689,9 +759,6 @@ pub fn assemble_3d(input: &SolverInput3D, dof_num: &DofNumbering) -> AssemblyRes
                         k_global[gi * n + gj] += k_glob[i * 12 + j];
                     }
                 }
-
-                // Assemble element loads with 12-DOF transform, mapped to 14-DOF space
-                assemble_element_loads_3d_mapped(input, elem, &t, l, e, sec, &elem_dofs, &mut f_global, phi_y, phi_z);
             } else {
                 // Standard 6-DOF-per-node path
                 let k_local = frame_local_stiffness_3d(
@@ -708,9 +775,6 @@ pub fn assemble_3d(input: &SolverInput3D, dof_num: &DofNumbering) -> AssemblyRes
                         k_global[elem_dofs[i] * n + elem_dofs[j]] += k_glob[i * ndof + j];
                     }
                 }
-
-                // Assemble 3D element loads
-                assemble_element_loads_3d(input, elem, &t, l, e, sec, &elem_dofs, &mut f_global, phi_y, phi_z);
             }
         }
     }
@@ -842,8 +906,331 @@ pub fn assemble_3d(input: &SolverInput3D, dof_num: &DofNumbering) -> AssemblyRes
         );
     }
 
+    // Add 3D spring stiffness
+    for sup in input.supports.values() {
+        let springs = [sup.kx, sup.ky, sup.kz, sup.krx, sup.kry, sup.krz];
+        for (i, ks) in springs.iter().enumerate() {
+            if let Some(k) = ks {
+                if *k > 0.0 && i < dof_num.dofs_per_node {
+                    if let Some(&d) = dof_num.map.get(&(sup.node_id, i)) {
+                        k_global[d * n + d] += k;
+                    }
+                }
+            }
+        }
+        // Warping spring (DOF 6)
+        if dof_num.dofs_per_node >= 7 {
+            if let Some(kw) = sup.kw {
+                if kw > 0.0 {
+                    if let Some(&d) = dof_num.map.get(&(sup.node_id, 6)) {
+                        k_global[d * n + d] += kw;
+                    }
+                }
+            }
+        }
+    }
+
+    let mut max_diag = 0.0f64;
+    for i in 0..n {
+        max_diag = max_diag.max(k_global[i * n + i].abs());
+    }
+
+    // Add artificial stiffness at warping DOFs for nodes with no warping stiffness.
+    // This prevents a singular matrix when some elements lack warping.
+    let mut artificial_dofs_3d = Vec::new();
+    if dof_num.dofs_per_node >= 7 {
+        let artificial_k = if max_diag > 0.0 { max_diag * 1e-10 } else { 1e-6 };
+        for &node_id in &dof_num.node_order {
+            if let Some(&d) = dof_num.map.get(&(node_id, 6)) {
+                if d < dof_num.n_free && k_global[d * n + d].abs() < 1e-20 {
+                    k_global[d * n + d] += artificial_k;
+                    artificial_dofs_3d.push(d);
+                }
+            }
+        }
+    }
+
+    // Apply inclined support transformations (stiffness only; the force
+    // vector rotation happens in `assemble_load_vector_3d_dense`)
+    let mut inclined_transforms = Vec::new();
+    for sup in input.supports.values() {
+        if sup.is_inclined.unwrap_or(false) {
+            if let (Some(nx), Some(ny), Some(nz)) = (sup.normal_x, sup.normal_y, sup.normal_z) {
+                let n_len = (nx * nx + ny * ny + nz * nz).sqrt();
+                if n_len > 1e-12 {
+                    let r = inclined_rotation_matrix(nx, ny, nz);
+                    if let (Some(&d0), Some(&d1), Some(&d2)) = (
+                        dof_num.map.get(&(sup.node_id, 0)),
+                        dof_num.map.get(&(sup.node_id, 1)),
+                        dof_num.map.get(&(sup.node_id, 2)),
+                    ) {
+                        let dofs = [d0, d1, d2];
+                        rotate_inclined_k_3d(&mut k_global, n, &dofs, &r);
+                        inclined_transforms.push(InclinedTransformData {
+                            node_id: sup.node_id,
+                            dofs,
+                            r,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // Element quality diagnostics
+    let mut diagnostics = Vec::new();
+
+    for plate in input.plates.values() {
+        let n0 = node_map[&plate.nodes[0]];
+        let n1 = node_map[&plate.nodes[1]];
+        let n2 = node_map[&plate.nodes[2]];
+        let coords = [
+            [n0.x, n0.y, n0.z],
+            [n1.x, n1.y, n1.z],
+            [n2.x, n2.y, n2.z],
+        ];
+        let (aspect_ratio, _skew, min_angle) = crate::element::plate_element_quality(&coords);
+        if aspect_ratio > 10.0 {
+            diagnostics.push(crate::types::AssemblyDiagnostic {
+                element_id: plate.id,
+                element_type: "plate".into(),
+                metric: "aspect_ratio".into(),
+                value: aspect_ratio,
+                threshold: 10.0,
+                message: format!("Plate {} aspect ratio {:.1} exceeds 10", plate.id, aspect_ratio),
+            });
+        }
+        if min_angle < 10.0 {
+            diagnostics.push(crate::types::AssemblyDiagnostic {
+                element_id: plate.id,
+                element_type: "plate".into(),
+                metric: "min_angle".into(),
+                value: min_angle,
+                threshold: 10.0,
+                message: format!("Plate {} min angle {:.1}° below 10°", plate.id, min_angle),
+            });
+        }
+    }
+
+    for quad in input.quads.values() {
+        let qn0 = node_map[&quad.nodes[0]];
+        let qn1 = node_map[&quad.nodes[1]];
+        let qn2 = node_map[&quad.nodes[2]];
+        let qn3 = node_map[&quad.nodes[3]];
+        let coords = [
+            [qn0.x, qn0.y, qn0.z],
+            [qn1.x, qn1.y, qn1.z],
+            [qn2.x, qn2.y, qn2.z],
+            [qn3.x, qn3.y, qn3.z],
+        ];
+        let qm = crate::element::quad::quad_quality_metrics(&coords);
+        let (_, _, has_neg_j) = crate::element::quad::quad_check_jacobian(&coords);
+        if has_neg_j {
+            diagnostics.push(crate::types::AssemblyDiagnostic {
+                element_id: quad.id,
+                element_type: "quad".into(),
+                metric: "negative_jacobian".into(),
+                value: -1.0,
+                threshold: 0.0,
+                message: format!("Quad {} has negative Jacobian determinant (inverted element)", quad.id),
+            });
+        }
+        if qm.aspect_ratio > 10.0 {
+            diagnostics.push(crate::types::AssemblyDiagnostic {
+                element_id: quad.id,
+                element_type: "quad".into(),
+                metric: "aspect_ratio".into(),
+                value: qm.aspect_ratio,
+                threshold: 10.0,
+                message: format!("Quad {} aspect ratio {:.1} exceeds 10", quad.id, qm.aspect_ratio),
+            });
+        }
+        if qm.warping > 0.01 && qm.warping <= 0.1 {
+            diagnostics.push(crate::types::AssemblyDiagnostic {
+                element_id: quad.id,
+                element_type: "quad".into(),
+                metric: "warping_moderate".into(),
+                value: qm.warping,
+                threshold: 0.01,
+                message: format!("Quad {} moderate warping {:.3} (0.01-0.1 range)", quad.id, qm.warping),
+            });
+        }
+        if qm.warping > 0.1 {
+            diagnostics.push(crate::types::AssemblyDiagnostic {
+                element_id: quad.id,
+                element_type: "quad".into(),
+                metric: "warping".into(),
+                value: qm.warping,
+                threshold: 0.1,
+                message: format!("Quad {} warping {:.3} exceeds 0.1", quad.id, qm.warping),
+            });
+        }
+        if qm.jacobian_ratio < 0.1 {
+            diagnostics.push(crate::types::AssemblyDiagnostic {
+                element_id: quad.id,
+                element_type: "quad".into(),
+                metric: "jacobian_ratio".into(),
+                value: qm.jacobian_ratio,
+                threshold: 0.1,
+                message: format!("Quad {} jacobian ratio {:.3} below 0.1", quad.id, qm.jacobian_ratio),
+            });
+        }
+    }
+
+    // Quad9 diagnostics (dense path)
+    for q9 in input.quad9s.values() {
+        let coords = quad9_coords(&node_map, q9);
+        let (_, _, has_neg_j) = crate::element::quad9::quad9_check_jacobian(&coords);
+        if has_neg_j {
+            diagnostics.push(crate::types::AssemblyDiagnostic {
+                element_id: q9.id, element_type: "quad9".into(), metric: "negative_jacobian".into(),
+                value: -1.0, threshold: 0.0,
+                message: format!("Quad9 {} has negative Jacobian determinant (inverted element)", q9.id),
+            });
+        }
+    }
+
+    StiffnessAssembly3D {
+        k: k_global,
+        max_diag_k: max_diag,
+        artificial_dofs: artificial_dofs_3d,
+        inclined_transforms,
+        diagnostics,
+    }
+}
+
+/// Frame/truss element load contributions (FEF + truss thermal) for 3D.
+/// Shared by the dense and sequential-sparse load-vector builders; iterates
+/// frame/truss elements sorted by ID, exactly like the fused assemblers did.
+fn assemble_frame_loads_3d(
+    input: &SolverInput3D,
+    loads: &[SolverLoad3D],
+    dof_num: &DofNumbering,
+    f_global: &mut [f64],
+) {
+    // Index elements carrying element-bound loads so unloaded elements are skipped
+    let mut loaded_elems: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    for load in loads {
+        match load {
+            SolverLoad3D::Distributed(dl) => { loaded_elems.insert(dl.element_id); }
+            SolverLoad3D::PointOnElement(pl) => { loaded_elems.insert(pl.element_id); }
+            SolverLoad3D::Thermal(tl) => { loaded_elems.insert(tl.element_id); }
+            _ => {}
+        }
+    }
+    if loaded_elems.is_empty() {
+        return;
+    }
+
+    let node_map: std::collections::HashMap<usize, &SolverNode3D> =
+        input.nodes.values().map(|n| (n.id, n)).collect();
+    let mat_map: std::collections::HashMap<usize, &SolverMaterial> =
+        input.materials.values().map(|m| (m.id, m)).collect();
+    let sec_map: std::collections::HashMap<usize, &SolverSection3D> =
+        input.sections.values().map(|s| (s.id, s)).collect();
+    let left_hand = input.left_hand.unwrap_or(false);
+
+    let mut sorted_elems: Vec<&SolverElement3D> = input.elements.values().collect();
+    sorted_elems.sort_by_key(|e| e.id);
+    for elem in sorted_elems {
+        if !loaded_elems.contains(&elem.id) { continue; }
+
+        let node_i = node_map[&elem.node_i];
+        let node_j = node_map[&elem.node_j];
+        let mat = mat_map[&elem.material_id];
+        let sec = sec_map[&elem.section_id];
+
+        let dx = node_j.x - node_i.x;
+        let dy = node_j.y - node_i.y;
+        let dz = node_j.z - node_i.z;
+        let l = (dx * dx + dy * dy + dz * dz).sqrt();
+        let e = mat.e * 1000.0;
+        let g = e / (2.0 * (1.0 + mat.nu));
+
+        if elem.elem_type == "truss" || elem.elem_type == "cable" {
+            // Assemble thermal FEF for truss elements
+            let dir = [dx / l, dy / l, dz / l];
+            for load in loads {
+                if let SolverLoad3D::Thermal(tl) = load {
+                    if tl.element_id == elem.id {
+                        let alpha = 12e-6; // Steel default
+                        let fx = e * sec.a * alpha * tl.dt_uniform;
+                        // Equivalent nodal loads: node I ← -fx along axis, node J ← +fx along axis
+                        for k in 0..3 {
+                            if let Some(&d) = dof_num.map.get(&(elem.node_i, k)) {
+                                f_global[d] += -fx * dir[k];
+                            }
+                            if let Some(&d) = dof_num.map.get(&(elem.node_j, k)) {
+                                f_global[d] += fx * dir[k];
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            let (ex, ey, ez) = compute_local_axes_3d(
+                node_i.x, node_i.y, node_i.z,
+                node_j.x, node_j.y, node_j.z,
+                elem.local_yx, elem.local_yy, elem.local_yz,
+                elem.roll_angle,
+                left_hand,
+            );
+
+            let has_cw = sec.cw.is_some_and(|cw| cw > 0.0);
+
+            // Compute Timoshenko shear parameters for each bending plane
+            let (phi_y, phi_z) = if sec.as_y.is_some() || sec.as_z.is_some() {
+                let l2 = l * l;
+                let py = sec.as_y.map(|ay| 12.0 * e * sec.iy / (g * ay * l2)).unwrap_or(0.0);
+                let pz = sec.as_z.map(|az| 12.0 * e * sec.iz / (g * az * l2)).unwrap_or(0.0);
+                (py, pz)
+            } else {
+                (0.0, 0.0)
+            };
+
+            let elem_dofs = dof_num.element_dofs(elem.node_i, elem.node_j);
+
+            if has_cw && dof_num.dofs_per_node >= 7 {
+                let t = frame_transform_3d_warping(&ex, &ey, &ez);
+                assemble_element_loads_3d_warping(loads, elem, &t, l, e, sec, &elem_dofs, f_global, phi_y, phi_z);
+            } else if dof_num.dofs_per_node >= 7 {
+                let t = frame_transform_3d(&ex, &ey, &ez);
+                assemble_element_loads_3d_mapped(loads, elem, &t, l, e, sec, &elem_dofs, f_global, phi_y, phi_z);
+            } else {
+                let t = frame_transform_3d(&ex, &ey, &ez);
+                assemble_element_loads_3d(loads, elem, &t, l, e, sec, &elem_dofs, f_global, phi_y, phi_z);
+            }
+        }
+    }
+}
+
+/// Assemble the global force vector for 3D for a given set of loads, dense-path
+/// flavor (with inclined support rotations applied). Produces exactly the same
+/// `f` as `assemble_3d` would on the same loads.
+pub fn assemble_load_vector_3d_dense(
+    input: &SolverInput3D,
+    loads: &[SolverLoad3D],
+    dof_num: &DofNumbering,
+    inclined_transforms: &[InclinedTransformData],
+) -> Vec<f64> {
+    let n = dof_num.n_total;
+    let mut f_global = vec![0.0; n];
+
+    // Pre-build O(1) lookup maps
+    let node_map: std::collections::HashMap<usize, &SolverNode3D> =
+        input.nodes.values().map(|n| (n.id, n)).collect();
+    let mat_map: std::collections::HashMap<usize, &SolverMaterial> =
+        input.materials.values().map(|m| (m.id, m)).collect();
+    let plate_map: std::collections::HashMap<usize, &SolverPlateElement> =
+        input.plates.values().map(|p| (p.id, p)).collect();
+    let quad_map: std::collections::HashMap<usize, &SolverQuadElement> =
+        input.quads.values().map(|q| (q.id, q)).collect();
+
+    // Frame/truss element loads (FEF + thermal)
+    assemble_frame_loads_3d(input, loads, dof_num, &mut f_global);
+
     // Assemble 3D nodal loads
-    for load in &input.loads {
+    for load in loads {
         if let SolverLoad3D::Nodal(nl) = load {
             let forces = [nl.fx, nl.fy, nl.fz, nl.mx, nl.my, nl.mz];
             for (i, &f) in forces.iter().enumerate() {
@@ -1021,7 +1408,7 @@ pub fn assemble_3d(input: &SolverInput3D, dof_num: &DofNumbering) -> AssemblyRes
     // Quad9 (MITC9) load dispatch — dense path
     let quad9_map: std::collections::HashMap<usize, &SolverQuad9Element> =
         input.quad9s.values().map(|q| (q.id, q)).collect();
-    for load in &input.loads {
+    for load in loads {
         if let SolverLoad3D::Quad9Pressure(pl) = load {
             if let Some(&q9) = quad9_map.get(&pl.element_id) {
                 let coords = quad9_coords(&node_map, q9);
@@ -1077,7 +1464,7 @@ pub fn assemble_3d(input: &SolverInput3D, dof_num: &DofNumbering) -> AssemblyRes
     // Solid-shell load dispatch — dense path
     let ss_map: std::collections::HashMap<usize, &SolverSolidShellElement> =
         input.solid_shells.values().map(|s| (s.id, s)).collect();
-    for load in &input.loads {
+    for load in loads {
         if let SolverLoad3D::SolidShellPressure(pl) = load {
             if let Some(&ss) = ss_map.get(&pl.element_id) {
                 let coords = solid_shell_coords(&node_map, ss);
@@ -1105,7 +1492,7 @@ pub fn assemble_3d(input: &SolverInput3D, dof_num: &DofNumbering) -> AssemblyRes
     // Curved shell load dispatch — dense path
     let cs_map: std::collections::HashMap<usize, &SolverCurvedShellElement> =
         input.curved_shells.values().map(|s| (s.id, s)).collect();
-    for load in &input.loads {
+    for load in loads {
         if let SolverLoad3D::CurvedShellPressure(pl) = load {
             if let Some(&cs) = cs_map.get(&pl.element_id) {
                 let coords = curved_shell_coords(&node_map, cs);
@@ -1162,202 +1549,31 @@ pub fn assemble_3d(input: &SolverInput3D, dof_num: &DofNumbering) -> AssemblyRes
         }
     }
 
-    // Add 3D spring stiffness
-    for sup in input.supports.values() {
-        let springs = [sup.kx, sup.ky, sup.kz, sup.krx, sup.kry, sup.krz];
-        for (i, ks) in springs.iter().enumerate() {
-            if let Some(k) = ks {
-                if *k > 0.0 && i < dof_num.dofs_per_node {
-                    if let Some(&d) = dof_num.map.get(&(sup.node_id, i)) {
-                        k_global[d * n + d] += k;
-                    }
-                }
-            }
-        }
-        // Warping spring (DOF 6)
-        if dof_num.dofs_per_node >= 7 {
-            if let Some(kw) = sup.kw {
-                if kw > 0.0 {
-                    if let Some(&d) = dof_num.map.get(&(sup.node_id, 6)) {
-                        k_global[d * n + d] += kw;
-                    }
-                }
-            }
-        }
+    // Apply inclined support rotations to the force vector
+    for it in inclined_transforms {
+        rotate_inclined_f_3d(&mut f_global, &it.dofs, &it.r);
     }
 
-    let mut max_diag = 0.0f64;
-    for i in 0..n {
-        max_diag = max_diag.max(k_global[i * n + i].abs());
-    }
+    f_global
+}
 
-    // Add artificial stiffness at warping DOFs for nodes with no warping stiffness.
-    // This prevents a singular matrix when some elements lack warping.
-    let mut artificial_dofs_3d = Vec::new();
-    if dof_num.dofs_per_node >= 7 {
-        let artificial_k = if max_diag > 0.0 { max_diag * 1e-10 } else { 1e-6 };
-        for &node_id in &dof_num.node_order {
-            if let Some(&d) = dof_num.map.get(&(node_id, 6)) {
-                if d < dof_num.n_free && k_global[d * n + d].abs() < 1e-20 {
-                    k_global[d * n + d] += artificial_k;
-                    artificial_dofs_3d.push(d);
-                }
-            }
-        }
-    }
-
-    // Apply inclined support transformations
-    let mut inclined_transforms = Vec::new();
-    for sup in input.supports.values() {
-        if sup.is_inclined.unwrap_or(false) {
-            if let (Some(nx), Some(ny), Some(nz)) = (sup.normal_x, sup.normal_y, sup.normal_z) {
-                let n_len = (nx * nx + ny * ny + nz * nz).sqrt();
-                if n_len > 1e-12 {
-                    let r = inclined_rotation_matrix(nx, ny, nz);
-                    if let (Some(&d0), Some(&d1), Some(&d2)) = (
-                        dof_num.map.get(&(sup.node_id, 0)),
-                        dof_num.map.get(&(sup.node_id, 1)),
-                        dof_num.map.get(&(sup.node_id, 2)),
-                    ) {
-                        let dofs = [d0, d1, d2];
-                        apply_inclined_transform(&mut k_global, &mut f_global, n, &dofs, &r);
-                        inclined_transforms.push(InclinedTransformData {
-                            node_id: sup.node_id,
-                            dofs,
-                            r,
-                        });
-                    }
-                }
-            }
-        }
-    }
-
-    // Element quality diagnostics
-    let mut diagnostics = Vec::new();
-
-    for plate in input.plates.values() {
-        let n0 = node_map[&plate.nodes[0]];
-        let n1 = node_map[&plate.nodes[1]];
-        let n2 = node_map[&plate.nodes[2]];
-        let coords = [
-            [n0.x, n0.y, n0.z],
-            [n1.x, n1.y, n1.z],
-            [n2.x, n2.y, n2.z],
-        ];
-        let (aspect_ratio, _skew, min_angle) = crate::element::plate_element_quality(&coords);
-        if aspect_ratio > 10.0 {
-            diagnostics.push(crate::types::AssemblyDiagnostic {
-                element_id: plate.id,
-                element_type: "plate".into(),
-                metric: "aspect_ratio".into(),
-                value: aspect_ratio,
-                threshold: 10.0,
-                message: format!("Plate {} aspect ratio {:.1} exceeds 10", plate.id, aspect_ratio),
-            });
-        }
-        if min_angle < 10.0 {
-            diagnostics.push(crate::types::AssemblyDiagnostic {
-                element_id: plate.id,
-                element_type: "plate".into(),
-                metric: "min_angle".into(),
-                value: min_angle,
-                threshold: 10.0,
-                message: format!("Plate {} min angle {:.1}° below 10°", plate.id, min_angle),
-            });
-        }
-    }
-
-    for quad in input.quads.values() {
-        let qn0 = node_map[&quad.nodes[0]];
-        let qn1 = node_map[&quad.nodes[1]];
-        let qn2 = node_map[&quad.nodes[2]];
-        let qn3 = node_map[&quad.nodes[3]];
-        let coords = [
-            [qn0.x, qn0.y, qn0.z],
-            [qn1.x, qn1.y, qn1.z],
-            [qn2.x, qn2.y, qn2.z],
-            [qn3.x, qn3.y, qn3.z],
-        ];
-        let qm = crate::element::quad::quad_quality_metrics(&coords);
-        let (_, _, has_neg_j) = crate::element::quad::quad_check_jacobian(&coords);
-        if has_neg_j {
-            diagnostics.push(crate::types::AssemblyDiagnostic {
-                element_id: quad.id,
-                element_type: "quad".into(),
-                metric: "negative_jacobian".into(),
-                value: -1.0,
-                threshold: 0.0,
-                message: format!("Quad {} has negative Jacobian determinant (inverted element)", quad.id),
-            });
-        }
-        if qm.aspect_ratio > 10.0 {
-            diagnostics.push(crate::types::AssemblyDiagnostic {
-                element_id: quad.id,
-                element_type: "quad".into(),
-                metric: "aspect_ratio".into(),
-                value: qm.aspect_ratio,
-                threshold: 10.0,
-                message: format!("Quad {} aspect ratio {:.1} exceeds 10", quad.id, qm.aspect_ratio),
-            });
-        }
-        if qm.warping > 0.01 && qm.warping <= 0.1 {
-            diagnostics.push(crate::types::AssemblyDiagnostic {
-                element_id: quad.id,
-                element_type: "quad".into(),
-                metric: "warping_moderate".into(),
-                value: qm.warping,
-                threshold: 0.01,
-                message: format!("Quad {} moderate warping {:.3} (0.01-0.1 range)", quad.id, qm.warping),
-            });
-        }
-        if qm.warping > 0.1 {
-            diagnostics.push(crate::types::AssemblyDiagnostic {
-                element_id: quad.id,
-                element_type: "quad".into(),
-                metric: "warping".into(),
-                value: qm.warping,
-                threshold: 0.1,
-                message: format!("Quad {} warping {:.3} exceeds 0.1", quad.id, qm.warping),
-            });
-        }
-        if qm.jacobian_ratio < 0.1 {
-            diagnostics.push(crate::types::AssemblyDiagnostic {
-                element_id: quad.id,
-                element_type: "quad".into(),
-                metric: "jacobian_ratio".into(),
-                value: qm.jacobian_ratio,
-                threshold: 0.1,
-                message: format!("Quad {} jacobian ratio {:.3} below 0.1", quad.id, qm.jacobian_ratio),
-            });
-        }
-    }
-
-    // Quad9 diagnostics (dense path)
-    for q9 in input.quad9s.values() {
-        let coords = quad9_coords(&node_map, q9);
-        let (_, _, has_neg_j) = crate::element::quad9::quad9_check_jacobian(&coords);
-        if has_neg_j {
-            diagnostics.push(crate::types::AssemblyDiagnostic {
-                element_id: q9.id, element_type: "quad9".into(), metric: "negative_jacobian".into(),
-                value: -1.0, threshold: 0.0,
-                message: format!("Quad9 {} has negative Jacobian determinant (inverted element)", q9.id),
-            });
-        }
-    }
-
+/// Assemble global stiffness matrix and force vector for 3D.
+pub fn assemble_3d(input: &SolverInput3D, dof_num: &DofNumbering) -> AssemblyResult {
+    let stiff = assemble_stiffness_3d(input, dof_num);
+    let f = assemble_load_vector_3d_dense(input, &input.loads, dof_num, &stiff.inclined_transforms);
     AssemblyResult {
-        k: k_global,
-        f: f_global,
-        max_diag_k: max_diag,
-        artificial_dofs: artificial_dofs_3d,
-        inclined_transforms,
+        k: stiff.k,
+        f,
+        max_diag_k: stiff.max_diag_k,
+        artificial_dofs: stiff.artificial_dofs,
+        inclined_transforms: stiff.inclined_transforms,
         inclined_transforms_2d: Vec::new(),
-        diagnostics,
+        diagnostics: stiff.diagnostics,
     }
 }
 
 fn assemble_element_loads_3d(
-    input: &SolverInput3D,
+    loads: &[SolverLoad3D],
     elem: &SolverElement3D,
     t: &[f64],
     l: f64,
@@ -1368,7 +1584,7 @@ fn assemble_element_loads_3d(
     phi_y: f64,
     phi_z: f64,
 ) {
-    for load in &input.loads {
+    for load in loads {
         match load {
             SolverLoad3D::Distributed(dl) if dl.element_id == elem.id => {
                 let a = dl.a.unwrap_or(0.0);
@@ -1430,7 +1646,7 @@ fn assemble_element_loads_3d(
 
 /// Assemble 3D element loads for warping elements (14-DOF transform).
 fn assemble_element_loads_3d_warping(
-    input: &SolverInput3D,
+    loads: &[SolverLoad3D],
     elem: &SolverElement3D,
     t14: &[f64],
     l: f64,
@@ -1441,7 +1657,7 @@ fn assemble_element_loads_3d_warping(
     phi_y: f64,
     phi_z: f64,
 ) {
-    for load in &input.loads {
+    for load in loads {
         match load {
             SolverLoad3D::Distributed(dl) if dl.element_id == elem.id => {
                 let a = dl.a.unwrap_or(0.0);
@@ -1498,7 +1714,7 @@ fn assemble_element_loads_3d_warping(
 
 /// Assemble 3D element loads for non-warping elements in a warping model (12-DOF mapped to 14).
 fn assemble_element_loads_3d_mapped(
-    input: &SolverInput3D,
+    loads: &[SolverLoad3D],
     elem: &SolverElement3D,
     t12: &[f64],
     l: f64,
@@ -1509,7 +1725,7 @@ fn assemble_element_loads_3d_mapped(
     phi_y: f64,
     phi_z: f64,
 ) {
-    for load in &input.loads {
+    for load in loads {
         match load {
             SolverLoad3D::Distributed(dl) if dl.element_id == elem.id => {
                 let a = dl.a.unwrap_or(0.0);
@@ -1671,7 +1887,7 @@ pub fn assemble_sparse_2d(input: &SolverInput, dof_num: &DofNumbering) -> Sparse
                 diag_vals[elem_dofs[i]] += k_glob[i * ndof + i];
             }
 
-            assemble_element_loads_2d(input, elem, &k_local, &t, l, e, sec, node_i, &elem_dofs, &mut f_global);
+            assemble_element_loads_2d(&input.loads, elem, &t, l, e, sec, &elem_dofs, &mut f_global);
         }
     }
 
@@ -1785,6 +2001,23 @@ pub fn apply_inclined_transform_triplets(
     trip_rows: &mut Vec<usize>, trip_cols: &mut Vec<usize>, trip_vals: &mut Vec<f64>,
     f_global: &mut [f64], dofs: &[usize; 3], r: &[[f64; 3]; 3],
 ) {
+    apply_inclined_transform_triplets_k(trip_rows, trip_cols, trip_vals, dofs, r);
+    rotate_inclined_f_triplets(f_global, dofs, r);
+}
+
+/// Rotate force vector at inclined-support DOFs: F'[dofs[a]] = sum_b R[a][b] * F[dofs[b]].
+pub fn rotate_inclined_f_triplets(f_global: &mut [f64], dofs: &[usize; 3], r: &[[f64; 3]; 3]) {
+    let fv = [f_global[dofs[0]], f_global[dofs[1]], f_global[dofs[2]]];
+    for a in 0..3 {
+        f_global[dofs[a]] = r[a][0] * fv[0] + r[a][1] * fv[1] + r[a][2] * fv[2];
+    }
+}
+
+/// K-only inclined support rotation on stiffness triplets (zeros originals, re-adds rotated entries).
+pub(crate) fn apply_inclined_transform_triplets_k(
+    trip_rows: &mut Vec<usize>, trip_cols: &mut Vec<usize>, trip_vals: &mut Vec<f64>,
+    dofs: &[usize; 3], r: &[[f64; 3]; 3],
+) {
     let dof_local: std::collections::HashMap<usize, usize> =
         dofs.iter().enumerate().map(|(i, &d)| (d, i)).collect();
 
@@ -1835,19 +2068,24 @@ pub fn apply_inclined_transform_triplets(
             }
         }
     }
-    // Rotate force: F'[dofs[a]] = sum_b R[a][b] * F[dofs[b]]
-    let fv = [f_global[dofs[0]], f_global[dofs[1]], f_global[dofs[2]]];
-    for a in 0..3 {
-        f_global[dofs[a]] = r[a][0] * fv[0] + r[a][1] * fv[1] + r[a][2] * fv[2];
-    }
 }
 
-/// Assemble sparse K for 3D. Returns CSC of Kff (always) and full K (if `build_k_full` is true).
-/// Collects all triplets for the full n×n K, then filters for Kff at the end.
-pub fn assemble_sparse_3d(input: &SolverInput3D, dof_num: &DofNumbering, build_k_full: bool) -> SparseAssemblyResult3D {
+/// Stiffness-only sparse 3D assembly result (triplet transforms applied, CSC built).
+pub struct StiffnessSparseAssembly3D {
+    pub k_ff: CscMatrix,
+    pub k_full: Option<CscMatrix>,
+    pub max_diag_k: f64,
+    pub artificial_dofs: Vec<usize>,
+    pub inclined_transforms: Vec<InclinedTransformData>,
+    pub diagnostics: Vec<crate::types::AssemblyDiagnostic>,
+}
+
+/// Assemble sparse K for 3D (load-independent). Returns CSC of Kff (always) and
+/// full K (if `build_k_full` is true). The force vector is assembled separately
+/// by `assemble_load_vector_3d_sparse`.
+pub fn assemble_stiffness_sparse_3d(input: &SolverInput3D, dof_num: &DofNumbering, build_k_full: bool) -> StiffnessSparseAssembly3D {
     let n = dof_num.n_total;
     let nf = dof_num.n_free;
-    let mut f_global = vec![0.0; n];
     let left_hand = input.left_hand.unwrap_or(false);
 
     let mut trip_rows = Vec::new();
@@ -1863,10 +2101,6 @@ pub fn assemble_sparse_3d(input: &SolverInput3D, dof_num: &DofNumbering, build_k
         input.materials.values().map(|m| (m.id, m)).collect();
     let sec_map: std::collections::HashMap<usize, &SolverSection3D> =
         input.sections.values().map(|s| (s.id, s)).collect();
-    let plate_map: std::collections::HashMap<usize, &SolverPlateElement> =
-        input.plates.values().map(|p| (p.id, p)).collect();
-    let quad_map: std::collections::HashMap<usize, &SolverQuadElement> =
-        input.quads.values().map(|q| (q.id, q)).collect();
 
     // Helper: scatter element stiffness into triplets (full K, lower triangle)
     macro_rules! scatter {
@@ -1924,30 +2158,13 @@ pub fn assemble_sparse_3d(input: &SolverInput3D, dof_num: &DofNumbering, build_k
                     }
                 }
             }
-            // Assemble thermal FEF for truss elements
-            for load in &input.loads {
-                if let SolverLoad3D::Thermal(tl) = load {
-                    if tl.element_id == elem.id {
-                        let alpha = 12e-6;
-                        let fx = e * sec.a * alpha * tl.dt_uniform;
-                        for k in 0..3 {
-                            if let Some(&d) = dof_num.map.get(&(elem.node_i, k)) {
-                                f_global[d] += -fx * dir[k];
-                            }
-                            if let Some(&d) = dof_num.map.get(&(elem.node_j, k)) {
-                                f_global[d] += fx * dir[k];
-                            }
-                        }
-                    }
-                }
-            }
         } else {
             let (ex, ey, ez) = compute_local_axes_3d(
                 node_i.x, node_i.y, node_i.z, node_j.x, node_j.y, node_j.z,
                 elem.local_yx, elem.local_yy, elem.local_yz, elem.roll_angle, left_hand,
             );
             let elem_dofs = dof_num.element_dofs(elem.node_i, elem.node_j);
-            let has_cw = sec.cw.map_or(false, |cw| cw > 0.0);
+            let has_cw = sec.cw.is_some_and(|cw| cw > 0.0);
 
             let (phi_y, phi_z) = if sec.as_y.is_some() || sec.as_z.is_some() {
                 let l2 = l * l;
@@ -1968,7 +2185,6 @@ pub fn assemble_sparse_3d(input: &SolverInput3D, dof_num: &DofNumbering, build_k
                 let k_glob = transform_stiffness(&k_local, &t, 14);
                 let ndof = elem_dofs.len();
                 scatter!(k_glob, elem_dofs, ndof);
-                assemble_element_loads_3d_warping(input, elem, &t, l, e, sec, &elem_dofs, &mut f_global, phi_y, phi_z);
             } else if dof_num.dofs_per_node >= 7 {
                 let k_local = frame_local_stiffness_3d(e, sec.a, sec.iy, sec.iz, sec.j, l, g,
                     Hinge3D::from_elem(elem),
@@ -1986,7 +2202,6 @@ pub fn assemble_sparse_3d(input: &SolverInput3D, dof_num: &DofNumbering, build_k
                     }
                     if gi < nf { diag_vals[gi] += k_glob[i * 12 + i]; }
                 }
-                assemble_element_loads_3d_mapped(input, elem, &t, l, e, sec, &elem_dofs, &mut f_global, phi_y, phi_z);
             } else {
                 let k_local = frame_local_stiffness_3d(e, sec.a, sec.iy, sec.iz, sec.j, l, g,
                     Hinge3D::from_elem(elem),
@@ -1995,7 +2210,6 @@ pub fn assemble_sparse_3d(input: &SolverInput3D, dof_num: &DofNumbering, build_k
                 let k_glob = transform_stiffness(&k_local, &t, 12);
                 let ndof = elem_dofs.len();
                 scatter!(k_glob, elem_dofs, ndof);
-                assemble_element_loads_3d(input, elem, &t, l, e, sec, &elem_dofs, &mut f_global, phi_y, phi_z);
             }
         }
     }
@@ -2113,8 +2327,224 @@ pub fn assemble_sparse_3d(input: &SolverInput3D, dof_num: &DofNumbering, build_k
         scatter!(k_elem, cs_dofs, ndof);
     }
 
+    // Spring stiffness
+    for sup in input.supports.values() {
+        let springs = [sup.kx, sup.ky, sup.kz, sup.krx, sup.kry, sup.krz];
+        for (i, ks) in springs.iter().enumerate() {
+            if let Some(k) = ks {
+                if *k > 0.0 && i < dof_num.dofs_per_node {
+                    if let Some(&d) = dof_num.map.get(&(sup.node_id, i)) {
+                        trip_rows.push(d); trip_cols.push(d); trip_vals.push(*k);
+                        if d < nf { diag_vals[d] += *k; }
+                    }
+                }
+            }
+        }
+        if dof_num.dofs_per_node >= 7 {
+            if let Some(kw) = sup.kw {
+                if kw > 0.0 {
+                    if let Some(&d) = dof_num.map.get(&(sup.node_id, 6)) {
+                        trip_rows.push(d); trip_cols.push(d); trip_vals.push(kw);
+                        if d < nf { diag_vals[d] += kw; }
+                    }
+                }
+            }
+        }
+    }
+
+    for d in &diag_vals[..nf] { max_diag = max_diag.max(d.abs()); }
+
+    // Artificial stiffness at floating warping DOFs
+    let mut artificial_dofs_3d = Vec::new();
+    if dof_num.dofs_per_node >= 7 {
+        let artificial_k = if max_diag > 0.0 { max_diag * 1e-10 } else { 1e-6 };
+        for &node_id in &dof_num.node_order {
+            if let Some(&d) = dof_num.map.get(&(node_id, 6)) {
+                if d < nf && diag_vals[d].abs() < 1e-20 {
+                    trip_rows.push(d); trip_cols.push(d); trip_vals.push(artificial_k);
+                    artificial_dofs_3d.push(d);
+                }
+            }
+        }
+    }
+
+    // Inclined support transforms (applied to triplets before CSC conversion;
+    // the force vector rotation happens in `assemble_load_vector_3d_sparse`)
+    let mut inclined_transforms = Vec::new();
+    for sup in input.supports.values() {
+        if sup.is_inclined.unwrap_or(false) {
+            if let (Some(nx), Some(ny), Some(nz)) = (sup.normal_x, sup.normal_y, sup.normal_z) {
+                let n_len = (nx * nx + ny * ny + nz * nz).sqrt();
+                if n_len > 1e-12 {
+                    let r = inclined_rotation_matrix(nx, ny, nz);
+                    if let (Some(&d0), Some(&d1), Some(&d2)) = (
+                        dof_num.map.get(&(sup.node_id, 0)),
+                        dof_num.map.get(&(sup.node_id, 1)),
+                        dof_num.map.get(&(sup.node_id, 2)),
+                    ) {
+                        let dofs = [d0, d1, d2];
+                        apply_inclined_transform_triplets_k(
+                            &mut trip_rows, &mut trip_cols, &mut trip_vals,
+                            &dofs, &r,
+                        );
+                        inclined_transforms.push(InclinedTransformData { node_id: sup.node_id, dofs, r });
+                    }
+                }
+            }
+        }
+    }
+
+    // Compact zeroed-out triplets left by inclined support transforms
+    if !inclined_transforms.is_empty() {
+        let mut w = 0;
+        for r in 0..trip_rows.len() {
+            if trip_vals[r] != 0.0 {
+                trip_rows[w] = trip_rows[r];
+                trip_cols[w] = trip_cols[r];
+                trip_vals[w] = trip_vals[r];
+                w += 1;
+            }
+        }
+        trip_rows.truncate(w);
+        trip_cols.truncate(w);
+        trip_vals.truncate(w);
+    }
+
+    // Element quality diagnostics
+    let mut diagnostics = Vec::new();
+    for plate in input.plates.values() {
+        let n0 = node_map[&plate.nodes[0]];
+        let n1 = node_map[&plate.nodes[1]];
+        let n2 = node_map[&plate.nodes[2]];
+        let coords = [[n0.x, n0.y, n0.z], [n1.x, n1.y, n1.z], [n2.x, n2.y, n2.z]];
+        let (aspect_ratio, _skew, min_angle) = crate::element::plate_element_quality(&coords);
+        if aspect_ratio > 10.0 {
+            diagnostics.push(crate::types::AssemblyDiagnostic {
+                element_id: plate.id, element_type: "plate".into(), metric: "aspect_ratio".into(),
+                value: aspect_ratio, threshold: 10.0,
+                message: format!("Plate {} aspect ratio {:.1} exceeds 10", plate.id, aspect_ratio),
+            });
+        }
+        if min_angle < 10.0 {
+            diagnostics.push(crate::types::AssemblyDiagnostic {
+                element_id: plate.id, element_type: "plate".into(), metric: "min_angle".into(),
+                value: min_angle, threshold: 10.0,
+                message: format!("Plate {} min angle {:.1}° below 10°", plate.id, min_angle),
+            });
+        }
+    }
+    for quad in input.quads.values() {
+        let qn0 = node_map[&quad.nodes[0]];
+        let qn1 = node_map[&quad.nodes[1]];
+        let qn2 = node_map[&quad.nodes[2]];
+        let qn3 = node_map[&quad.nodes[3]];
+        let coords = [[qn0.x, qn0.y, qn0.z], [qn1.x, qn1.y, qn1.z], [qn2.x, qn2.y, qn2.z], [qn3.x, qn3.y, qn3.z]];
+        let qm = crate::element::quad::quad_quality_metrics(&coords);
+        let (_, _, has_neg_j) = crate::element::quad::quad_check_jacobian(&coords);
+        if has_neg_j {
+            diagnostics.push(crate::types::AssemblyDiagnostic {
+                element_id: quad.id, element_type: "quad".into(), metric: "negative_jacobian".into(),
+                value: -1.0, threshold: 0.0,
+                message: format!("Quad {} has negative Jacobian determinant (inverted element)", quad.id),
+            });
+        }
+        if qm.aspect_ratio > 10.0 {
+            diagnostics.push(crate::types::AssemblyDiagnostic {
+                element_id: quad.id, element_type: "quad".into(), metric: "aspect_ratio".into(),
+                value: qm.aspect_ratio, threshold: 10.0,
+                message: format!("Quad {} aspect ratio {:.1} exceeds 10", quad.id, qm.aspect_ratio),
+            });
+        }
+        if qm.warping > 0.01 && qm.warping <= 0.1 {
+            diagnostics.push(crate::types::AssemblyDiagnostic {
+                element_id: quad.id, element_type: "quad".into(), metric: "warping_moderate".into(),
+                value: qm.warping, threshold: 0.01,
+                message: format!("Quad {} moderate warping {:.3} (0.01-0.1 range)", quad.id, qm.warping),
+            });
+        }
+        if qm.warping > 0.1 {
+            diagnostics.push(crate::types::AssemblyDiagnostic {
+                element_id: quad.id, element_type: "quad".into(), metric: "warping".into(),
+                value: qm.warping, threshold: 0.1,
+                message: format!("Quad {} warping {:.3} exceeds 0.1", quad.id, qm.warping),
+            });
+        }
+        if qm.jacobian_ratio < 0.1 {
+            diagnostics.push(crate::types::AssemblyDiagnostic {
+                element_id: quad.id, element_type: "quad".into(), metric: "jacobian_ratio".into(),
+                value: qm.jacobian_ratio, threshold: 0.1,
+                message: format!("Quad {} jacobian ratio {:.3} below 0.1", quad.id, qm.jacobian_ratio),
+            });
+        }
+    }
+
+    // Quad9 diagnostics (sparse path)
+    for q9 in input.quad9s.values() {
+        let coords = quad9_coords(&node_map, q9);
+        let (_, _, has_neg_j) = crate::element::quad9::quad9_check_jacobian(&coords);
+        if has_neg_j {
+            diagnostics.push(crate::types::AssemblyDiagnostic {
+                element_id: q9.id, element_type: "quad9".into(), metric: "negative_jacobian".into(),
+                value: -1.0, threshold: 0.0,
+                message: format!("Quad9 {} has negative Jacobian determinant (inverted element)", q9.id),
+            });
+        }
+    }
+
+    // Build full-K CSC only if requested (linear solve needs it for reactions)
+    let k_full = if build_k_full {
+        Some(CscMatrix::from_triplets(n, &trip_rows, &trip_cols, &trip_vals))
+    } else {
+        None
+    };
+
+    // Filter triplets for Kff (free-free block)
+    let mut ff_rows = Vec::new();
+    let mut ff_cols = Vec::new();
+    let mut ff_vals = Vec::new();
+    for i in 0..trip_rows.len() {
+        if trip_rows[i] < nf && trip_cols[i] < nf {
+            ff_rows.push(trip_rows[i]); ff_cols.push(trip_cols[i]); ff_vals.push(trip_vals[i]);
+        }
+    }
+    let mut k_ff = CscMatrix::from_triplets(nf, &ff_rows, &ff_cols, &ff_vals);
+    // Drop tiny entries to match from_dense_symmetric behavior — prevents
+    // spurious near-zero entries from making Cholesky succeed on singular matrices.
+    k_ff.drop_below_threshold(1e-30);
+
+    StiffnessSparseAssembly3D {
+        k_ff, k_full, max_diag_k: max_diag,
+        artificial_dofs: artificial_dofs_3d, inclined_transforms, diagnostics,
+    }
+}
+
+/// Assemble the global force vector for 3D for a given set of loads,
+/// sequential-sparse flavor (with inclined support rotations applied).
+/// Produces exactly the same `f` as `assemble_sparse_3d` would on the same loads.
+pub fn assemble_load_vector_3d_sparse(
+    input: &SolverInput3D,
+    loads: &[SolverLoad3D],
+    dof_num: &DofNumbering,
+    inclined_transforms: &[InclinedTransformData],
+) -> Vec<f64> {
+    let n = dof_num.n_total;
+    let mut f_global = vec![0.0; n];
+
+    // Pre-build O(1) lookup maps
+    let node_map: std::collections::HashMap<usize, &SolverNode3D> =
+        input.nodes.values().map(|n| (n.id, n)).collect();
+    let mat_map: std::collections::HashMap<usize, &SolverMaterial> =
+        input.materials.values().map(|m| (m.id, m)).collect();
+    let plate_map: std::collections::HashMap<usize, &SolverPlateElement> =
+        input.plates.values().map(|p| (p.id, p)).collect();
+    let quad_map: std::collections::HashMap<usize, &SolverQuadElement> =
+        input.quads.values().map(|q| (q.id, q)).collect();
+
+    // Frame/truss element loads (FEF + thermal)
+    assemble_frame_loads_3d(input, loads, dof_num, &mut f_global);
+
     // All loads (nodal, bimoment, plate pressure/thermal, quad pressure/thermal/self-weight/edge)
-    for load in &input.loads {
+    for load in loads {
         if let SolverLoad3D::Nodal(nl) = load {
             let forces = [nl.fx, nl.fy, nl.fz, nl.mx, nl.my, nl.mz];
             for (i, &f) in forces.iter().enumerate() {
@@ -2346,193 +2776,28 @@ pub fn assemble_sparse_3d(input: &SolverInput3D, dof_num: &DofNumbering, build_k
         }
     }
 
-    // Spring stiffness
-    for sup in input.supports.values() {
-        let springs = [sup.kx, sup.ky, sup.kz, sup.krx, sup.kry, sup.krz];
-        for (i, ks) in springs.iter().enumerate() {
-            if let Some(k) = ks {
-                if *k > 0.0 && i < dof_num.dofs_per_node {
-                    if let Some(&d) = dof_num.map.get(&(sup.node_id, i)) {
-                        trip_rows.push(d); trip_cols.push(d); trip_vals.push(*k);
-                        if d < nf { diag_vals[d] += *k; }
-                    }
-                }
-            }
-        }
-        if dof_num.dofs_per_node >= 7 {
-            if let Some(kw) = sup.kw {
-                if kw > 0.0 {
-                    if let Some(&d) = dof_num.map.get(&(sup.node_id, 6)) {
-                        trip_rows.push(d); trip_cols.push(d); trip_vals.push(kw);
-                        if d < nf { diag_vals[d] += kw; }
-                    }
-                }
-            }
-        }
+    // Apply inclined support rotations to the force vector
+    for it in inclined_transforms {
+        rotate_inclined_f_triplets(&mut f_global, &it.dofs, &it.r);
     }
 
-    for d in &diag_vals[..nf] { max_diag = max_diag.max(d.abs()); }
+    f_global
+}
 
-    // Artificial stiffness at floating warping DOFs
-    let mut artificial_dofs_3d = Vec::new();
-    if dof_num.dofs_per_node >= 7 {
-        let artificial_k = if max_diag > 0.0 { max_diag * 1e-10 } else { 1e-6 };
-        for &node_id in &dof_num.node_order {
-            if let Some(&d) = dof_num.map.get(&(node_id, 6)) {
-                if d < nf && diag_vals[d].abs() < 1e-20 {
-                    trip_rows.push(d); trip_cols.push(d); trip_vals.push(artificial_k);
-                    artificial_dofs_3d.push(d);
-                }
-            }
-        }
-    }
-
-    // Inclined support transforms (applied to triplets before CSC conversion)
-    let mut inclined_transforms = Vec::new();
-    for sup in input.supports.values() {
-        if sup.is_inclined.unwrap_or(false) {
-            if let (Some(nx), Some(ny), Some(nz)) = (sup.normal_x, sup.normal_y, sup.normal_z) {
-                let n_len = (nx * nx + ny * ny + nz * nz).sqrt();
-                if n_len > 1e-12 {
-                    let r = inclined_rotation_matrix(nx, ny, nz);
-                    if let (Some(&d0), Some(&d1), Some(&d2)) = (
-                        dof_num.map.get(&(sup.node_id, 0)),
-                        dof_num.map.get(&(sup.node_id, 1)),
-                        dof_num.map.get(&(sup.node_id, 2)),
-                    ) {
-                        let dofs = [d0, d1, d2];
-                        apply_inclined_transform_triplets(
-                            &mut trip_rows, &mut trip_cols, &mut trip_vals,
-                            &mut f_global, &dofs, &r,
-                        );
-                        inclined_transforms.push(InclinedTransformData { node_id: sup.node_id, dofs, r });
-                    }
-                }
-            }
-        }
-    }
-
-    // Compact zeroed-out triplets left by inclined support transforms
-    if !inclined_transforms.is_empty() {
-        let mut w = 0;
-        for r in 0..trip_rows.len() {
-            if trip_vals[r] != 0.0 {
-                trip_rows[w] = trip_rows[r];
-                trip_cols[w] = trip_cols[r];
-                trip_vals[w] = trip_vals[r];
-                w += 1;
-            }
-        }
-        trip_rows.truncate(w);
-        trip_cols.truncate(w);
-        trip_vals.truncate(w);
-    }
-
-    // Element quality diagnostics
-    let mut diagnostics = Vec::new();
-    for plate in input.plates.values() {
-        let n0 = node_map[&plate.nodes[0]];
-        let n1 = node_map[&plate.nodes[1]];
-        let n2 = node_map[&plate.nodes[2]];
-        let coords = [[n0.x, n0.y, n0.z], [n1.x, n1.y, n1.z], [n2.x, n2.y, n2.z]];
-        let (aspect_ratio, _skew, min_angle) = crate::element::plate_element_quality(&coords);
-        if aspect_ratio > 10.0 {
-            diagnostics.push(crate::types::AssemblyDiagnostic {
-                element_id: plate.id, element_type: "plate".into(), metric: "aspect_ratio".into(),
-                value: aspect_ratio, threshold: 10.0,
-                message: format!("Plate {} aspect ratio {:.1} exceeds 10", plate.id, aspect_ratio),
-            });
-        }
-        if min_angle < 10.0 {
-            diagnostics.push(crate::types::AssemblyDiagnostic {
-                element_id: plate.id, element_type: "plate".into(), metric: "min_angle".into(),
-                value: min_angle, threshold: 10.0,
-                message: format!("Plate {} min angle {:.1}° below 10°", plate.id, min_angle),
-            });
-        }
-    }
-    for quad in input.quads.values() {
-        let qn0 = node_map[&quad.nodes[0]];
-        let qn1 = node_map[&quad.nodes[1]];
-        let qn2 = node_map[&quad.nodes[2]];
-        let qn3 = node_map[&quad.nodes[3]];
-        let coords = [[qn0.x, qn0.y, qn0.z], [qn1.x, qn1.y, qn1.z], [qn2.x, qn2.y, qn2.z], [qn3.x, qn3.y, qn3.z]];
-        let qm = crate::element::quad::quad_quality_metrics(&coords);
-        let (_, _, has_neg_j) = crate::element::quad::quad_check_jacobian(&coords);
-        if has_neg_j {
-            diagnostics.push(crate::types::AssemblyDiagnostic {
-                element_id: quad.id, element_type: "quad".into(), metric: "negative_jacobian".into(),
-                value: -1.0, threshold: 0.0,
-                message: format!("Quad {} has negative Jacobian determinant (inverted element)", quad.id),
-            });
-        }
-        if qm.aspect_ratio > 10.0 {
-            diagnostics.push(crate::types::AssemblyDiagnostic {
-                element_id: quad.id, element_type: "quad".into(), metric: "aspect_ratio".into(),
-                value: qm.aspect_ratio, threshold: 10.0,
-                message: format!("Quad {} aspect ratio {:.1} exceeds 10", quad.id, qm.aspect_ratio),
-            });
-        }
-        if qm.warping > 0.01 && qm.warping <= 0.1 {
-            diagnostics.push(crate::types::AssemblyDiagnostic {
-                element_id: quad.id, element_type: "quad".into(), metric: "warping_moderate".into(),
-                value: qm.warping, threshold: 0.01,
-                message: format!("Quad {} moderate warping {:.3} (0.01-0.1 range)", quad.id, qm.warping),
-            });
-        }
-        if qm.warping > 0.1 {
-            diagnostics.push(crate::types::AssemblyDiagnostic {
-                element_id: quad.id, element_type: "quad".into(), metric: "warping".into(),
-                value: qm.warping, threshold: 0.1,
-                message: format!("Quad {} warping {:.3} exceeds 0.1", quad.id, qm.warping),
-            });
-        }
-        if qm.jacobian_ratio < 0.1 {
-            diagnostics.push(crate::types::AssemblyDiagnostic {
-                element_id: quad.id, element_type: "quad".into(), metric: "jacobian_ratio".into(),
-                value: qm.jacobian_ratio, threshold: 0.1,
-                message: format!("Quad {} jacobian ratio {:.3} below 0.1", quad.id, qm.jacobian_ratio),
-            });
-        }
-    }
-
-    // Quad9 diagnostics (sparse path)
-    for q9 in input.quad9s.values() {
-        let coords = quad9_coords(&node_map, q9);
-        let (_, _, has_neg_j) = crate::element::quad9::quad9_check_jacobian(&coords);
-        if has_neg_j {
-            diagnostics.push(crate::types::AssemblyDiagnostic {
-                element_id: q9.id, element_type: "quad9".into(), metric: "negative_jacobian".into(),
-                value: -1.0, threshold: 0.0,
-                message: format!("Quad9 {} has negative Jacobian determinant (inverted element)", q9.id),
-            });
-        }
-    }
-
-    // Build full-K CSC only if requested (linear solve needs it for reactions)
-    let k_full = if build_k_full {
-        Some(CscMatrix::from_triplets(n, &trip_rows, &trip_cols, &trip_vals))
-    } else {
-        None
-    };
-
-    // Filter triplets for Kff (free-free block)
-    let mut ff_rows = Vec::new();
-    let mut ff_cols = Vec::new();
-    let mut ff_vals = Vec::new();
-    for i in 0..trip_rows.len() {
-        if trip_rows[i] < nf && trip_cols[i] < nf {
-            ff_rows.push(trip_rows[i]); ff_cols.push(trip_cols[i]); ff_vals.push(trip_vals[i]);
-        }
-    }
-    let mut k_ff = CscMatrix::from_triplets(nf, &ff_rows, &ff_cols, &ff_vals);
-    // Drop tiny entries to match from_dense_symmetric behavior — prevents
-    // spurious near-zero entries from making Cholesky succeed on singular matrices.
-    k_ff.drop_below_threshold(1e-30);
-
+/// Assemble sparse K and force vector for 3D. Returns CSC of Kff (always) and
+/// full K (if `build_k_full` is true).
+/// Collects all triplets for the full n×n K, then filters for Kff at the end.
+pub fn assemble_sparse_3d(input: &SolverInput3D, dof_num: &DofNumbering, build_k_full: bool) -> SparseAssemblyResult3D {
+    let stiff = assemble_stiffness_sparse_3d(input, dof_num, build_k_full);
+    let f = assemble_load_vector_3d_sparse(input, &input.loads, dof_num, &stiff.inclined_transforms);
     SparseAssemblyResult3D {
-        k_ff, k_full, f: f_global, max_diag_k: max_diag,
-        artificial_dofs: artificial_dofs_3d, inclined_transforms, diagnostics,
+        k_ff: stiff.k_ff,
+        k_full: stiff.k_full,
+        f,
+        max_diag_k: stiff.max_diag_k,
+        artificial_dofs: stiff.artificial_dofs,
+        inclined_transforms: stiff.inclined_transforms,
+        diagnostics: stiff.diagnostics,
     }
 }
 

--- a/engine/src/solver/linear.rs
+++ b/engine/src/solver/linear.rs
@@ -41,13 +41,78 @@ pub fn solve_2d(input: &SolverInput) -> Result<AnalysisResults, String> {
         return super::constraints::solve_constrained_2d(&ci);
     }
 
+    let prepared = prepare_static_2d(input)?;
+    prepared.solve_loads(&input.loads)
+}
+
+// ==================== Prepared static analysis (factor reuse across load sets) ====================
+
+/// Factorization of K_ff, computed once from the (load-independent) stiffness
+/// matrix and reused across right-hand sides.
+enum FactorizedKff {
+    /// Dense in-place Cholesky factor L (lower triangle) of K_ff.
+    DenseCholesky(Vec<f64>),
+    /// Dense in-place LU factors of K_ff with row permutation.
+    DenseLu { lu: Vec<f64>, piv: Vec<usize> },
+    /// Sparse Cholesky factorization of K_ff.
+    SparseCholesky(NumericCholesky),
+}
+
+/// 2D static analysis prepared for multiple right-hand sides: DOF numbering,
+/// assembled stiffness (inclined transforms applied), K_ff factorization, and
+/// the prescribed-displacement coupling terms — everything that depends only on
+/// the structure, not on the loads. Build once with `prepare_static_2d`, then
+/// solve any number of load sets with `solve_loads`.
+pub struct PreparedStatic2D<'a> {
+    input: &'a SolverInput,
+    dof_num: DofNumbering,
+    n: usize,
+    nf: usize,
+    nr: usize,
+    u_r: Vec<f64>,
+    pre_solve_diags: Vec<StructuredDiagnostic>,
+    artificial_dofs: Vec<usize>,
+    inclined_transforms_2d: Vec<InclinedTransformData2D>,
+    path: PreparedPath2D,
+}
+
+enum PreparedPath2D {
+    /// All DOFs restrained: no system to solve; reactions = K·u_r − F.
+    FullyRestrained {
+        /// K · u_full (u_full = u_r); zero vector when u_r ≈ 0.
+        ku_full: Vec<f64>,
+    },
+    Solve(Box<PreparedSolve2D>),
+}
+
+/// Factorized form of the free-free stiffness block plus everything the
+/// per-load-set solve reuses (boxed to keep `PreparedPath2D` small).
+struct PreparedSolve2D {
+    /// Dense nf×nf K_ff (residual checks).
+    k_ff: Vec<f64>,
+    /// nr×nf reaction coupling block.
+    k_rf: Vec<f64>,
+    /// nf — K_fr · u_r (prescribed-displacement coupling).
+    k_fr_ur: Vec<f64>,
+    /// nr — K_rr · u_r.
+    k_rr_ur: Vec<f64>,
+    factor: FactorizedKff,
+    used_sparse: bool,
+    cholesky_failed: bool,
+    cond_report: super::conditioning::ConditioningReport,
+}
+
+/// Prepare a 2D structure for one or more static solves: numbering, assembly,
+/// and factorization of the free-free stiffness block happen exactly once here.
+/// This is exactly the load-independent part of `solve_2d`.
+pub fn prepare_static_2d(input: &SolverInput) -> Result<PreparedStatic2D<'_>, String> {
     let dof_num = DofNumbering::build_2d(input);
     let pre_solve_diags = super::pre_solve_gates::run_pre_solve_gates_2d(input);
 
     // ── Input validation (before assembly) ──
     validate_input_2d(input)?;
 
-    let asm = assemble_2d(input, &dof_num);
+    let stiff = assemble_stiffness_2d(input, &dof_num);
     let n = dof_num.n_total;
     let nf = dof_num.n_free;
 
@@ -66,87 +131,6 @@ pub fn solve_2d(input: &SolverInput) -> Result<AnalysisResults, String> {
                 let s = theta.sin();
                 let glob_dx = sup.dx.unwrap_or(0.0);
                 let glob_dz = sup.dz.unwrap_or(0.0);
-                // u_local_normal = c * dx + s * dz  (this is the restrained DOF = local_dof 1 after rotation)
-                // But in our scheme, local_dof 0 = rotated-x = normal, local_dof 1 = rotated-z = tangent...
-                // Wait: the rotation matrix R maps global to local: u_local = R * u_global
-                // R = [[c, s], [-s, c]]
-                // local_0 (mapped to ux DOF) = c*dx + s*dz  → this is the normal (restrained, local_dof=0 maps to global DOF for ux)
-                // But in DOF numbering, inclinedRoller restrains local_dof=1 (uz).
-                // After rotation, local_dof=0 (ux row) becomes the normal direction.
-                // Hmm, we need to be careful. Let me re-think.
-                //
-                // DOF numbering: inclinedRoller restrains local_dof=1 (the uz slot).
-                // The rotation R transforms so that: rotated_ux = c*ux + s*uz (= normal direction)
-                //                                    rotated_uz = -s*ux + c*uz (= tangent direction)
-                // But we restrain local_dof=1 which is the uz slot.
-                // After rotation, the uz slot corresponds to the tangent direction, not normal!
-                //
-                // Actually: the apply_inclined_transform_2d rotates the matrix so that
-                // the rotated frame's DOF 0 = normal, DOF 1 = tangent.
-                // But we restrain DOF 1 (uz slot). That means we're restraining the tangent direction!
-                // That's wrong. We should restrain DOF 0 (the normal direction).
-                //
-                // Let me reconsider. Looking at the 3D implementation:
-                // - is_dof_restrained_3d for inclined supports: local_dof 0 is restrained (normal)
-                // - DOF numbering puts local_dof 0 as restrained
-                //
-                // For 2D, inclinedRoller restrains local_dof=1, which after the transform
-                // should map to... Let me think about this differently.
-                //
-                // The rotation is applied to the stiffness matrix at the (ux,uz) DOFs.
-                // After rotation: row 0 = normal equation, row 1 = tangent equation.
-                // We want to restrain the normal direction = row 0 = the ux DOF slot.
-                // So inclinedRoller should restrain local_dof=0, not local_dof=1!
-                //
-                // But current code restrains local_dof=1 for inclinedRoller.
-                // Let me check what happens: if we restrain local_dof=1 (uz slot),
-                // after rotation that's the tangent direction. That would mean
-                // the roller restrains the tangent (free sliding) direction, which is wrong.
-                //
-                // I need to fix this: inclinedRoller with angle should restrain local_dof=0.
-                // But without angle (or angle=0), inclinedRoller = rollerX = restrain uz = local_dof=1.
-                // Hmm, at angle=0 the rotation is identity, so DOF 0 = normal = x direction.
-                // Restraining DOF 0 at angle=0 means restraining x direction = rollerZ behavior.
-                // But inclinedRoller at angle=0 should be rollerX (restrain z, free x).
-                //
-                // The convention: angle θ is measured from X axis, and the support
-                // restrains the direction at angle θ.
-                // At θ=0: restrain X direction → rollerZ behavior (free in Z)
-                //   Wait no: "restrain displacement in the direction at angle θ"
-                //   At θ=0: restrain along X → that's rollerZ behavior
-                //
-                // But the test says: "inclined roller at 0° matches rollerX behavior"
-                // rollerX = restrain uz (vertical), free ux (horizontal)
-                //
-                // So at θ=0: the support restrains the Z (vertical) direction.
-                // This means θ is the angle of the surface normal from Z axis,
-                // or equivalently: the restrained direction is at angle (θ + π/2) from X? No...
-                //
-                // From the test at line 224:
-                //   uPerp = ux * sin(θ) + uz * cos(θ)
-                // This is the component along direction (sin θ, cos θ).
-                // At θ=0: uPerp = uz → perpendicular to surface = Z direction (vertical)
-                // At θ=π/2: uPerp = ux → perpendicular = X direction (horizontal)
-                // So the restrained direction has unit vector (sin θ, cos θ).
-                //
-                // Our rotation matrix should make the restrained DOF slot correspond to
-                // this direction. Let's define:
-                //   restrained direction = (sin θ, cos θ)
-                //   free direction = (-cos θ, sin θ)  (perpendicular, 90° CCW)
-                //
-                // R should map global to local where local[0] = restrained direction:
-                //   R = [[sin θ, cos θ],
-                //        [-cos θ, sin θ]]
-                //
-                // Then local_dof=0 (ux slot) = restrained = sin θ * ux + cos θ * uz
-                //
-                // If we restrain local_dof=1 (uz slot) instead:
-                //   R = [[-cos θ, sin θ],
-                //        [sin θ, cos θ]]
-                //   local_dof=1 = sin θ * ux + cos θ * uz = restrained
-                //
-                // Let me use this second form so inclinedRoller keeps restraining local_dof=1.
-
                 // The restrained direction is (sin θ, cos θ).
                 // In the rotated frame, local_dof=1 should be this direction:
                 // u_local[1] = sin θ * ux + cos θ * uz
@@ -203,297 +187,357 @@ pub fn solve_2d(input: &SolverInput) -> Result<AnalysisResults, String> {
     }
 
     // Fully restrained: all DOFs are restrained, no solve needed.
-    // u_full = u_r, reactions = K_rr * u_r - F_r, element forces from K*u - FEF.
     if nf == 0 {
-        let mut u_full = vec![0.0; n];
-        for i in 0..nr {
-            u_full[i] = u_r[i]; // nf==0, so restrained DOFs start at index 0
-        }
-
-        // Reactions = K * u_r - F  (all DOFs are restrained, so K_rr = K, F_r = F)
-        let f_r: Vec<f64> = asm.f.clone();
-        let k_rr_ur = if u_r.iter().any(|v| v.abs() > 1e-15) {
-            // K * u_r via dense matvec
+        let u_full = u_r.clone();
+        // K · u_full via dense matvec (needed for reactions: R = K·u_r − F)
+        let ku_full = if u_r.iter().any(|v| v.abs() > 1e-15) {
             let mut ku = vec![0.0; n];
             for i in 0..n {
                 for j in 0..n {
-                    ku[i] += asm.k[i * n + j] * u_full[j];
+                    ku[i] += stiff.k[i * n + j] * u_full[j];
                 }
             }
             ku
         } else {
             vec![0.0; n]
         };
-        let mut reactions_vec = vec![0.0; nr];
-        for i in 0..nr {
-            reactions_vec[i] = k_rr_ur[i] - f_r[i];
-        }
 
-        // Reverse inclined transforms on displacements
-        for it in &asm.inclined_transforms_2d {
-            reverse_inclined_transform_2d(&mut u_full, &it.dofs, &it.r);
-        }
-
-        let displacements = build_displacements_2d(&dof_num, &u_full);
-        let mut reactions = build_reactions_2d_inclined(
-            input, &dof_num, &reactions_vec, &f_r, nf, &u_full, &asm.inclined_transforms_2d,
-        );
-        reactions.sort_by_key(|r| r.node_id);
-        let mut element_forces = compute_internal_forces_2d(input, &dof_num, &u_full);
-        element_forces.sort_by_key(|ef| ef.element_id);
-
-        let equilibrium = compute_equilibrium_summary_2d(&asm.f, &reactions_vec, &dof_num, 0.0, &asm.inclined_transforms_2d);
-
-        let mut structured = Vec::new();
-        structured.extend(pre_solve_diags);
-        structured.push(StructuredDiagnostic::global(
-            DiagnosticCode::ResidualOk,
-            Severity::Info,
-            format!("Fully restrained model (0 free DOFs, {} restrained)", nr),
-        ).with_phase("solve"));
-
-        let mut results = AnalysisResults {
-            displacements,
-            reactions,
-            element_forces,
-            constraint_forces: vec![],
-            diagnostics: asm.diagnostics,
-            solver_diagnostics: vec![],
-            structured_diagnostics: structured,
-            equilibrium: Some(equilibrium),
-            result_summary: None,
-            solver_run_meta: Some(SolverRunMeta::new("fully_restrained", nf, input.elements.len(), input.nodes.len())),
-        };
-        results.result_summary = Some(crate::postprocess::result_summary::compute_result_summary_2d(&results));
-        return Ok(results);
+        return Ok(PreparedStatic2D {
+            input,
+            dof_num,
+            n,
+            nf,
+            nr,
+            u_r,
+            pre_solve_diags,
+            artificial_dofs: stiff.artificial_dofs,
+            inclined_transforms_2d: stiff.inclined_transforms_2d,
+            path: PreparedPath2D::FullyRestrained { ku_full },
+        });
     }
 
-    // Extract Kff and Ff, modify Ff for prescribed displacement coupling
+    // Extract Kff and reaction coupling blocks; precompute the
+    // prescribed-displacement coupling terms (all load-independent)
     let free_idx: Vec<usize> = (0..nf).collect();
     let rest_idx: Vec<usize> = (nf..n).collect();
-    let k_ff = extract_submatrix(&asm.k, n, &free_idx, &free_idx);
-    let mut f_f = extract_subvec(&asm.f, &free_idx);
-
-    // F_f_modified = F_f - K_fr * u_r
-    let k_fr = extract_submatrix(&asm.k, n, &free_idx, &rest_idx);
+    let k_ff = extract_submatrix(&stiff.k, n, &free_idx, &free_idx);
+    let k_fr = extract_submatrix(&stiff.k, n, &free_idx, &rest_idx);
     let k_fr_ur = mat_vec_rect(&k_fr, &u_r, nf, nr);
-    for i in 0..nf {
-        f_f[i] -= k_fr_ur[i];
-    }
+    let k_rf = extract_submatrix(&stiff.k, n, &rest_idx, &free_idx);
+    let k_rr = extract_submatrix(&stiff.k, n, &rest_idx, &rest_idx);
+    let k_rr_ur = mat_vec_rect(&k_rr, &u_r, nr, nr);
 
     // Dense conditioning check
     let cond_report = super::conditioning::check_conditioning(&k_ff, nf);
 
-    // Solve Kff * u_f = Ff_modified
-    let mut cholesky_failed = false;
-    let (u_f, used_sparse) = if nf >= SPARSE_THRESHOLD {
+    // Factor K_ff once. The Cholesky/LU success decisions depend only on K,
+    // so the path chosen here is the one each per-case solve would take.
+    let (factor, used_sparse, cholesky_failed) = if nf >= SPARSE_THRESHOLD {
         // Sparse path
         let k_ff_sparse = CscMatrix::from_dense_symmetric(&k_ff, nf);
-        match sparse_cholesky_solve_full(&k_ff_sparse, &f_f) {
-            Some(u) => (u, true),
+        let sym = symbolic_cholesky(&k_ff_sparse);
+        match numeric_cholesky(&sym, &k_ff_sparse) {
+            Some(num) => (FactorizedKff::SparseCholesky(num), true, false),
             None => {
-                cholesky_failed = true;
                 let mut k_work = k_ff.clone();
-                let mut f_work = f_f.clone();
-                let u = lu_solve(&mut k_work, &mut f_work, nf)
+                let piv = lu_factor(&mut k_work, nf)
                     .ok_or_else(|| "Singular stiffness matrix — structure is a mechanism".to_string())?;
-                (u, false)
+                (FactorizedKff::DenseLu { lu: k_work, piv }, false, true)
             }
         }
     } else {
         let mut k_work = k_ff.clone();
-        match cholesky_solve(&mut k_work, &f_f, nf) {
-            Some(u) => (u, false),
-            None => {
-                cholesky_failed = true;
-                let mut k_work = k_ff.clone();
-                let mut f_work = f_f.clone();
-                let u = lu_solve(&mut k_work, &mut f_work, nf)
-                    .ok_or_else(|| "Singular stiffness matrix — structure is a mechanism".to_string())?;
-                (u, false)
-            }
+        if cholesky_decompose(&mut k_work, nf) {
+            (FactorizedKff::DenseCholesky(k_work), false, false)
+        } else {
+            let mut k_work = k_ff.clone();
+            let piv = lu_factor(&mut k_work, nf)
+                .ok_or_else(|| "Singular stiffness matrix — structure is a mechanism".to_string())?;
+            (FactorizedKff::DenseLu { lu: k_work, piv }, false, true)
         }
     };
 
-    // Build full displacement vector
-    let mut u_full = vec![0.0; n];
-    for i in 0..nf {
-        u_full[i] = u_f[i];
-    }
-    for i in 0..nr {
-        u_full[nf + i] = u_r[i];
-    }
+    Ok(PreparedStatic2D {
+        input,
+        dof_num,
+        n,
+        nf,
+        nr,
+        u_r,
+        pre_solve_diags,
+        artificial_dofs: stiff.artificial_dofs,
+        inclined_transforms_2d: stiff.inclined_transforms_2d,
+        path: PreparedPath2D::Solve(Box::new(PreparedSolve2D {
+            k_ff, k_rf, k_fr_ur, k_rr_ur, factor, used_sparse, cholesky_failed, cond_report,
+        })),
+    })
+}
 
-    // Check artificial DOFs for mechanism (absurd rotations)
-    if !asm.artificial_dofs.is_empty() {
-        for &idx in &asm.artificial_dofs {
-            if idx < nf && u_f[idx].abs() > 100.0 {
-                return Err(
-                    "Local mechanism detected: a node with all elements hinged has \
-                     excessive rotation, indicating local instability.".to_string()
+impl PreparedStatic2D<'_> {
+    /// Solve the prepared 2D structure for one load set. Rebuilds only the
+    /// load vector (prescribed-displacement coupling included), reuses the
+    /// stored factorization, then runs the same postprocessing as `solve_2d`.
+    pub fn solve_loads(&self, loads: &[SolverLoad]) -> Result<AnalysisResults, String> {
+        // Per-case load validation (the structure was validated in prepare)
+        validate_loads_2d(self.input, loads)?;
+
+        let input = self.input;
+        let dof_num = &self.dof_num;
+        let (n, nf, nr) = (self.n, self.nf, self.nr);
+        let f = assemble_load_vector_2d(input, loads, dof_num, &self.inclined_transforms_2d);
+
+        match &self.path {
+            PreparedPath2D::FullyRestrained { ku_full } => {
+                let mut u_full = self.u_r.clone(); // nf==0, restrained DOFs start at index 0
+
+                // Reactions = K · u_r − F  (all DOFs are restrained, so K_rr = K, F_r = F)
+                let f_r: Vec<f64> = f.clone();
+                let mut reactions_vec = vec![0.0; nr];
+                for i in 0..nr {
+                    reactions_vec[i] = ku_full[i] - f_r[i];
+                }
+
+                // Reverse inclined transforms on displacements
+                for it in &self.inclined_transforms_2d {
+                    reverse_inclined_transform_2d(&mut u_full, &it.dofs, &it.r);
+                }
+
+                let displacements = build_displacements_2d(dof_num, &u_full);
+                let mut reactions = build_reactions_2d_inclined(
+                    input, dof_num, &reactions_vec, &f_r, nf, &u_full, &self.inclined_transforms_2d,
                 );
+                reactions.sort_by_key(|r| r.node_id);
+                let mut element_forces = compute_internal_forces_2d_with_loads(input, loads, dof_num, &u_full);
+                element_forces.sort_by_key(|ef| ef.element_id);
+
+                let equilibrium = compute_equilibrium_summary_2d(&f, &reactions_vec, dof_num, 0.0, &self.inclined_transforms_2d);
+
+                let mut structured = Vec::new();
+                structured.extend(self.pre_solve_diags.iter().cloned());
+                structured.push(StructuredDiagnostic::global(
+                    DiagnosticCode::ResidualOk,
+                    Severity::Info,
+                    format!("Fully restrained model (0 free DOFs, {} restrained)", nr),
+                ).with_phase("solve"));
+
+                let mut results = AnalysisResults {
+                    displacements,
+                    reactions,
+                    element_forces,
+                    constraint_forces: vec![],
+                    diagnostics: vec![],
+                    solver_diagnostics: vec![],
+                    structured_diagnostics: structured,
+                    equilibrium: Some(equilibrium),
+                    result_summary: None,
+                    solver_run_meta: Some(SolverRunMeta::new("fully_restrained", nf, input.elements.len(), input.nodes.len())),
+                };
+                results.result_summary = Some(crate::postprocess::result_summary::compute_result_summary_2d(&results));
+                Ok(results)
+            }
+
+            PreparedPath2D::Solve(p) => {
+                let PreparedSolve2D {
+                    k_ff, k_rf, k_fr_ur, k_rr_ur, factor, used_sparse, cholesky_failed, cond_report,
+                } = &**p;
+                // F_f_modified = F_f − K_fr · u_r
+                let mut f_f: Vec<f64> = f[..nf].to_vec();
+                for i in 0..nf {
+                    f_f[i] -= k_fr_ur[i];
+                }
+
+                // Solve Kff · u_f = Ff_modified with the precomputed factorization
+                let u_f = match factor {
+                    FactorizedKff::SparseCholesky(num) => sparse_cholesky_solve(num, &f_f),
+                    FactorizedKff::DenseCholesky(l) => {
+                        let y = forward_solve(l, &f_f, nf);
+                        back_solve(l, &y, nf)
+                    }
+                    FactorizedKff::DenseLu { lu, piv } => {
+                        lu_apply(lu, piv, &f_f, nf)
+                            .ok_or_else(|| "Singular stiffness matrix — structure is a mechanism".to_string())?
+                    }
+                };
+
+                // Build full displacement vector
+                let mut u_full = vec![0.0; n];
+                for i in 0..nf {
+                    u_full[i] = u_f[i];
+                }
+                for i in 0..nr {
+                    u_full[nf + i] = self.u_r[i];
+                }
+
+                // Check artificial DOFs for mechanism (absurd rotations)
+                if !self.artificial_dofs.is_empty() {
+                    for &idx in &self.artificial_dofs {
+                        if idx < nf && u_f[idx].abs() > 100.0 {
+                            return Err(
+                                "Local mechanism detected: a node with all elements hinged has \
+                                 excessive rotation, indicating local instability.".to_string()
+                            );
+                        }
+                    }
+                }
+
+                // NaN/Inf guard: numerical blow-up means singular matrix
+                let has_nan_inf = u_f.iter().any(|v| v.is_nan() || v.is_infinite());
+                if has_nan_inf {
+                    return Err("Singular stiffness matrix — structure is a mechanism".to_string());
+                }
+
+                // Compute reactions: R = K_rf · u_f + K_rr · u_r − F_r
+                let f_r: Vec<f64> = f[nf..].to_vec();
+                let k_rf_uf = mat_vec_rect(k_rf, &u_f, nr, nf);
+                let mut reactions_vec = vec![0.0; nr];
+                for i in 0..nr {
+                    reactions_vec[i] = k_rf_uf[i] + k_rr_ur[i] - f_r[i];
+                }
+
+                // Reverse inclined transforms on displacements before building results
+                for it in &self.inclined_transforms_2d {
+                    reverse_inclined_transform_2d(&mut u_full, &it.dofs, &it.r);
+                }
+
+                // Build results
+                let displacements = build_displacements_2d(dof_num, &u_full);
+                let mut reactions = build_reactions_2d_inclined(
+                    input, dof_num, &reactions_vec, &f_r, nf, &u_full, &self.inclined_transforms_2d,
+                );
+                reactions.sort_by_key(|r| r.node_id);
+                let mut element_forces = compute_internal_forces_2d_with_loads(input, loads, dof_num, &u_full);
+                element_forces.sort_by_key(|ef| ef.element_id);
+
+                // Compute residual: ||K_ff · u_f − f_f|| / ||f_f||
+                let rel_residual = {
+                    let mut res2 = 0.0f64;
+                    let mut f2 = 0.0f64;
+                    for i in 0..nf {
+                        let mut ku_i = 0.0;
+                        for j in 0..nf {
+                            ku_i += k_ff[i * nf + j] * u_f[j];
+                        }
+                        let r = ku_i - f_f[i];
+                        res2 += r * r;
+                        f2 += f_f[i] * f_f[i];
+                    }
+                    res2.sqrt() / f2.sqrt().max(1e-30)
+                };
+
+                let equilibrium = compute_equilibrium_summary_2d(&f, &reactions_vec, dof_num, rel_residual, &self.inclined_transforms_2d);
+
+                // Build structured diagnostics — same contract as before
+                let mut structured = Vec::new();
+                structured.extend(self.pre_solve_diags.iter().cloned());
+
+                // Solver path
+                structured.push(StructuredDiagnostic::global(
+                    if *used_sparse { DiagnosticCode::SparseCholesky } else { DiagnosticCode::DenseLu },
+                    Severity::Info,
+                    format!("{} solver ({} free DOFs)", if *used_sparse { "Sparse Cholesky" } else { "Dense" }, nf),
+                ).with_phase("solve"));
+
+                // LU fallback warning
+                if *cholesky_failed {
+                    structured.push(StructuredDiagnostic::global(
+                        DiagnosticCode::CholeskyFailedLuFallback,
+                        Severity::Warning,
+                        "Cholesky factorization failed — LU fallback succeeded but model may be unstable (not positive-definite)".to_string(),
+                    ).with_phase("solve"));
+                }
+
+                // Displacement sanity check — translational DOFs only (rotations are in radians, not length units)
+                let max_disp = dof_num.map.iter()
+                    .filter(|&(&(_node, local_dof), &global)| local_dof < 2 && global < nf)
+                    .map(|(&_, &global)| u_f[global].abs())
+                    .fold(0.0f64, f64::max);
+                let char_length = {
+                    let mut min_x = f64::MAX;
+                    let mut max_x = f64::MIN;
+                    let mut min_z = f64::MAX;
+                    let mut max_z = f64::MIN;
+                    for node in input.nodes.values() {
+                        min_x = min_x.min(node.x);
+                        max_x = max_x.max(node.x);
+                        min_z = min_z.min(node.z);
+                        max_z = max_z.max(node.z);
+                    }
+                    let span = ((max_x - min_x).powi(2) + (max_z - min_z).powi(2)).sqrt();
+                    span.max(1.0)
+                };
+                if max_disp > 1000.0 * char_length {
+                    structured.push(StructuredDiagnostic::global(
+                        DiagnosticCode::ExcessiveDisplacement,
+                        Severity::Warning,
+                        format!(
+                            "Maximum displacement {:.2e} exceeds 1000× characteristic length {:.2e} — likely mechanism or instability",
+                            max_disp, char_length
+                        ),
+                    ).with_value(max_disp, 1000.0 * char_length).with_phase("solve"));
+                }
+
+                // Conditioning
+                let cond = cond_report.diagonal_ratio;
+                if cond > 1e12 {
+                    structured.push(StructuredDiagnostic::global(
+                        DiagnosticCode::ExtremelyHighDiagonalRatio,
+                        Severity::Warning,
+                        format!("Extremely high diagonal ratio {:.2e}", cond),
+                    ).with_value(cond, 1e12).with_phase("conditioning"));
+                } else if cond > 1e8 {
+                    structured.push(StructuredDiagnostic::global(
+                        DiagnosticCode::HighDiagonalRatio,
+                        Severity::Warning,
+                        format!("High diagonal ratio {:.2e}", cond),
+                    ).with_value(cond, 1e8).with_phase("conditioning"));
+                }
+
+                if !cond_report.near_zero_dofs.is_empty() {
+                    structured.push(StructuredDiagnostic::global(
+                        DiagnosticCode::NearZeroDiagonal,
+                        Severity::Warning,
+                        format!("{} near-zero diagonal entries", cond_report.near_zero_dofs.len()),
+                    ).with_dofs(cond_report.near_zero_dofs.clone()).with_phase("conditioning"));
+                }
+
+                // Residual
+                structured.push(if rel_residual < 1e-6 {
+                    StructuredDiagnostic::global(
+                        DiagnosticCode::ResidualOk,
+                        Severity::Info,
+                        format!("Residual {:.2e} ({} free DOFs)", rel_residual, nf),
+                    ).with_value(rel_residual, 1e-6).with_phase("solve")
+                } else {
+                    StructuredDiagnostic::global(
+                        DiagnosticCode::ResidualHigh,
+                        Severity::Warning,
+                        format!("Residual {:.2e} exceeds tolerance ({} free DOFs)", rel_residual, nf),
+                    ).with_value(rel_residual, 1e-6).with_phase("solve")
+                });
+
+                let solver_path_2d = if *used_sparse { "sparse_cholesky" } else { "dense_lu" };
+                let mut results = AnalysisResults {
+                    displacements,
+                    reactions,
+                    element_forces,
+                    constraint_forces: vec![],
+                    diagnostics: vec![],
+                    solver_diagnostics: vec![],
+                    structured_diagnostics: structured,
+                    equilibrium: Some(equilibrium),
+                    result_summary: None,
+                    solver_run_meta: Some(SolverRunMeta::new(
+                        solver_path_2d,
+                        nf,
+                        input.elements.len(),
+                        input.nodes.len(),
+                    )),
+                };
+                results.result_summary = Some(crate::postprocess::result_summary::compute_result_summary_2d(&results));
+                Ok(results)
             }
         }
     }
-
-    // NaN/Inf guard: numerical blow-up means singular matrix
-    let has_nan_inf = u_f.iter().any(|v| v.is_nan() || v.is_infinite());
-    if has_nan_inf {
-        return Err("Singular stiffness matrix — structure is a mechanism".to_string());
-    }
-
-    // Compute reactions: R = K_rf * u_f + K_rr * u_r - F_r
-    let k_rf = extract_submatrix(&asm.k, n, &rest_idx, &free_idx);
-    let k_rr = extract_submatrix(&asm.k, n, &rest_idx, &rest_idx);
-    let f_r = extract_subvec(&asm.f, &rest_idx);
-    let k_rf_uf = mat_vec_rect(&k_rf, &u_f, nr, nf);
-    let k_rr_ur = mat_vec_rect(&k_rr, &u_r, nr, nr);
-    let mut reactions_vec = vec![0.0; nr];
-    for i in 0..nr {
-        reactions_vec[i] = k_rf_uf[i] + k_rr_ur[i] - f_r[i];
-    }
-
-    // Reverse inclined transforms on displacements before building results
-    for it in &asm.inclined_transforms_2d {
-        reverse_inclined_transform_2d(&mut u_full, &it.dofs, &it.r);
-    }
-
-    // Build results
-    let displacements = build_displacements_2d(&dof_num, &u_full);
-    let mut reactions = build_reactions_2d_inclined(
-        input, &dof_num, &reactions_vec, &f_r, nf, &u_full, &asm.inclined_transforms_2d,
-    );
-    reactions.sort_by_key(|r| r.node_id);
-    let mut element_forces = compute_internal_forces_2d(input, &dof_num, &u_full);
-    element_forces.sort_by_key(|ef| ef.element_id);
-
-    // Compute residual: ||K_ff * u_f - f_f|| / ||f_f||
-    let rel_residual = {
-        let mut res2 = 0.0f64;
-        let mut f2 = 0.0f64;
-        for i in 0..nf {
-            let mut ku_i = 0.0;
-            for j in 0..nf {
-                ku_i += k_ff[i * nf + j] * u_f[j];
-            }
-            let r = ku_i - f_f[i];
-            res2 += r * r;
-            f2 += f_f[i] * f_f[i];
-        }
-        res2.sqrt() / f2.sqrt().max(1e-30)
-    };
-
-    let equilibrium = compute_equilibrium_summary_2d(&asm.f, &reactions_vec, &dof_num, rel_residual, &asm.inclined_transforms_2d);
-
-    // Build structured diagnostics — same contract as 3D sparse/dense paths
-    let mut structured = Vec::new();
-    structured.extend(pre_solve_diags);
-
-    // Solver path
-    structured.push(StructuredDiagnostic::global(
-        if used_sparse { DiagnosticCode::SparseCholesky } else { DiagnosticCode::DenseLu },
-        Severity::Info,
-        format!("{} solver ({} free DOFs)", if used_sparse { "Sparse Cholesky" } else { "Dense" }, nf),
-    ).with_phase("solve"));
-
-    // LU fallback warning
-    if cholesky_failed {
-        structured.push(StructuredDiagnostic::global(
-            DiagnosticCode::CholeskyFailedLuFallback,
-            Severity::Warning,
-            "Cholesky factorization failed — LU fallback succeeded but model may be unstable (not positive-definite)".to_string(),
-        ).with_phase("solve"));
-    }
-
-    // Displacement sanity check — translational DOFs only (rotations are in radians, not length units)
-    let max_disp = dof_num.map.iter()
-        .filter(|&(&(_node, local_dof), &global)| local_dof < 2 && global < nf)
-        .map(|(&_, &global)| u_f[global].abs())
-        .fold(0.0f64, f64::max);
-    let char_length = {
-        let mut min_x = f64::MAX;
-        let mut max_x = f64::MIN;
-        let mut min_z = f64::MAX;
-        let mut max_z = f64::MIN;
-        for node in input.nodes.values() {
-            min_x = min_x.min(node.x);
-            max_x = max_x.max(node.x);
-            min_z = min_z.min(node.z);
-            max_z = max_z.max(node.z);
-        }
-        let span = ((max_x - min_x).powi(2) + (max_z - min_z).powi(2)).sqrt();
-        span.max(1.0)
-    };
-    if max_disp > 1000.0 * char_length {
-        structured.push(StructuredDiagnostic::global(
-            DiagnosticCode::ExcessiveDisplacement,
-            Severity::Warning,
-            format!(
-                "Maximum displacement {:.2e} exceeds 1000× characteristic length {:.2e} — likely mechanism or instability",
-                max_disp, char_length
-            ),
-        ).with_value(max_disp, 1000.0 * char_length).with_phase("solve"));
-    }
-
-    // Conditioning
-    let cond = cond_report.diagonal_ratio;
-    if cond > 1e12 {
-        structured.push(StructuredDiagnostic::global(
-            DiagnosticCode::ExtremelyHighDiagonalRatio,
-            Severity::Warning,
-            format!("Extremely high diagonal ratio {:.2e}", cond),
-        ).with_value(cond, 1e12).with_phase("conditioning"));
-    } else if cond > 1e8 {
-        structured.push(StructuredDiagnostic::global(
-            DiagnosticCode::HighDiagonalRatio,
-            Severity::Warning,
-            format!("High diagonal ratio {:.2e}", cond),
-        ).with_value(cond, 1e8).with_phase("conditioning"));
-    }
-
-    if !cond_report.near_zero_dofs.is_empty() {
-        structured.push(StructuredDiagnostic::global(
-            DiagnosticCode::NearZeroDiagonal,
-            Severity::Warning,
-            format!("{} near-zero diagonal entries", cond_report.near_zero_dofs.len()),
-        ).with_dofs(cond_report.near_zero_dofs.clone()).with_phase("conditioning"));
-    }
-
-    // Residual
-    structured.push(if rel_residual < 1e-6 {
-        StructuredDiagnostic::global(
-            DiagnosticCode::ResidualOk,
-            Severity::Info,
-            format!("Residual {:.2e} ({} free DOFs)", rel_residual, nf),
-        ).with_value(rel_residual, 1e-6).with_phase("solve")
-    } else {
-        StructuredDiagnostic::global(
-            DiagnosticCode::ResidualHigh,
-            Severity::Warning,
-            format!("Residual {:.2e} exceeds tolerance ({} free DOFs)", rel_residual, nf),
-        ).with_value(rel_residual, 1e-6).with_phase("solve")
-    });
-
-    let solver_path_2d = if used_sparse { "sparse_cholesky" } else { "dense_lu" };
-    let mut results = AnalysisResults {
-        displacements,
-        reactions,
-        element_forces,
-        constraint_forces: vec![],
-        diagnostics: asm.diagnostics,
-        solver_diagnostics: vec![],
-        structured_diagnostics: structured,
-        equilibrium: Some(equilibrium),
-        result_summary: None,
-        solver_run_meta: Some(SolverRunMeta::new(
-            solver_path_2d,
-            nf,
-            input.elements.len(),
-            input.nodes.len(),
-        )),
-    };
-    results.result_summary = Some(crate::postprocess::result_summary::compute_result_summary_2d(&results));
-    Ok(results)
 }
 
 /// Solve a 3D linear static analysis.
@@ -507,9 +551,108 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
         return super::constraints::solve_constrained_3d(&ci);
     }
 
+    let prepared = prepare_static_3d(input)?;
+    prepared.solve_loads(&input.loads)
+}
+
+/// 3D static analysis prepared for multiple right-hand sides: curved-beam
+/// expansion, DOF numbering, assembled stiffness, K_ff factorization, and the
+/// prescribed-displacement coupling terms — everything that depends only on
+/// the structure, not on the loads. Build once with `prepare_static_3d`, then
+/// solve any number of load sets with `solve_loads`.
+pub struct PreparedStatic3D {
+    /// Curved-beam-expanded input (loads field unused by `solve_loads`).
+    input: SolverInput3D,
+    dof_num: DofNumbering,
+    n: usize,
+    nf: usize,
+    nr: usize,
+    n_elements: usize,
+    n_nodes: usize,
+    u_r: Vec<f64>,
+    pre_solve_diags: Vec<StructuredDiagnostic>,
+    path: PreparedPath3D,
+}
+
+enum PreparedPath3D {
+    FullyRestrained(FullyRestrained3D),
+    Dense(DensePrepared3D),
+    Sparse(SparsePrepared3D),
+    /// Sparse Cholesky failed even with regularization: dense LU of K_ff.
+    SparseDenseLu(SparseDenseLuPrepared3D),
+}
+
+struct FullyRestrained3D {
+    /// K · u_full (u_full = u_r); zero vector when u_r ≈ 0.
+    ku_full: Vec<f64>,
+    diagnostics: Vec<AssemblyDiagnostic>,
+    inclined_transforms: Vec<InclinedTransformData>,
+}
+
+struct DensePrepared3D {
+    k_ff: Vec<f64>,
+    k_rf: Vec<f64>,
+    k_fr_ur: Vec<f64>,
+    k_rr_ur: Vec<f64>,
+    factor: FactorizedKff,
+    cholesky_failed: bool,
+    cond_report: super::conditioning::ConditioningReport,
+    diagnostics: Vec<AssemblyDiagnostic>,
+    inclined_transforms: Vec<InclinedTransformData>,
+    /// Conditioning warnings (emitted before the per-case solver-path message).
+    solver_diags_base: Vec<SolverDiagnostic>,
+}
+
+struct SparsePrepared3D {
+    k_ff: CscMatrix,
+    k_full: CscMatrix,
+    num: NumericCholesky,
+    /// True when K_ff needed a diagonal shift to factor (drilling stabilization).
+    regularized: bool,
+    max_perturbation: f64,
+    /// nf — K_fr · u_r from the sparse full-K (zeros when no prescribed DOFs).
+    kfr_ur: Vec<f64>,
+    cond: f64,
+    nnz_kff: usize,
+    nnz_l: usize,
+    diagnostics: Vec<AssemblyDiagnostic>,
+    inclined_transforms: Vec<InclinedTransformData>,
+    /// Conditioning (+ regularization) messages, emitted before per-case ones.
+    solver_diags_base: Vec<SolverDiagnostic>,
+    assembly_us: u64,
+    conditioning_us: u64,
+    symbolic_us: u64,
+    numeric_us: u64,
+}
+
+struct SparseDenseLuPrepared3D {
+    k_full: CscMatrix,
+    lu: Vec<f64>,
+    piv: Vec<usize>,
+    /// nf — K_fr · u_r from the dense assembly (LU right-hand-side coupling).
+    k_fr_ur: Vec<f64>,
+    cond: f64,
+    nnz_kff: usize,
+    nnz_l: usize,
+    diagnostics: Vec<AssemblyDiagnostic>,
+    /// Sparse-path transforms (reactions/postprocessing).
+    inclined_transforms: Vec<InclinedTransformData>,
+    /// Dense-path transforms (dense load-vector rebuild for the LU RHS).
+    dense_inclined_transforms: Vec<InclinedTransformData>,
+    solver_diags_base: Vec<SolverDiagnostic>,
+    assembly_us: u64,
+    conditioning_us: u64,
+    symbolic_us: u64,
+    numeric_us: u64,
+    dense_fb_us: u64,
+}
+
+/// Prepare a 3D structure for one or more static solves: curved-beam expansion,
+/// numbering, assembly, and factorization of the free-free stiffness block
+/// happen exactly once here. This is exactly the load-independent part of `solve_3d`.
+pub fn prepare_static_3d(input: &SolverInput3D) -> Result<PreparedStatic3D, String> {
     // Expand curved beams into frame elements before solving
     let input = expand_curved_beams_3d(input);
-    let input = &input;
     let n_nodes = input.nodes.len();
     let n_elements = input.elements.len()
         + input.plates.len()
@@ -517,11 +660,11 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
         + input.quad9s.len()
         + input.solid_shells.len()
         + input.curved_shells.len();
-    let dof_num = DofNumbering::build_3d(input);
-    let pre_solve_diags = super::pre_solve_gates::run_pre_solve_gates_3d(input);
+    let dof_num = DofNumbering::build_3d(&input);
+    let pre_solve_diags = super::pre_solve_gates::run_pre_solve_gates_3d(&input);
 
     // ── Input validation (before assembly) ──
-    validate_input_3d(input)?;
+    validate_input_3d(&input)?;
 
     let n = dof_num.n_total;
     let nf = dof_num.n_free;
@@ -546,94 +689,59 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
 
     // Fully restrained: all DOFs are restrained, no solve needed.
     if nf == 0 {
-        let asm = assemble_3d(input, &dof_num);
-        let mut u_full = vec![0.0; n];
-        for i in 0..nr {
-            u_full[i] = u_r[i];
-        }
+        let stiff = assemble_stiffness_3d(&input, &dof_num);
+        let u_full = u_r.clone();
 
-        // Reactions = K * u_r - F  (all DOFs restrained)
-        let f_r: Vec<f64> = asm.f.clone();
-        let k_rr_ur = if u_r.iter().any(|v| v.abs() > 1e-15) {
+        // K · u_full via dense matvec (needed for reactions: R = K·u_r − F)
+        let ku_full = if u_r.iter().any(|v| v.abs() > 1e-15) {
             let mut ku = vec![0.0; n];
             for i in 0..n {
                 for j in 0..n {
-                    ku[i] += asm.k[i * n + j] * u_full[j];
+                    ku[i] += stiff.k[i * n + j] * u_full[j];
                 }
             }
             ku
         } else {
             vec![0.0; n]
         };
-        let mut reactions_vec = vec![0.0; nr];
-        for i in 0..nr {
-            reactions_vec[i] = k_rr_ur[i] - f_r[i];
-        }
 
-        let displacements = build_displacements_3d(&dof_num, &u_full);
-        let mut reactions = build_reactions_3d_inclined(
-            input, &dof_num, &reactions_vec, &f_r, nf, &u_full, &asm.inclined_transforms,
-        );
-        reactions.sort_by_key(|r| r.node_id);
-        let mut element_forces = compute_internal_forces_3d(input, &dof_num, &u_full);
-        element_forces.sort_by_key(|ef| ef.element_id);
-        let plate_stresses = compute_plate_stresses(input, &dof_num, &u_full);
-        let quad_stresses = compute_quad_stresses(input, &dof_num, &u_full);
-
-        let equilibrium = compute_equilibrium_summary_3d(&asm.f, &reactions_vec, &dof_num, 0.0, &asm.inclined_transforms);
-
-        let mut structured = Vec::new();
-        structured.extend(pre_solve_diags);
-        structured.push(StructuredDiagnostic::global(
-            DiagnosticCode::ResidualOk,
-            Severity::Info,
-            format!("Fully restrained model (0 free DOFs, {} restrained)", nr),
-        ).with_phase("solve"));
-
-        let mut results = AnalysisResults3D {
-            displacements,
-            reactions,
-            element_forces,
-            plate_stresses,
-            quad_stresses,
-            quad_nodal_stresses: compute_quad_nodal_stresses(input, &dof_num, &u_full),
-            constraint_forces: vec![],
-            diagnostics: asm.diagnostics,
-            solver_diagnostics: vec![],
-            structured_diagnostics: structured,
-            equilibrium: Some(equilibrium),
-            timings: None,
-            result_summary: None,
-            solver_run_meta: Some(SolverRunMeta::new(
-                "fully_restrained", nf, n_elements, n_nodes,
-            )),
-        };
-        results.result_summary = Some(crate::postprocess::result_summary::compute_result_summary_3d(&results));
-        return Ok(results);
+        return Ok(PreparedStatic3D {
+            input,
+            dof_num,
+            n,
+            nf,
+            nr,
+            n_elements,
+            n_nodes,
+            u_r,
+            pre_solve_diags,
+            path: PreparedPath3D::FullyRestrained(FullyRestrained3D {
+                ku_full,
+                diagnostics: stiff.diagnostics,
+                inclined_transforms: stiff.inclined_transforms,
+            }),
+        });
     }
 
     if nf >= SPARSE_THRESHOLD {
         // ── Sparse path: O(nnz) assembly, no dense n×n matrix ──
-        let t_total = now_micros();
-
         let t0 = now_micros();
-        let asm = super::sparse_assembly::assemble_sparse_3d_parallel(input, &dof_num, true);
+        let stiff = super::sparse_assembly::assemble_stiffness_sparse_3d_parallel(&input, &dof_num, true);
         let assembly_us = now_micros().saturating_sub(t0);
 
-        let mut solver_diags: Vec<SolverDiagnostic> = Vec::new();
-        let mut dense_fb_us: u64 = 0;
+        let mut solver_diags_base: Vec<SolverDiagnostic> = Vec::new();
 
         // Sparse diagonal conditioning check
         let t0 = now_micros();
-        let cond = sparse_diagonal_conditioning(&asm.k_ff);
+        let cond = sparse_diagonal_conditioning(&stiff.k_ff);
         if cond > 1e12 {
-            solver_diags.push(SolverDiagnostic {
+            solver_diags_base.push(SolverDiagnostic {
                 category: "conditioning".into(),
                 message: format!("Extremely high diagonal ratio {:.2e} — matrix is likely ill-conditioned", cond),
                 severity: "warning".into(),
             });
         } else if cond > 1e8 {
-            solver_diags.push(SolverDiagnostic {
+            solver_diags_base.push(SolverDiagnostic {
                 category: "conditioning".into(),
                 message: format!("High diagonal ratio {:.2e} — potential conditioning issues", cond),
                 severity: "warning".into(),
@@ -641,55 +749,30 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
         }
         let conditioning_us = now_micros().saturating_sub(t0);
 
-        // F_f modified for prescribed displacements: F_f -= K_fr * u_r
-        let mut f_f: Vec<f64> = asm.f[..nf].to_vec();
-        let has_prescribed = u_r.iter().any(|v| v.abs() > 1e-15);
-        if has_prescribed {
-            let kfr_ur = asm.k_full.as_ref().unwrap().sparse_cross_block_matvec(&u_r, nf);
-            for i in 0..nf { f_f[i] -= kfr_ur[i]; }
-        }
-
-        // Dense LU fallback: used when sparse Cholesky fails or gives bad residual
-        let dense_lu_fallback = || -> Result<Vec<f64>, String> {
-            let asm_d = assemble_3d(input, &dof_num);
-            let free_idx: Vec<usize> = (0..nf).collect();
-            let rest_idx: Vec<usize> = (nf..n).collect();
-            let k_fr = extract_submatrix(&asm_d.k, n, &free_idx, &rest_idx);
-            let kfr_ur_d = mat_vec_rect(&k_fr, &u_r, nf, nr);
-            let mut f_work = extract_subvec(&asm_d.f, &free_idx);
-            for i in 0..nf { f_work[i] -= kfr_ur_d[i]; }
-            let mut k_ff_d = extract_submatrix(&asm_d.k, n, &free_idx, &free_idx);
-            lu_solve(&mut k_ff_d, &mut f_work, nf)
-                .ok_or_else(|| "Singular stiffness matrix — structure is a mechanism".to_string())
-        };
-
-        // Solve Kff * u_f = f_f (split into symbolic → numeric → solve)
+        // Symbolic + numeric factorization of K_ff (split phases, K-only)
         let t0 = now_micros();
-        let sym = symbolic_cholesky(&asm.k_ff);
+        let sym = symbolic_cholesky(&stiff.k_ff);
         let symbolic_us = now_micros().saturating_sub(t0);
-        let nnz_kff = asm.k_ff.col_ptr[nf]; // total nnz in lower triangle
+        let nnz_kff = stiff.k_ff.col_ptr[nf]; // total nnz in lower triangle
         let nnz_l = sym.l_nnz;
 
         // Try strict Cholesky first; if it fails (shell drilling DOFs),
         // regularize K_ff with a diagonal shift and retry.
         let t0 = now_micros();
-        let num_result = numeric_cholesky(&sym, &asm.k_ff);
+        let num_result = numeric_cholesky(&sym, &stiff.k_ff);
         let numeric_us = now_micros().saturating_sub(t0);
 
-        let mut pivot_perturbations = 0usize;
-        let mut max_perturbation_val = 0.0f64;
-
         let num = if let Some(n) = num_result {
-            n
+            Some((n, false, 0.0))
         } else {
             // Regularize: clone K_ff and add a diagonal shift to make it SPD.
             // Try increasing shifts until Cholesky succeeds.
-            let max_d = asm.max_diag_k;
+            let max_d = stiff.max_diag_k;
             let mut factored = None;
             let mut shift = 0.0;
             for &alpha in &[1e-6, 1e-4, 1e-2, 1e-1, 1.0, 10.0] {
                 shift = alpha * max_d;
-                let mut k_reg = asm.k_ff.clone();
+                let mut k_reg = stiff.k_ff.clone();
                 for j in 0..nf {
                     for p in k_reg.col_ptr[j]..k_reg.col_ptr[j + 1] {
                         if k_reg.row_idx[p] == j {
@@ -703,176 +786,485 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
                     break;
                 }
             }
-            match factored {
-                Some(n) => {
-                    pivot_perturbations = nf;
-                    max_perturbation_val = shift;
-                    solver_diags.push(SolverDiagnostic {
+            factored.map(|n| (n, true, shift))
+        };
+
+        let has_prescribed = u_r.iter().any(|v| v.abs() > 1e-15);
+
+        match num {
+            Some((num, regularized, max_perturbation)) => {
+                if regularized {
+                    solver_diags_base.push(SolverDiagnostic {
                         category: "solver_path".into(),
                         message: format!(
                             "Regularized K_ff with diagonal shift {:.2e} (drilling DOF stabilization)",
-                            shift
+                            max_perturbation
                         ),
                         severity: "info".into(),
                     });
-                    n
                 }
-                None => {
-                    // All shifts failed — fall back to dense LU
-                    solver_diags.push(SolverDiagnostic {
-                        category: "fallback".into(),
-                        message: "Sparse Cholesky failed even with regularization, fell back to dense LU".into(),
-                        severity: "warning".into(),
-                    });
-                    let t0 = now_micros();
-                    let u_fb = dense_lu_fallback()?;
-                    dense_fb_us = now_micros().saturating_sub(t0);
-                    // Jump to timings construction
-                    let total_us = now_micros().saturating_sub(t_total);
-                    let timings = SolveTimings {
-                        assembly_ms: micros_to_ms(assembly_us),
-                        conditioning_ms: micros_to_ms(conditioning_us),
-                        symbolic_ms: micros_to_ms(symbolic_us),
-                        numeric_ms: micros_to_ms(numeric_us),
-                        solve_ms: 0.0,
-                        residual_ms: 0.0,
-                        dense_fallback_ms: micros_to_ms(dense_fb_us),
-                        reactions_ms: 0.0,
-                        stress_recovery_ms: 0.0,
-                        total_ms: micros_to_ms(total_us),
-                        n_free: nf, nnz_kff, nnz_l,
-                        pivot_perturbations: 0, max_perturbation: 0.0,
-                    };
-                    // Build full solution and return early
-                    let mut u_full = vec![0.0; n];
-                    u_full[..nf].copy_from_slice(&u_fb);
-                    for i in 0..nr { u_full[nf + i] = u_r[i]; }
-                    let ku_full = asm.k_full.as_ref().unwrap().sym_mat_vec(&u_full);
-                    let mut reactions_vec = vec![0.0; nr];
-                    let f_r: Vec<f64> = asm.f[nf..].to_vec();
-                    for i in 0..nr { reactions_vec[i] = ku_full[nf + i] - f_r[i]; }
-                    for it in &asm.inclined_transforms {
-                        reverse_inclined_transform(&mut u_full, &it.dofs, &it.r);
-                    }
-                    let displacements = build_displacements_3d(&dof_num, &u_full);
-                    let mut reactions = build_reactions_3d_inclined(
-                        input, &dof_num, &reactions_vec, &f_r, nf, &u_full, &asm.inclined_transforms,
-                    );
-                    reactions.sort_by_key(|r| r.node_id);
-                    let mut element_forces = compute_internal_forces_3d(input, &dof_num, &u_full);
-                    element_forces.sort_by_key(|ef| ef.element_id);
-                    let plate_stresses = compute_plate_stresses(input, &dof_num, &u_full);
-                    let quad_stresses = compute_quad_stresses(input, &dof_num, &u_full);
+                // Prescribed-displacement coupling F_f −= K_fr · u_r (K-only)
+                let kfr_ur = if has_prescribed {
+                    stiff.k_full.as_ref().unwrap().sparse_cross_block_matvec(&u_r, nf)
+                } else {
+                    vec![0.0; nf]
+                };
+                Ok(PreparedStatic3D {
+                    input,
+                    dof_num,
+                    n,
+                    nf,
+                    nr,
+                    n_elements,
+                    n_nodes,
+                    u_r,
+                    pre_solve_diags,
+                    path: PreparedPath3D::Sparse(SparsePrepared3D {
+                        k_ff: stiff.k_ff,
+                        k_full: stiff.k_full.unwrap(),
+                        num,
+                        regularized,
+                        max_perturbation,
+                        kfr_ur,
+                        cond,
+                        nnz_kff,
+                        nnz_l,
+                        diagnostics: stiff.diagnostics,
+                        inclined_transforms: stiff.inclined_transforms,
+                        solver_diags_base,
+                        assembly_us,
+                        conditioning_us,
+                        symbolic_us,
+                        numeric_us,
+                    }),
+                })
+            }
+            None => {
+                // All shifts failed — fall back to dense LU (factorized once
+                // here; the factorization depends only on K, not the loads).
+                solver_diags_base.push(SolverDiagnostic {
+                    category: "fallback".into(),
+                    message: "Sparse Cholesky failed even with regularization, fell back to dense LU".into(),
+                    severity: "warning".into(),
+                });
+                let t0 = now_micros();
+                let stiff_d = assemble_stiffness_3d(&input, &dof_num);
+                let free_idx: Vec<usize> = (0..nf).collect();
+                let rest_idx: Vec<usize> = (nf..n).collect();
+                let k_fr_d = extract_submatrix(&stiff_d.k, n, &free_idx, &rest_idx);
+                let k_fr_ur = mat_vec_rect(&k_fr_d, &u_r, nf, nr);
+                let mut k_ff_d = extract_submatrix(&stiff_d.k, n, &free_idx, &free_idx);
+                let piv = lu_factor(&mut k_ff_d, nf)
+                    .ok_or_else(|| "Singular stiffness matrix — structure is a mechanism".to_string())?;
+                let dense_fb_us = now_micros().saturating_sub(t0);
+                Ok(PreparedStatic3D {
+                    input,
+                    dof_num,
+                    n,
+                    nf,
+                    nr,
+                    n_elements,
+                    n_nodes,
+                    u_r,
+                    pre_solve_diags,
+                    path: PreparedPath3D::SparseDenseLu(SparseDenseLuPrepared3D {
+                        k_full: stiff.k_full.unwrap(),
+                        lu: k_ff_d,
+                        piv,
+                        k_fr_ur,
+                        cond,
+                        nnz_kff,
+                        nnz_l,
+                        diagnostics: stiff.diagnostics,
+                        inclined_transforms: stiff.inclined_transforms,
+                        dense_inclined_transforms: stiff_d.inclined_transforms,
+                        solver_diags_base,
+                        assembly_us,
+                        conditioning_us,
+                        symbolic_us,
+                        numeric_us,
+                        dense_fb_us,
+                    }),
+                })
+            }
+        }
+    } else {
+        // ── Dense path: small models (nf < 64) ──
+        let stiff = assemble_stiffness_3d(&input, &dof_num);
 
-                    // Compute actual residual: ||K*u - F||_free / ||F||_free
-                    let rel_residual = {
-                        let mut res2 = 0.0f64;
-                        let mut f2 = 0.0f64;
-                        for i in 0..nf {
-                            let r = ku_full[i] - asm.f[i];
-                            res2 += r * r;
-                            f2 += asm.f[i] * asm.f[i];
-                        }
-                        res2.sqrt() / f2.sqrt().max(1e-30)
-                    };
+        let free_idx: Vec<usize> = (0..nf).collect();
+        let rest_idx: Vec<usize> = (nf..n).collect();
+        let k_ff = extract_submatrix(&stiff.k, n, &free_idx, &free_idx);
 
-                    let equilibrium = compute_equilibrium_summary_3d(&asm.f, &reactions_vec, &dof_num, rel_residual, &asm.inclined_transforms);
+        // Dense conditioning check
+        let cond_report = super::conditioning::check_conditioning(&k_ff, nf);
+        let mut solver_diags_base: Vec<SolverDiagnostic> = Vec::new();
+        for w in &cond_report.warnings {
+            solver_diags_base.push(SolverDiagnostic {
+                category: "conditioning".into(),
+                message: w.clone(),
+                severity: "warning".into(),
+            });
+        }
 
-                    // Build structured diagnostics for fallback path
-                    let mut structured = Vec::new();
-                    structured.extend(pre_solve_diags.clone());
-                    structured.push(StructuredDiagnostic::global(
-                        DiagnosticCode::SparseFallbackDenseLu,
-                        Severity::Warning,
-                        format!("Sparse Cholesky failed, fell back to dense LU ({} free DOFs)", nf),
-                    ).with_phase("solve"));
+        // Prescribed-displacement coupling and reaction blocks (K-only)
+        let k_fr = extract_submatrix(&stiff.k, n, &free_idx, &rest_idx);
+        let k_fr_ur = mat_vec_rect(&k_fr, &u_r, nf, nr);
+        let k_rf = extract_submatrix(&stiff.k, n, &rest_idx, &free_idx);
+        let k_rr = extract_submatrix(&stiff.k, n, &rest_idx, &rest_idx);
+        let k_rr_ur = mat_vec_rect(&k_rr, &u_r, nr, nr);
 
-                    // LU fallback stability warning
-                    structured.push(StructuredDiagnostic::global(
-                        DiagnosticCode::CholeskyFailedLuFallback,
-                        Severity::Warning,
-                        "Cholesky factorization failed — LU fallback succeeded but model may be unstable (not positive-definite)".to_string(),
-                    ).with_phase("solve"));
-
-                    // Displacement sanity check — translational DOFs only
-                    let max_disp = dof_num.map.iter()
-                        .filter(|&(&(_node, local_dof), &global)| local_dof < 3 && global < nf)
-                        .map(|(&_, &global)| u_fb[global].abs())
-                        .fold(0.0f64, f64::max);
-                    let char_length = {
-                        let (mut mn_x, mut mx_x) = (f64::MAX, f64::MIN);
-                        let (mut mn_y, mut mx_y) = (f64::MAX, f64::MIN);
-                        let (mut mn_z, mut mx_z) = (f64::MAX, f64::MIN);
-                        for node in input.nodes.values() {
-                            mn_x = mn_x.min(node.x); mx_x = mx_x.max(node.x);
-                            mn_y = mn_y.min(node.y); mx_y = mx_y.max(node.y);
-                            mn_z = mn_z.min(node.z); mx_z = mx_z.max(node.z);
-                        }
-                        ((mx_x - mn_x).powi(2) + (mx_y - mn_y).powi(2) + (mx_z - mn_z).powi(2)).sqrt().max(1.0)
-                    };
-                    if max_disp > 1000.0 * char_length {
-                        structured.push(StructuredDiagnostic::global(
-                            DiagnosticCode::ExcessiveDisplacement,
-                            Severity::Warning,
-                            format!(
-                                "Maximum displacement {:.2e} exceeds 1000× characteristic length {:.2e} — likely mechanism or instability",
-                                max_disp, char_length
-                            ),
-                        ).with_value(max_disp, 1000.0 * char_length).with_phase("solve"));
-                    }
-
-                    if cond > 1e12 {
-                        structured.push(StructuredDiagnostic::global(
-                            DiagnosticCode::ExtremelyHighDiagonalRatio,
-                            Severity::Warning,
-                            format!("Extremely high diagonal ratio {:.2e}", cond),
-                        ).with_value(cond, 1e12).with_phase("conditioning"));
-                    } else if cond > 1e8 {
-                        structured.push(StructuredDiagnostic::global(
-                            DiagnosticCode::HighDiagonalRatio,
-                            Severity::Warning,
-                            format!("High diagonal ratio {:.2e}", cond),
-                        ).with_value(cond, 1e8).with_phase("conditioning"));
-                    }
-
-                    // Residual diagnostic with actual computed value
-                    structured.push(if rel_residual < 1e-6 {
-                        StructuredDiagnostic::global(
-                            DiagnosticCode::ResidualOk,
-                            Severity::Info,
-                            format!("Dense LU fallback ({} free DOFs, residual {:.2e})", nf, rel_residual),
-                        ).with_value(rel_residual, 1e-6).with_phase("solve")
-                    } else {
-                        StructuredDiagnostic::global(
-                            DiagnosticCode::ResidualHigh,
-                            Severity::Warning,
-                            format!("Dense LU fallback residual {:.2e} exceeds tolerance", rel_residual),
-                        ).with_value(rel_residual, 1e-6).with_phase("solve")
-                    });
-
-                    let mut results = AnalysisResults3D {
-                        displacements, reactions, element_forces, plate_stresses, quad_stresses,
-                        quad_nodal_stresses: compute_quad_nodal_stresses(input, &dof_num, &u_full),
-                        constraint_forces: vec![], diagnostics: asm.diagnostics,
-                        solver_diagnostics: solver_diags, structured_diagnostics: structured, equilibrium: Some(equilibrium), timings: Some(timings), result_summary: None,
-                        solver_run_meta: Some(SolverRunMeta::new(
-                            "sparse_fallback_dense_lu", nf, n_elements, n_nodes,
-                        )),
-                    };
-                    results.result_summary = Some(crate::postprocess::result_summary::compute_result_summary_3d(&results));
-                    return Ok(results);
-                }
+        // Factor K_ff once (Cholesky, LU on failure — K-only decision)
+        let (factor, cholesky_failed) = {
+            let mut k_work = k_ff.clone();
+            if cholesky_decompose(&mut k_work, nf) {
+                (FactorizedKff::DenseCholesky(k_work), false)
+            } else {
+                let mut k_work = k_ff.clone();
+                let piv = lu_factor(&mut k_work, nf)
+                    .ok_or_else(|| "Singular stiffness matrix — structure is a mechanism".to_string())?;
+                (FactorizedKff::DenseLu { lu: k_work, piv }, true)
             }
         };
 
+        Ok(PreparedStatic3D {
+            input,
+            dof_num,
+            n,
+            nf,
+            nr,
+            n_elements,
+            n_nodes,
+            u_r,
+            pre_solve_diags,
+            path: PreparedPath3D::Dense(DensePrepared3D {
+                k_ff,
+                k_rf,
+                k_fr_ur,
+                k_rr_ur,
+                factor,
+                cholesky_failed,
+                cond_report,
+                diagnostics: stiff.diagnostics,
+                inclined_transforms: stiff.inclined_transforms,
+                solver_diags_base,
+            }),
+        })
+    }
+}
+
+impl PreparedStatic3D {
+    /// Solve the prepared 3D structure for one load set. Rebuilds only the
+    /// load vector (prescribed-displacement coupling included), reuses the
+    /// stored factorization, then runs the same postprocessing as `solve_3d`.
+    pub fn solve_loads(&self, loads: &[SolverLoad3D]) -> Result<AnalysisResults3D, String> {
+        // Per-case load validation (the structure was validated in prepare)
+        validate_loads_3d(&self.input, loads)?;
+        match &self.path {
+            PreparedPath3D::FullyRestrained(p) => self.solve_loads_fully_restrained(loads, p),
+            PreparedPath3D::Dense(p) => self.solve_loads_dense(loads, p),
+            PreparedPath3D::Sparse(p) => self.solve_loads_sparse(loads, p),
+            PreparedPath3D::SparseDenseLu(p) => self.solve_loads_sparse_dense_lu(loads, p),
+        }
+    }
+
+    fn solve_loads_fully_restrained(
+        &self,
+        loads: &[SolverLoad3D],
+        p: &FullyRestrained3D,
+    ) -> Result<AnalysisResults3D, String> {
+        let input = &self.input;
+        let dof_num = &self.dof_num;
+        let nf = self.nf;
+        let nr = self.nr;
+        let f = assemble_load_vector_3d_dense(input, loads, dof_num, &p.inclined_transforms);
+        let u_full = self.u_r.clone();
+
+        // Reactions = K · u_r − F  (all DOFs restrained)
+        let f_r: Vec<f64> = f.clone();
+        let mut reactions_vec = vec![0.0; nr];
+        for i in 0..nr {
+            reactions_vec[i] = p.ku_full[i] - f_r[i];
+        }
+
+        let displacements = build_displacements_3d(dof_num, &u_full);
+        let mut reactions = build_reactions_3d_inclined(
+            input, dof_num, &reactions_vec, &f_r, nf, &u_full, &p.inclined_transforms,
+        );
+        reactions.sort_by_key(|r| r.node_id);
+        let mut element_forces = compute_internal_forces_3d_with_loads(input, loads, dof_num, &u_full);
+        element_forces.sort_by_key(|ef| ef.element_id);
+        let plate_stresses = compute_plate_stresses(input, dof_num, &u_full);
+        let quad_stresses = compute_quad_stresses(input, dof_num, &u_full);
+
+        let equilibrium = compute_equilibrium_summary_3d(&f, &reactions_vec, dof_num, 0.0, &p.inclined_transforms);
+
+        let mut structured = Vec::new();
+        structured.extend(self.pre_solve_diags.iter().cloned());
+        structured.push(StructuredDiagnostic::global(
+            DiagnosticCode::ResidualOk,
+            Severity::Info,
+            format!("Fully restrained model (0 free DOFs, {} restrained)", nr),
+        ).with_phase("solve"));
+
+        let mut results = AnalysisResults3D {
+            displacements,
+            reactions,
+            element_forces,
+            plate_stresses,
+            quad_stresses,
+            quad_nodal_stresses: compute_quad_nodal_stresses(input, dof_num, &u_full),
+            constraint_forces: vec![],
+            diagnostics: p.diagnostics.clone(),
+            solver_diagnostics: vec![],
+            structured_diagnostics: structured,
+            equilibrium: Some(equilibrium),
+            timings: None,
+            result_summary: None,
+            solver_run_meta: Some(SolverRunMeta::new(
+                "fully_restrained", nf, self.n_elements, self.n_nodes,
+            )),
+        };
+        results.result_summary = Some(crate::postprocess::result_summary::compute_result_summary_3d(&results));
+        Ok(results)
+    }
+
+    fn solve_loads_dense(
+        &self,
+        loads: &[SolverLoad3D],
+        p: &DensePrepared3D,
+    ) -> Result<AnalysisResults3D, String> {
+        let input = &self.input;
+        let dof_num = &self.dof_num;
+        let (n, nf, nr) = (self.n, self.nf, self.nr);
+
+        let f = assemble_load_vector_3d_dense(input, loads, dof_num, &p.inclined_transforms);
+
+        // F_f_modified = F_f − K_fr · u_r
+        let mut f_f: Vec<f64> = f[..nf].to_vec();
+        for i in 0..nf { f_f[i] -= p.k_fr_ur[i]; }
+
+        let u_f = match &p.factor {
+            FactorizedKff::DenseCholesky(l) => {
+                let y = forward_solve(l, &f_f, nf);
+                back_solve(l, &y, nf)
+            }
+            FactorizedKff::DenseLu { lu, piv } => {
+                lu_apply(lu, piv, &f_f, nf)
+                    .ok_or_else(|| "Singular stiffness matrix — structure is a mechanism".to_string())?
+            }
+            FactorizedKff::SparseCholesky(_) => unreachable!("dense path holds dense factors"),
+        };
+
+        let mut solver_diags = p.solver_diags_base.clone();
+        solver_diags.push(SolverDiagnostic {
+            category: "solver_path".into(),
+            message: format!("Dense solver ({} free DOFs)", nf),
+            severity: "info".into(),
+        });
+
+        // Compute residual: ||K_ff · u_f − f_f|| / ||f_f||
+        let rel_residual = {
+            let mut res2 = 0.0f64;
+            let mut f2 = 0.0f64;
+            for i in 0..nf {
+                let mut ku_i = 0.0;
+                for j in 0..nf {
+                    ku_i += p.k_ff[i * nf + j] * u_f[j];
+                }
+                let r = ku_i - f_f[i];
+                res2 += r * r;
+                f2 += f_f[i] * f_f[i];
+            }
+            res2.sqrt() / f2.sqrt().max(1e-30)
+        };
+
+        let mut u_full = vec![0.0; n];
+        for i in 0..nf { u_full[i] = u_f[i]; }
+        for i in 0..nr { u_full[nf + i] = self.u_r[i]; }
+
+        // Compute reactions: R = K_rf · u_f + K_rr · u_r − F_r
+        let f_r: Vec<f64> = f[nf..].to_vec();
+        let k_rf_uf = mat_vec_rect(&p.k_rf, &u_f, nr, nf);
+        let mut reactions_vec = vec![0.0; nr];
+        for i in 0..nr {
+            reactions_vec[i] = k_rf_uf[i] + p.k_rr_ur[i] - f_r[i];
+        }
+
+        // Reverse inclined support rotations on displacements
+        for it in &p.inclined_transforms {
+            reverse_inclined_transform(&mut u_full, &it.dofs, &it.r);
+        }
+
+        let displacements = build_displacements_3d(dof_num, &u_full);
+        let mut reactions = build_reactions_3d_inclined(
+            input, dof_num, &reactions_vec, &f_r, nf, &u_full, &p.inclined_transforms,
+        );
+        reactions.sort_by_key(|r| r.node_id);
+        let mut element_forces = compute_internal_forces_3d_with_loads(input, loads, dof_num, &u_full);
+        element_forces.sort_by_key(|ef| ef.element_id);
+
+        let plate_stresses = compute_plate_stresses(input, dof_num, &u_full);
+        let quad_stresses = compute_quad_stresses(input, dof_num, &u_full);
+
+        let equilibrium = compute_equilibrium_summary_3d(&f, &reactions_vec, dof_num, rel_residual, &p.inclined_transforms);
+
+        // Build structured diagnostics for dense path — same contract as sparse path
+        let mut structured = Vec::new();
+        structured.extend(self.pre_solve_diags.iter().cloned());
+
+        // Solver path
+        structured.push(StructuredDiagnostic::global(
+            DiagnosticCode::DenseLu,
+            Severity::Info,
+            format!("Dense solver ({} free DOFs)", nf),
+        ).with_phase("solve"));
+
+        // LU fallback warning
+        if p.cholesky_failed {
+            structured.push(StructuredDiagnostic::global(
+                DiagnosticCode::CholeskyFailedLuFallback,
+                Severity::Warning,
+                "Cholesky factorization failed — LU fallback succeeded but model may be unstable (not positive-definite)".to_string(),
+            ).with_phase("solve"));
+        }
+
+        // Displacement sanity check — translational DOFs only
+        let max_disp = dof_num.map.iter()
+            .filter(|&(&(_node, local_dof), &global)| local_dof < 3 && global < nf)
+            .map(|(&_, &global)| u_f[global].abs())
+            .fold(0.0f64, f64::max);
+        let char_length = {
+            let (mut mn_x, mut mx_x) = (f64::MAX, f64::MIN);
+            let (mut mn_y, mut mx_y) = (f64::MAX, f64::MIN);
+            let (mut mn_z, mut mx_z) = (f64::MAX, f64::MIN);
+            for node in input.nodes.values() {
+                mn_x = mn_x.min(node.x); mx_x = mx_x.max(node.x);
+                mn_y = mn_y.min(node.y); mx_y = mx_y.max(node.y);
+                mn_z = mn_z.min(node.z); mx_z = mx_z.max(node.z);
+            }
+            ((mx_x - mn_x).powi(2) + (mx_y - mn_y).powi(2) + (mx_z - mn_z).powi(2)).sqrt().max(1.0)
+        };
+        if max_disp > 1000.0 * char_length {
+            structured.push(StructuredDiagnostic::global(
+                DiagnosticCode::ExcessiveDisplacement,
+                Severity::Warning,
+                format!(
+                    "Maximum displacement {:.2e} exceeds 1000× characteristic length {:.2e} — likely mechanism or instability",
+                    max_disp, char_length
+                ),
+            ).with_value(max_disp, 1000.0 * char_length).with_phase("solve"));
+        }
+
+        // Conditioning
+        let cond = p.cond_report.diagonal_ratio;
+        if cond > 1e12 {
+            structured.push(StructuredDiagnostic::global(
+                DiagnosticCode::ExtremelyHighDiagonalRatio,
+                Severity::Warning,
+                format!("Extremely high diagonal ratio {:.2e}", cond),
+            ).with_value(cond, 1e12).with_phase("conditioning"));
+        } else if cond > 1e8 {
+            structured.push(StructuredDiagnostic::global(
+                DiagnosticCode::HighDiagonalRatio,
+                Severity::Warning,
+                format!("High diagonal ratio {:.2e}", cond),
+            ).with_value(cond, 1e8).with_phase("conditioning"));
+        }
+
+        if !p.cond_report.near_zero_dofs.is_empty() {
+            structured.push(StructuredDiagnostic::global(
+                DiagnosticCode::NearZeroDiagonal,
+                Severity::Warning,
+                format!("{} near-zero diagonal entries", p.cond_report.near_zero_dofs.len()),
+            ).with_dofs(p.cond_report.near_zero_dofs.clone()).with_phase("conditioning"));
+        }
+
+        // Residual
+        structured.push(if rel_residual < 1e-6 {
+            StructuredDiagnostic::global(
+                DiagnosticCode::ResidualOk,
+                Severity::Info,
+                format!("Dense solver residual {:.2e} ({} free DOFs)", rel_residual, nf),
+            ).with_value(rel_residual, 1e-6).with_phase("solve")
+        } else {
+            StructuredDiagnostic::global(
+                DiagnosticCode::ResidualHigh,
+                Severity::Warning,
+                format!("Dense solver residual {:.2e} exceeds tolerance ({} free DOFs)", rel_residual, nf),
+            ).with_value(rel_residual, 1e-6).with_phase("solve")
+        });
+
+        let mut results = AnalysisResults3D {
+            displacements,
+            reactions,
+            element_forces,
+            plate_stresses,
+            quad_stresses,
+            quad_nodal_stresses: compute_quad_nodal_stresses(input, dof_num, &u_full),
+            constraint_forces: vec![],
+            diagnostics: p.diagnostics.clone(),
+            solver_diagnostics: solver_diags,
+            structured_diagnostics: structured,
+            equilibrium: Some(equilibrium),
+            timings: None,
+            result_summary: None,
+            solver_run_meta: Some(SolverRunMeta::new(
+                "dense_lu", nf, self.n_elements, self.n_nodes,
+            )),
+        };
+        results.result_summary = Some(crate::postprocess::result_summary::compute_result_summary_3d(&results));
+        Ok(results)
+    }
+
+    /// Dense LU fallback (per case): dense K_ff factor + dense load vector.
+    /// Used when the sparse Cholesky solve gives a bad residual.
+    fn dense_lu_fallback_3d(&self, loads: &[SolverLoad3D]) -> Result<Vec<f64>, String> {
+        let input = &self.input;
+        let dof_num = &self.dof_num;
+        let (n, nf, nr) = (self.n, self.nf, self.nr);
+        let stiff_d = assemble_stiffness_3d(input, dof_num);
+        let f_d = assemble_load_vector_3d_dense(input, loads, dof_num, &stiff_d.inclined_transforms);
+        let free_idx: Vec<usize> = (0..nf).collect();
+        let rest_idx: Vec<usize> = (nf..n).collect();
+        let k_fr = extract_submatrix(&stiff_d.k, n, &free_idx, &rest_idx);
+        let kfr_ur_d = mat_vec_rect(&k_fr, &self.u_r, nf, nr);
+        let mut f_work: Vec<f64> = f_d[..nf].to_vec();
+        for i in 0..nf { f_work[i] -= kfr_ur_d[i]; }
+        let mut k_ff_d = extract_submatrix(&stiff_d.k, n, &free_idx, &free_idx);
+        lu_solve(&mut k_ff_d, &mut f_work, nf)
+            .ok_or_else(|| "Singular stiffness matrix — structure is a mechanism".to_string())
+    }
+
+    fn solve_loads_sparse(
+        &self,
+        loads: &[SolverLoad3D],
+        p: &SparsePrepared3D,
+    ) -> Result<AnalysisResults3D, String> {
+        let t_total = now_micros();
+        let input = &self.input;
+        let dof_num = &self.dof_num;
+        let (n, nf, nr) = (self.n, self.nf, self.nr);
+
+        // Rebuild only the load vector for this case
+        let f = super::sparse_assembly::assemble_load_vector_sparse_3d(input, loads, dof_num, &p.inclined_transforms);
+
+        let mut solver_diags = p.solver_diags_base.clone();
+        let mut dense_fb_us: u64 = 0;
+
+        // F_f modified for prescribed displacements: F_f −= K_fr · u_r (precomputed)
+        let mut f_f: Vec<f64> = f[..nf].to_vec();
+        for i in 0..nf { f_f[i] -= p.kfr_ur[i]; }
+
+        // Triangular solve with the precomputed sparse Cholesky factor
         let t0 = now_micros();
-        let mut u = sparse_cholesky_solve(&num, &f_f);
+        let mut u = sparse_cholesky_solve(&p.num, &f_f);
 
         // Iterative refinement against the ORIGINAL K_ff to correct for
         // the regularization shift. Up to 5 steps of residual correction.
-        if pivot_perturbations > 0 {
+        if p.regularized {
             for _ in 0..5 {
-                let ku = asm.k_ff.sym_mat_vec(&u);
+                let ku = p.k_ff.sym_mat_vec(&u);
                 let mut residual: Vec<f64> = vec![0.0; nf];
                 let mut res2 = 0.0f64;
                 let mut f2 = 0.0f64;
@@ -884,7 +1276,7 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
                 if res2.sqrt() / f2.sqrt().max(1e-30) < 1e-10 {
                     break;
                 }
-                let du = sparse_cholesky_solve(&num, &residual);
+                let du = sparse_cholesky_solve(&p.num, &residual);
                 for i in 0..nf {
                     u[i] += du[i];
                 }
@@ -894,7 +1286,7 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
 
         // Verify final solution quality via residual check.
         let t0 = now_micros();
-        let ku = asm.k_ff.sym_mat_vec(&u);
+        let ku = p.k_ff.sym_mat_vec(&u);
         let mut res_norm2 = 0.0f64;
         let mut f_norm2 = 0.0f64;
         for i in 0..nf {
@@ -923,7 +1315,7 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
             });
             used_residual_fallback = true;
             let t0 = now_micros();
-            let u_fb = dense_lu_fallback()?;
+            let u_fb = self.dense_lu_fallback_3d(loads)?;
             dense_fb_us = now_micros().saturating_sub(t0);
             (u_fb, s_us, r_us)
         };
@@ -931,13 +1323,13 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
         // Build full displacement vector
         let mut u_full = vec![0.0; n];
         u_full[..nf].copy_from_slice(&u_f);
-        for i in 0..nr { u_full[nf + i] = u_r[i]; }
+        for i in 0..nr { u_full[nf + i] = self.u_r[i]; }
 
-        // Reactions via full-K sym_mat_vec: R[i] = (K*u)[i] - F[i] for restrained DOFs
+        // Reactions via full-K sym_mat_vec: R[i] = (K·u)[i] − F[i] for restrained DOFs
         let t0 = now_micros();
-        let ku = asm.k_full.as_ref().unwrap().sym_mat_vec(&u_full);
+        let ku = p.k_full.sym_mat_vec(&u_full);
         let mut reactions_vec = vec![0.0; nr];
-        let f_r: Vec<f64> = asm.f[nf..].to_vec();
+        let f_r: Vec<f64> = f[nf..].to_vec();
         for i in 0..nr {
             reactions_vec[i] = ku[nf + i] - f_r[i];
         }
@@ -950,9 +1342,9 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
             let mut res2 = 0.0f64;
             let mut f2 = 0.0f64;
             for i in 0..nf {
-                let r = ku[i] - asm.f[i];
+                let r = ku[i] - f[i];
                 res2 += r * r;
-                f2 += asm.f[i] * asm.f[i];
+                f2 += f[i] * f[i];
             }
             res2.sqrt() / f2.sqrt().max(1e-30)
         } else {
@@ -960,31 +1352,32 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
         };
 
         // Reverse inclined support rotations on displacements
-        for it in &asm.inclined_transforms {
+        for it in &p.inclined_transforms {
             reverse_inclined_transform(&mut u_full, &it.dofs, &it.r);
         }
 
-        let displacements = build_displacements_3d(&dof_num, &u_full);
+        let displacements = build_displacements_3d(dof_num, &u_full);
         let mut reactions = build_reactions_3d_inclined(
-            input, &dof_num, &reactions_vec, &f_r, nf, &u_full, &asm.inclined_transforms,
+            input, dof_num, &reactions_vec, &f_r, nf, &u_full, &p.inclined_transforms,
         );
         reactions.sort_by_key(|r| r.node_id);
-        let mut element_forces = compute_internal_forces_3d(input, &dof_num, &u_full);
+        let mut element_forces = compute_internal_forces_3d_with_loads(input, loads, dof_num, &u_full);
         element_forces.sort_by_key(|ef| ef.element_id);
         let reactions_us = now_micros().saturating_sub(t0);
 
         let t0 = now_micros();
-        let plate_stresses = compute_plate_stresses(input, &dof_num, &u_full);
-        let quad_stresses = compute_quad_stresses(input, &dof_num, &u_full);
+        let plate_stresses = compute_plate_stresses(input, dof_num, &u_full);
+        let quad_stresses = compute_quad_stresses(input, dof_num, &u_full);
         let stress_recovery_us = now_micros().saturating_sub(t0);
 
-        let total_us = now_micros().saturating_sub(t_total);
+        let total_us = (p.assembly_us + p.conditioning_us + p.symbolic_us + p.numeric_us)
+            + now_micros().saturating_sub(t_total);
 
         let timings = SolveTimings {
-            assembly_ms: micros_to_ms(assembly_us),
-            conditioning_ms: micros_to_ms(conditioning_us),
-            symbolic_ms: micros_to_ms(symbolic_us),
-            numeric_ms: micros_to_ms(numeric_us),
+            assembly_ms: micros_to_ms(p.assembly_us),
+            conditioning_ms: micros_to_ms(p.conditioning_us),
+            symbolic_ms: micros_to_ms(p.symbolic_us),
+            numeric_ms: micros_to_ms(p.numeric_us),
             solve_ms: micros_to_ms(solve_us),
             residual_ms: micros_to_ms(residual_us),
             dense_fallback_ms: micros_to_ms(dense_fb_us),
@@ -992,15 +1385,15 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
             stress_recovery_ms: micros_to_ms(stress_recovery_us),
             total_ms: micros_to_ms(total_us),
             n_free: nf,
-            nnz_kff,
-            nnz_l,
-            pivot_perturbations,
-            max_perturbation: max_perturbation_val,
+            nnz_kff: p.nnz_kff,
+            nnz_l: p.nnz_l,
+            pivot_perturbations: if p.regularized { nf } else { 0 },
+            max_perturbation: p.max_perturbation,
         };
 
         // Build structured diagnostics (enum-based, machine-matchable)
         let mut structured = Vec::new();
-        structured.extend(pre_solve_diags.clone());
+        structured.extend(self.pre_solve_diags.iter().cloned());
 
         // Solver path — report the actual solver that produced the returned result
         if used_residual_fallback {
@@ -1013,40 +1406,40 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
             structured.push(StructuredDiagnostic::global(
                 DiagnosticCode::SparseCholesky,
                 Severity::Info,
-                format!("Sparse Cholesky solver ({} free DOFs, nnz(L)={})", nf, nnz_l),
+                format!("Sparse Cholesky solver ({} free DOFs, nnz(L)={})", nf, p.nnz_l),
             ).with_phase("solve"));
         }
 
         // Sparse fill ratio diagnostic
-        let fill_ratio = nnz_l as f64 / nnz_kff.max(1) as f64;
+        let fill_ratio = p.nnz_l as f64 / p.nnz_kff.max(1) as f64;
         structured.push(StructuredDiagnostic::global(
             DiagnosticCode::SparseFillRatio,
             if fill_ratio > 20.0 { Severity::Warning } else { Severity::Info },
-            format!("Sparse fill ratio: {:.1}x (nnz(K_ff)={}, nnz(L)={})", fill_ratio, nnz_kff, nnz_l),
+            format!("Sparse fill ratio: {:.1}x (nnz(K_ff)={}, nnz(L)={})", fill_ratio, p.nnz_kff, p.nnz_l),
         ).with_value(fill_ratio, 20.0).with_phase("factorization"));
 
         // Conditioning diagnostics
-        if cond > 1e12 {
+        if p.cond > 1e12 {
             structured.push(StructuredDiagnostic::global(
                 DiagnosticCode::ExtremelyHighDiagonalRatio,
                 Severity::Warning,
-                format!("Extremely high diagonal ratio {:.2e} — matrix is likely ill-conditioned", cond),
-            ).with_value(cond, 1e12).with_phase("conditioning"));
-        } else if cond > 1e8 {
+                format!("Extremely high diagonal ratio {:.2e} — matrix is likely ill-conditioned", p.cond),
+            ).with_value(p.cond, 1e12).with_phase("conditioning"));
+        } else if p.cond > 1e8 {
             structured.push(StructuredDiagnostic::global(
                 DiagnosticCode::HighDiagonalRatio,
                 Severity::Warning,
-                format!("High diagonal ratio {:.2e} — potential conditioning issues", cond),
-            ).with_value(cond, 1e8).with_phase("conditioning"));
+                format!("High diagonal ratio {:.2e} — potential conditioning issues", p.cond),
+            ).with_value(p.cond, 1e8).with_phase("conditioning"));
         }
 
         // Solver path diagnostic
-        if pivot_perturbations > 0 {
+        if p.regularized {
             structured.push(StructuredDiagnostic::global(
                 DiagnosticCode::DiagonalRegularization,
                 Severity::Info,
-                format!("Regularized K_ff with diagonal shift {:.2e}", max_perturbation_val),
-            ).with_value(max_perturbation_val, 0.0).with_phase("factorization"));
+                format!("Regularized K_ff with diagonal shift {:.2e}", p.max_perturbation),
+            ).with_value(p.max_perturbation, 0.0).with_phase("factorization"));
         }
 
         // Displacement sanity check — translational DOFs only
@@ -1093,7 +1486,7 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
         });
 
         // Compute equilibrium summary from assembled force vector (includes all load types)
-        let equilibrium = compute_equilibrium_summary_3d(&asm.f, &reactions_vec, &dof_num, rel_residual, &asm.inclined_transforms);
+        let equilibrium = compute_equilibrium_summary_3d(&f, &reactions_vec, dof_num, rel_residual, &p.inclined_transforms);
 
         let mut results = AnalysisResults3D {
             displacements,
@@ -1101,9 +1494,9 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
             element_forces,
             plate_stresses,
             quad_stresses,
-            quad_nodal_stresses: compute_quad_nodal_stresses(input, &dof_num, &u_full),
+            quad_nodal_stresses: compute_quad_nodal_stresses(input, dof_num, &u_full),
             constraint_forces: vec![],
-            diagnostics: asm.diagnostics,
+            diagnostics: p.diagnostics.clone(),
             solver_diagnostics: solver_diags,
             structured_diagnostics: structured,
             equilibrium: Some(equilibrium),
@@ -1111,130 +1504,107 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
             result_summary: None,
             solver_run_meta: Some(SolverRunMeta::new(
                 if used_residual_fallback { "sparse_fallback_dense_lu" } else { "sparse_cholesky" },
-                nf, n_elements, n_nodes,
+                nf, self.n_elements, self.n_nodes,
             )),
         };
         results.result_summary = Some(crate::postprocess::result_summary::compute_result_summary_3d(&results));
         Ok(results)
-    } else {
-        // ── Dense path: small models (nf < 64) ──
-        let asm = assemble_3d(input, &dof_num);
-        let mut solver_diags: Vec<SolverDiagnostic> = Vec::new();
+    }
 
-        let free_idx: Vec<usize> = (0..nf).collect();
-        let rest_idx: Vec<usize> = (nf..n).collect();
-        let k_ff = extract_submatrix(&asm.k, n, &free_idx, &free_idx);
-        let mut f_f = extract_subvec(&asm.f, &free_idx);
+    fn solve_loads_sparse_dense_lu(
+        &self,
+        loads: &[SolverLoad3D],
+        p: &SparseDenseLuPrepared3D,
+    ) -> Result<AnalysisResults3D, String> {
+        let t_total = now_micros();
+        let input = &self.input;
+        let dof_num = &self.dof_num;
+        let (n, nf, nr) = (self.n, self.nf, self.nr);
 
-        // Dense conditioning check
-        let cond_report = super::conditioning::check_conditioning(&k_ff, nf);
-        for w in &cond_report.warnings {
-            solver_diags.push(SolverDiagnostic {
-                category: "conditioning".into(),
-                message: w.clone(),
-                severity: "warning".into(),
-            });
-        }
+        // Dense f for the LU right-hand side (matches the old dense fallback),
+        // sparse f for reactions/equilibrium/residual (matches the old asm.f usage)
+        let f_d = assemble_load_vector_3d_dense(input, loads, dof_num, &p.dense_inclined_transforms);
+        let f = super::sparse_assembly::assemble_load_vector_sparse_3d(input, loads, dof_num, &p.inclined_transforms);
 
-        // F_f_modified = F_f - K_fr * u_r
-        let k_fr = extract_submatrix(&asm.k, n, &free_idx, &rest_idx);
-        let k_fr_ur = mat_vec_rect(&k_fr, &u_r, nf, nr);
-        for i in 0..nf { f_f[i] -= k_fr_ur[i]; }
+        let mut f_work: Vec<f64> = f_d[..nf].to_vec();
+        for i in 0..nf { f_work[i] -= p.k_fr_ur[i]; }
+        let t0 = now_micros();
+        let u_fb = lu_apply(&p.lu, &p.piv, &f_work, nf)
+            .ok_or_else(|| "Singular stiffness matrix — structure is a mechanism".to_string())?;
+        let dense_fb_us = p.dense_fb_us + now_micros().saturating_sub(t0);
 
-        let mut cholesky_failed_3d = false;
-        let u_f = {
-            let mut k_work = k_ff.clone();
-            match cholesky_solve(&mut k_work, &f_f, nf) {
-                Some(u) => u,
-                None => {
-                    cholesky_failed_3d = true;
-                    let mut k_work = k_ff.clone();
-                    let mut f_work = f_f.clone();
-                    lu_solve(&mut k_work, &mut f_work, nf)
-                        .ok_or_else(|| "Singular stiffness matrix — structure is a mechanism".to_string())?
-                }
-            }
+        let total_us = (p.assembly_us + p.conditioning_us + p.symbolic_us + p.numeric_us)
+            + now_micros().saturating_sub(t_total);
+        let timings = SolveTimings {
+            assembly_ms: micros_to_ms(p.assembly_us),
+            conditioning_ms: micros_to_ms(p.conditioning_us),
+            symbolic_ms: micros_to_ms(p.symbolic_us),
+            numeric_ms: micros_to_ms(p.numeric_us),
+            solve_ms: 0.0,
+            residual_ms: 0.0,
+            dense_fallback_ms: micros_to_ms(dense_fb_us),
+            reactions_ms: 0.0,
+            stress_recovery_ms: 0.0,
+            total_ms: micros_to_ms(total_us),
+            n_free: nf, nnz_kff: p.nnz_kff, nnz_l: p.nnz_l,
+            pivot_perturbations: 0, max_perturbation: 0.0,
         };
 
-        solver_diags.push(SolverDiagnostic {
-            category: "solver_path".into(),
-            message: format!("Dense solver ({} free DOFs)", nf),
-            severity: "info".into(),
-        });
+        // Build full solution
+        let mut u_full = vec![0.0; n];
+        u_full[..nf].copy_from_slice(&u_fb);
+        for i in 0..nr { u_full[nf + i] = self.u_r[i]; }
+        let ku_full = p.k_full.sym_mat_vec(&u_full);
+        let mut reactions_vec = vec![0.0; nr];
+        let f_r: Vec<f64> = f[nf..].to_vec();
+        for i in 0..nr { reactions_vec[i] = ku_full[nf + i] - f_r[i]; }
+        for it in &p.inclined_transforms {
+            reverse_inclined_transform(&mut u_full, &it.dofs, &it.r);
+        }
+        let displacements = build_displacements_3d(dof_num, &u_full);
+        let mut reactions = build_reactions_3d_inclined(
+            input, dof_num, &reactions_vec, &f_r, nf, &u_full, &p.inclined_transforms,
+        );
+        reactions.sort_by_key(|r| r.node_id);
+        let mut element_forces = compute_internal_forces_3d_with_loads(input, loads, dof_num, &u_full);
+        element_forces.sort_by_key(|ef| ef.element_id);
+        let plate_stresses = compute_plate_stresses(input, dof_num, &u_full);
+        let quad_stresses = compute_quad_stresses(input, dof_num, &u_full);
 
-        // Compute residual: ||K_ff * u_f - f_f|| / ||f_f||
+        // Compute actual residual: ||K·u − F||_free / ||F||_free
         let rel_residual = {
             let mut res2 = 0.0f64;
             let mut f2 = 0.0f64;
             for i in 0..nf {
-                let mut ku_i = 0.0;
-                for j in 0..nf {
-                    ku_i += k_ff[i * nf + j] * u_f[j];
-                }
-                let r = ku_i - f_f[i];
+                let r = ku_full[i] - f[i];
                 res2 += r * r;
-                f2 += f_f[i] * f_f[i];
+                f2 += f[i] * f[i];
             }
             res2.sqrt() / f2.sqrt().max(1e-30)
         };
 
-        let mut u_full = vec![0.0; n];
-        for i in 0..nf { u_full[i] = u_f[i]; }
-        for i in 0..nr { u_full[nf + i] = u_r[i]; }
+        let equilibrium = compute_equilibrium_summary_3d(&f, &reactions_vec, dof_num, rel_residual, &p.inclined_transforms);
 
-        // Compute reactions: R = K_rf * u_f + K_rr * u_r - F_r
-        let k_rf = extract_submatrix(&asm.k, n, &rest_idx, &free_idx);
-        let k_rr = extract_submatrix(&asm.k, n, &rest_idx, &rest_idx);
-        let f_r = extract_subvec(&asm.f, &rest_idx);
-        let k_rf_uf = mat_vec_rect(&k_rf, &u_f, nr, nf);
-        let k_rr_ur = mat_vec_rect(&k_rr, &u_r, nr, nr);
-        let mut reactions_vec = vec![0.0; nr];
-        for i in 0..nr {
-            reactions_vec[i] = k_rf_uf[i] + k_rr_ur[i] - f_r[i];
-        }
-
-        // Reverse inclined support rotations on displacements
-        for it in &asm.inclined_transforms {
-            reverse_inclined_transform(&mut u_full, &it.dofs, &it.r);
-        }
-
-        let displacements = build_displacements_3d(&dof_num, &u_full);
-        let mut reactions = build_reactions_3d_inclined(
-            input, &dof_num, &reactions_vec, &f_r, nf, &u_full, &asm.inclined_transforms,
-        );
-        reactions.sort_by_key(|r| r.node_id);
-        let mut element_forces = compute_internal_forces_3d(input, &dof_num, &u_full);
-        element_forces.sort_by_key(|ef| ef.element_id);
-
-        let plate_stresses = compute_plate_stresses(input, &dof_num, &u_full);
-        let quad_stresses = compute_quad_stresses(input, &dof_num, &u_full);
-
-        let equilibrium = compute_equilibrium_summary_3d(&asm.f, &reactions_vec, &dof_num, rel_residual, &asm.inclined_transforms);
-
-        // Build structured diagnostics for dense path — same contract as sparse path
+        // Build structured diagnostics for fallback path
         let mut structured = Vec::new();
-        structured.extend(pre_solve_diags);
-
-        // Solver path
+        structured.extend(self.pre_solve_diags.iter().cloned());
         structured.push(StructuredDiagnostic::global(
-            DiagnosticCode::DenseLu,
-            Severity::Info,
-            format!("Dense solver ({} free DOFs)", nf),
+            DiagnosticCode::SparseFallbackDenseLu,
+            Severity::Warning,
+            format!("Sparse Cholesky failed, fell back to dense LU ({} free DOFs)", nf),
         ).with_phase("solve"));
 
-        // LU fallback warning
-        if cholesky_failed_3d {
-            structured.push(StructuredDiagnostic::global(
-                DiagnosticCode::CholeskyFailedLuFallback,
-                Severity::Warning,
-                "Cholesky factorization failed — LU fallback succeeded but model may be unstable (not positive-definite)".to_string(),
-            ).with_phase("solve"));
-        }
+        // LU fallback stability warning
+        structured.push(StructuredDiagnostic::global(
+            DiagnosticCode::CholeskyFailedLuFallback,
+            Severity::Warning,
+            "Cholesky factorization failed — LU fallback succeeded but model may be unstable (not positive-definite)".to_string(),
+        ).with_phase("solve"));
 
         // Displacement sanity check — translational DOFs only
         let max_disp = dof_num.map.iter()
             .filter(|&(&(_node, local_dof), &global)| local_dof < 3 && global < nf)
-            .map(|(&_, &global)| u_f[global].abs())
+            .map(|(&_, &global)| u_fb[global].abs())
             .fold(0.0f64, f64::max);
         let char_length = {
             let (mut mn_x, mut mx_x) = (f64::MAX, f64::MIN);
@@ -1258,61 +1628,44 @@ pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
             ).with_value(max_disp, 1000.0 * char_length).with_phase("solve"));
         }
 
-        // Conditioning
-        let cond = cond_report.diagonal_ratio;
-        if cond > 1e12 {
+        if p.cond > 1e12 {
             structured.push(StructuredDiagnostic::global(
                 DiagnosticCode::ExtremelyHighDiagonalRatio,
                 Severity::Warning,
-                format!("Extremely high diagonal ratio {:.2e}", cond),
-            ).with_value(cond, 1e12).with_phase("conditioning"));
-        } else if cond > 1e8 {
+                format!("Extremely high diagonal ratio {:.2e}", p.cond),
+            ).with_value(p.cond, 1e12).with_phase("conditioning"));
+        } else if p.cond > 1e8 {
             structured.push(StructuredDiagnostic::global(
                 DiagnosticCode::HighDiagonalRatio,
                 Severity::Warning,
-                format!("High diagonal ratio {:.2e}", cond),
-            ).with_value(cond, 1e8).with_phase("conditioning"));
+                format!("High diagonal ratio {:.2e}", p.cond),
+            ).with_value(p.cond, 1e8).with_phase("conditioning"));
         }
 
-        if !cond_report.near_zero_dofs.is_empty() {
-            structured.push(StructuredDiagnostic::global(
-                DiagnosticCode::NearZeroDiagonal,
-                Severity::Warning,
-                format!("{} near-zero diagonal entries", cond_report.near_zero_dofs.len()),
-            ).with_dofs(cond_report.near_zero_dofs.clone()).with_phase("conditioning"));
-        }
-
-        // Residual
+        // Residual diagnostic with actual computed value
         structured.push(if rel_residual < 1e-6 {
             StructuredDiagnostic::global(
                 DiagnosticCode::ResidualOk,
                 Severity::Info,
-                format!("Dense solver residual {:.2e} ({} free DOFs)", rel_residual, nf),
+                format!("Dense LU fallback ({} free DOFs, residual {:.2e})", nf, rel_residual),
             ).with_value(rel_residual, 1e-6).with_phase("solve")
         } else {
             StructuredDiagnostic::global(
                 DiagnosticCode::ResidualHigh,
                 Severity::Warning,
-                format!("Dense solver residual {:.2e} exceeds tolerance ({} free DOFs)", rel_residual, nf),
+                format!("Dense LU fallback residual {:.2e} exceeds tolerance", rel_residual),
             ).with_value(rel_residual, 1e-6).with_phase("solve")
         });
 
+        let solver_diags = p.solver_diags_base.clone();
+
         let mut results = AnalysisResults3D {
-            displacements,
-            reactions,
-            element_forces,
-            plate_stresses,
-            quad_stresses,
-            quad_nodal_stresses: compute_quad_nodal_stresses(input, &dof_num, &u_full),
-            constraint_forces: vec![],
-            diagnostics: asm.diagnostics,
-            solver_diagnostics: solver_diags,
-            structured_diagnostics: structured,
-            equilibrium: Some(equilibrium),
-            timings: None,
-            result_summary: None,
+            displacements, reactions, element_forces, plate_stresses, quad_stresses,
+            quad_nodal_stresses: compute_quad_nodal_stresses(input, dof_num, &u_full),
+            constraint_forces: vec![], diagnostics: p.diagnostics.clone(),
+            solver_diagnostics: solver_diags, structured_diagnostics: structured, equilibrium: Some(equilibrium), timings: Some(timings), result_summary: None,
             solver_run_meta: Some(SolverRunMeta::new(
-                "dense_lu", nf, n_elements, n_nodes,
+                "sparse_fallback_dense_lu", nf, self.n_elements, self.n_nodes,
             )),
         };
         results.result_summary = Some(crate::postprocess::result_summary::compute_result_summary_3d(&results));
@@ -1618,31 +1971,8 @@ pub(crate) fn validate_input_2d(input: &SolverInput) -> Result<(), String> {
         }
     }
 
-    // 3. Referential integrity — load → node/element
-    for load in &input.loads {
-        match load {
-            SolverLoad::Nodal(l) => {
-                if !node_ids.contains(&l.node_id) {
-                    return Err(format!("Nodal load: node {} does not exist", l.node_id));
-                }
-            }
-            SolverLoad::Distributed(l) => {
-                if !elem_ids.contains(&l.element_id) {
-                    return Err(format!("Distributed load: element {} does not exist", l.element_id));
-                }
-            }
-            SolverLoad::PointOnElement(l) => {
-                if !elem_ids.contains(&l.element_id) {
-                    return Err(format!("Point load: element {} does not exist", l.element_id));
-                }
-            }
-            SolverLoad::Thermal(l) => {
-                if !elem_ids.contains(&l.element_id) {
-                    return Err(format!("Thermal load: element {} does not exist", l.element_id));
-                }
-            }
-        }
-    }
+    // 3. Referential integrity — load → node/element, and point-load positions
+    validate_loads_2d(input, &input.loads)?;
 
     // 4. Material properties
     for mat in input.materials.values() {
@@ -1684,8 +2014,48 @@ pub(crate) fn validate_input_2d(input: &SolverInput) -> Result<(), String> {
         }
     }
 
-    // 8. Point load position validation
-    for load in &input.loads {
+    Ok(())
+}
+
+/// Validate load references for 2D (load → node/element integrity and
+/// point-load positions). Split from `validate_input_2d` so multi-case solves
+/// can validate each case's loads independently of the structure.
+pub(crate) fn validate_loads_2d(input: &SolverInput, loads: &[SolverLoad]) -> Result<(), String> {
+    let node_ids: std::collections::HashSet<usize> =
+        input.nodes.values().map(|n| n.id).collect();
+    let elem_ids: std::collections::HashSet<usize> =
+        input.elements.values().map(|e| e.id).collect();
+    let node_map: std::collections::HashMap<usize, &SolverNode> =
+        input.nodes.values().map(|n| (n.id, n)).collect();
+
+    // Referential integrity — load → node/element
+    for load in loads {
+        match load {
+            SolverLoad::Nodal(l) => {
+                if !node_ids.contains(&l.node_id) {
+                    return Err(format!("Nodal load: node {} does not exist", l.node_id));
+                }
+            }
+            SolverLoad::Distributed(l) => {
+                if !elem_ids.contains(&l.element_id) {
+                    return Err(format!("Distributed load: element {} does not exist", l.element_id));
+                }
+            }
+            SolverLoad::PointOnElement(l) => {
+                if !elem_ids.contains(&l.element_id) {
+                    return Err(format!("Point load: element {} does not exist", l.element_id));
+                }
+            }
+            SolverLoad::Thermal(l) => {
+                if !elem_ids.contains(&l.element_id) {
+                    return Err(format!("Thermal load: element {} does not exist", l.element_id));
+                }
+            }
+        }
+    }
+
+    // Point load position validation
+    for load in loads {
         if let SolverLoad::PointOnElement(pl) = load {
             if let Some(elem) = input.elements.values().find(|e| e.id == pl.element_id) {
                 let ni = &node_map[&elem.node_i];
@@ -1758,73 +2128,8 @@ pub(crate) fn validate_input_3d(input: &SolverInput3D) -> Result<(), String> {
         }
     }
 
-    // 3. Referential integrity — load → node/element (check nodal and element-based loads)
-    for load in &input.loads {
-        match load {
-            SolverLoad3D::Nodal(l) => {
-                if !node_ids.contains(&l.node_id) {
-                    return Err(format!("Nodal load: node {} does not exist", l.node_id));
-                }
-            }
-            SolverLoad3D::Distributed(l) => {
-                if !elem_ids.contains(&l.element_id) {
-                    return Err(format!("Distributed load: element {} does not exist", l.element_id));
-                }
-            }
-            SolverLoad3D::PointOnElement(l) => {
-                if !elem_ids.contains(&l.element_id) {
-                    return Err(format!("Point load: element {} does not exist", l.element_id));
-                }
-            }
-            SolverLoad3D::Thermal(l) => {
-                if !elem_ids.contains(&l.element_id) {
-                    return Err(format!("Thermal load: element {} does not exist", l.element_id));
-                }
-            }
-            SolverLoad3D::Bimoment(l) => {
-                if !node_ids.contains(&l.node_id) {
-                    return Err(format!("Bimoment load: node {} does not exist", l.node_id));
-                }
-            }
-            // Shell/plate/quad loads — validated below with their respective element maps
-            _ => {}
-        }
-    }
-
-    // Shell/plate/quad load referential integrity
-    let plate_ids: std::collections::HashSet<usize> = input.plates.values().map(|p| p.id).collect();
-    let quad_ids: std::collections::HashSet<usize> = input.quads.values().map(|q| q.id).collect();
-    let quad9_ids: std::collections::HashSet<usize> = input.quad9s.values().map(|q| q.id).collect();
-    let solid_shell_ids: std::collections::HashSet<usize> = input.solid_shells.values().map(|s| s.id).collect();
-    let curved_shell_ids: std::collections::HashSet<usize> = input.curved_shells.values().map(|c| c.id).collect();
-    for load in &input.loads {
-        let (kind, eid) = match load {
-            SolverLoad3D::Pressure(l) => ("Plate pressure", l.element_id),
-            SolverLoad3D::PlateThermal(l) => ("Plate thermal", l.element_id),
-            SolverLoad3D::QuadPressure(l) => ("Quad pressure", l.element_id),
-            SolverLoad3D::QuadThermal(l) => ("Quad thermal", l.element_id),
-            SolverLoad3D::QuadEdge(l) => ("Quad edge", l.element_id),
-            SolverLoad3D::QuadSelfWeight(l) => ("Quad self-weight", l.element_id),
-            SolverLoad3D::Quad9Pressure(l) => ("Quad9 pressure", l.element_id),
-            SolverLoad3D::Quad9Thermal(l) => ("Quad9 thermal", l.element_id),
-            SolverLoad3D::Quad9Edge(l) => ("Quad9 edge", l.element_id),
-            SolverLoad3D::Quad9SelfWeight(l) => ("Quad9 self-weight", l.element_id),
-            SolverLoad3D::SolidShellPressure(l) => ("Solid shell pressure", l.element_id),
-            SolverLoad3D::SolidShellSelfWeight(l) => ("Solid shell self-weight", l.element_id),
-            SolverLoad3D::CurvedShellPressure(l) => ("Curved shell pressure", l.element_id),
-            SolverLoad3D::CurvedShellThermal(l) => ("Curved shell thermal", l.element_id),
-            SolverLoad3D::CurvedShellEdge(l) => ("Curved shell edge", l.element_id),
-            _ => continue,
-        };
-        let found = plate_ids.contains(&eid)
-            || quad_ids.contains(&eid)
-            || quad9_ids.contains(&eid)
-            || solid_shell_ids.contains(&eid)
-            || curved_shell_ids.contains(&eid);
-        if !found {
-            return Err(format!("{} load: element {} does not exist", kind, eid));
-        }
-    }
+    // 3. Referential integrity — load → node/element, and point-load positions
+    validate_loads_3d(input, &input.loads)?;
 
     // 4. Material properties
     for mat in input.materials.values() {
@@ -1874,8 +2179,90 @@ pub(crate) fn validate_input_3d(input: &SolverInput3D) -> Result<(), String> {
         }
     }
 
-    // 8. Point load position validation
-    for load in &input.loads {
+    Ok(())
+}
+
+/// Validate load references for 3D (load → node/element integrity and
+/// point-load positions). Split from `validate_input_3d` so multi-case solves
+/// can validate each case's loads independently of the structure.
+pub(crate) fn validate_loads_3d(input: &SolverInput3D, loads: &[SolverLoad3D]) -> Result<(), String> {
+    let node_ids: std::collections::HashSet<usize> =
+        input.nodes.values().map(|n| n.id).collect();
+    let elem_ids: std::collections::HashSet<usize> =
+        input.elements.values().map(|e| e.id).collect();
+    let node_map: std::collections::HashMap<usize, &SolverNode3D> =
+        input.nodes.values().map(|n| (n.id, n)).collect();
+
+    // Referential integrity — load → node/element (check nodal and element-based loads)
+    for load in loads {
+        match load {
+            SolverLoad3D::Nodal(l) => {
+                if !node_ids.contains(&l.node_id) {
+                    return Err(format!("Nodal load: node {} does not exist", l.node_id));
+                }
+            }
+            SolverLoad3D::Distributed(l) => {
+                if !elem_ids.contains(&l.element_id) {
+                    return Err(format!("Distributed load: element {} does not exist", l.element_id));
+                }
+            }
+            SolverLoad3D::PointOnElement(l) => {
+                if !elem_ids.contains(&l.element_id) {
+                    return Err(format!("Point load: element {} does not exist", l.element_id));
+                }
+            }
+            SolverLoad3D::Thermal(l) => {
+                if !elem_ids.contains(&l.element_id) {
+                    return Err(format!("Thermal load: element {} does not exist", l.element_id));
+                }
+            }
+            SolverLoad3D::Bimoment(l) => {
+                if !node_ids.contains(&l.node_id) {
+                    return Err(format!("Bimoment load: node {} does not exist", l.node_id));
+                }
+            }
+            // Shell/plate/quad loads — validated below with their respective element maps
+            _ => {}
+        }
+    }
+
+    // Shell/plate/quad load referential integrity
+    let plate_ids: std::collections::HashSet<usize> = input.plates.values().map(|p| p.id).collect();
+    let quad_ids: std::collections::HashSet<usize> = input.quads.values().map(|q| q.id).collect();
+    let quad9_ids: std::collections::HashSet<usize> = input.quad9s.values().map(|q| q.id).collect();
+    let solid_shell_ids: std::collections::HashSet<usize> = input.solid_shells.values().map(|s| s.id).collect();
+    let curved_shell_ids: std::collections::HashSet<usize> = input.curved_shells.values().map(|c| c.id).collect();
+    for load in loads {
+        let (kind, eid) = match load {
+            SolverLoad3D::Pressure(l) => ("Plate pressure", l.element_id),
+            SolverLoad3D::PlateThermal(l) => ("Plate thermal", l.element_id),
+            SolverLoad3D::QuadPressure(l) => ("Quad pressure", l.element_id),
+            SolverLoad3D::QuadThermal(l) => ("Quad thermal", l.element_id),
+            SolverLoad3D::QuadEdge(l) => ("Quad edge", l.element_id),
+            SolverLoad3D::QuadSelfWeight(l) => ("Quad self-weight", l.element_id),
+            SolverLoad3D::Quad9Pressure(l) => ("Quad9 pressure", l.element_id),
+            SolverLoad3D::Quad9Thermal(l) => ("Quad9 thermal", l.element_id),
+            SolverLoad3D::Quad9Edge(l) => ("Quad9 edge", l.element_id),
+            SolverLoad3D::Quad9SelfWeight(l) => ("Quad9 self-weight", l.element_id),
+            SolverLoad3D::SolidShellPressure(l) => ("Solid shell pressure", l.element_id),
+            SolverLoad3D::SolidShellSelfWeight(l) => ("Solid shell self-weight", l.element_id),
+            SolverLoad3D::CurvedShellPressure(l) => ("Curved shell pressure", l.element_id),
+            SolverLoad3D::CurvedShellThermal(l) => ("Curved shell thermal", l.element_id),
+            SolverLoad3D::CurvedShellEdge(l) => ("Curved shell edge", l.element_id),
+            _ => continue,
+        };
+        let found = plate_ids.contains(&eid)
+            || quad_ids.contains(&eid)
+            || quad9_ids.contains(&eid)
+            || solid_shell_ids.contains(&eid)
+            || curved_shell_ids.contains(&eid);
+        if !found {
+            return Err(format!("{} load: element {} does not exist", kind, eid));
+        }
+    }
+
+    // Point load position validation
+    for load in loads {
         if let SolverLoad3D::PointOnElement(pl) = load {
             if let Some(elem) = input.elements.values().find(|e| e.id == pl.element_id) {
                 let ni = &node_map[&elem.node_i];
@@ -1899,6 +2286,17 @@ pub(crate) fn validate_input_3d(input: &SolverInput3D) -> Result<(), String> {
 
 pub(crate) fn compute_internal_forces_2d(
     input: &SolverInput,
+    dof_num: &DofNumbering,
+    u: &[f64],
+) -> Vec<ElementForces> {
+    compute_internal_forces_2d_with_loads(input, &input.loads, dof_num, u)
+}
+
+/// `compute_internal_forces_2d` with the load set given explicitly, so
+/// multi-case solves can reuse one structure with per-case loads.
+pub(crate) fn compute_internal_forces_2d_with_loads(
+    input: &SolverInput,
+    loads: &[SolverLoad],
     dof_num: &DofNumbering,
     u: &[f64],
 ) -> Vec<ElementForces> {
@@ -1938,7 +2336,7 @@ pub(crate) fn compute_internal_forces_2d(
             let mut n_axial = e * sec.a / l * delta;
 
             // Subtract thermal FEF for truss: f = K*u - FEF (matches 3D truss path)
-            for load in &input.loads {
+            for load in loads {
                 if let SolverLoad::Thermal(tl) = load {
                     if tl.element_id == elem.id {
                         let alpha = 12e-6;
@@ -1994,7 +2392,7 @@ pub(crate) fn compute_internal_forces_2d(
             let mut point_loads_info = Vec::new();
             let mut dist_loads_info = Vec::new();
 
-            for load in &input.loads {
+            for load in loads {
                 match load {
                     SolverLoad::Distributed(dl) if dl.element_id == elem.id => {
                         let a = dl.a.unwrap_or(0.0);
@@ -2083,6 +2481,17 @@ pub(crate) fn compute_internal_forces_3d(
     dof_num: &DofNumbering,
     u: &[f64],
 ) -> Vec<ElementForces3D> {
+    compute_internal_forces_3d_with_loads(input, &input.loads, dof_num, u)
+}
+
+/// `compute_internal_forces_3d` with the load set given explicitly, so
+/// multi-case solves can reuse one structure with per-case loads.
+pub(crate) fn compute_internal_forces_3d_with_loads(
+    input: &SolverInput3D,
+    loads: &[SolverLoad3D],
+    dof_num: &DofNumbering,
+    u: &[f64],
+) -> Vec<ElementForces3D> {
     let mut forces = Vec::new();
     let left_hand = input.left_hand.unwrap_or(false);
 
@@ -2122,7 +2531,7 @@ pub(crate) fn compute_internal_forces_3d(
             // f_local_axial = EA/L * delta - (-EAαΔT) = EA/L * delta + EAαΔT
             // n = -f_local_axial (sign convention) → n = -(EA/L * delta + EAαΔT)
             // Equivalently: subtract EAαΔT from n_axial before the sign convention is applied
-            for load in &input.loads {
+            for load in loads {
                 if let SolverLoad3D::Thermal(tl) = load {
                     if tl.element_id == elem.id {
                         let alpha = 12e-6;
@@ -2246,7 +2655,7 @@ pub(crate) fn compute_internal_forces_3d(
         let mut pt_loads_y = Vec::new();
         let mut pt_loads_z = Vec::new();
 
-        for load in &input.loads {
+        for load in loads {
             match load {
                 SolverLoad3D::Distributed(dl) if dl.element_id == elem.id => {
                     let a_param = dl.a.unwrap_or(0.0);

--- a/engine/src/solver/load_cases.rs
+++ b/engine/src/solver/load_cases.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::solver::linear::{solve_2d, solve_3d};
+use crate::solver::linear::{prepare_static_2d, prepare_static_3d, solve_3d};
 use crate::postprocess::combinations::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -98,23 +98,23 @@ pub fn solve_multi_case_2d(input: &MultiCaseInput) -> Result<MultiCaseResult, St
         return Err("No combinations defined".into());
     }
 
-    // Solve each load case independently
+    // Prepare the structure once (assembly + factorization of K).
+    // Historical behavior: constraints and connectors are ignored in
+    // multi-case 2D, and only the per-case load lists are used.
+    let mut solver = input.solver.clone();
+    solver.loads = vec![];
+    solver.constraints = vec![];
+    solver.connectors = HashMap::new();
+
+    let prepared = prepare_static_2d(&solver)
+        .map_err(|e| format!("Failed to solve case '{}': {}", input.load_cases[0].name, e))?;
+
+    // Solve each load case with the shared factorization
     let mut case_results = Vec::new();
     let mut case_map: HashMap<String, usize> = HashMap::new();
 
     for (idx, lc) in input.load_cases.iter().enumerate() {
-        let case_input = SolverInput {
-            nodes: input.solver.nodes.clone(),
-            materials: input.solver.materials.clone(),
-            sections: input.solver.sections.clone(),
-            elements: input.solver.elements.clone(),
-            supports: input.solver.supports.clone(),
-            loads: lc.loads.clone(),
-            constraints: vec![],
-            connectors: HashMap::new(),
-        };
-
-        let results = solve_2d(&case_input)
+        let results = prepared.solve_loads(&lc.loads)
             .map_err(|e| format!("Failed to solve case '{}': {}", lc.name, e))?;
 
         case_map.insert(lc.name.clone(), idx);
@@ -124,8 +124,13 @@ pub fn solve_multi_case_2d(input: &MultiCaseInput) -> Result<MultiCaseResult, St
         });
     }
 
-    // Generate combined results for each combination
-    let mut combination_results = Vec::new();
+    // Generate combined results for each combination (borrowing case results)
+    let case_refs: Vec<(usize, &AnalysisResults)> = case_results
+        .iter()
+        .enumerate()
+        .map(|(idx, cr)| (idx, &cr.results))
+        .collect();
+    let mut combo_names: Vec<String> = Vec::new();
     let mut all_combined_results: Vec<AnalysisResults> = Vec::new();
 
     for combo in &input.combinations {
@@ -139,30 +144,21 @@ pub fn solve_multi_case_2d(input: &MultiCaseInput) -> Result<MultiCaseResult, St
             }
         }
 
-        let cases: Vec<CaseEntry> = case_results.iter().enumerate()
-            .map(|(idx, cr)| CaseEntry {
-                case_id: idx,
-                results: cr.results.clone(),
-            })
-            .collect();
-
-        let combo_input = CombinationInput {
-            factors: combo_factors,
-            cases,
-        };
-
-        if let Some(combined) = combine_results(&combo_input) {
-            all_combined_results.push(combined.clone());
-            combination_results.push(CombinedResult {
-                name: combo.name.clone(),
-                results: combined,
-            });
+        if let Some(combined) = combine_results_refs(&combo_factors, &case_refs) {
+            all_combined_results.push(combined);
+            combo_names.push(combo.name.clone());
         }
     }
 
     // Compute envelope from all combination results
     let envelope = compute_envelope(&all_combined_results)
         .ok_or_else(|| "Failed to compute envelope".to_string())?;
+
+    let combination_results = combo_names
+        .into_iter()
+        .zip(all_combined_results)
+        .map(|(name, results)| CombinedResult { name, results })
+        .collect();
 
     Ok(MultiCaseResult {
         case_results,
@@ -181,6 +177,81 @@ pub fn solve_multi_case_3d(input: &MultiCaseInput3D) -> Result<MultiCaseResult3D
         return Err("No combinations defined".into());
     }
 
+    // Constraints delegate to the constrained solver per case — keep the
+    // legacy per-case path for that (rare) configuration.
+    if !input.solver.constraints.is_empty() {
+        return solve_multi_case_3d_per_case(input);
+    }
+
+    // Prepare the structure once (assembly + factorization of K).
+    // Historical behavior: connectors are ignored in multi-case 3D, and only
+    // the per-case load lists are used.
+    let mut solver = input.solver.clone();
+    solver.loads = vec![];
+    solver.connectors = HashMap::new();
+
+    let prepared = prepare_static_3d(&solver)
+        .map_err(|e| format!("Failed to solve case '{}': {}", input.load_cases[0].name, e))?;
+
+    let mut case_results = Vec::new();
+    let mut case_map: HashMap<String, usize> = HashMap::new();
+
+    for (idx, lc) in input.load_cases.iter().enumerate() {
+        let results = prepared.solve_loads(&lc.loads)
+            .map_err(|e| format!("Failed to solve case '{}': {}", lc.name, e))?;
+
+        case_map.insert(lc.name.clone(), idx);
+        case_results.push(CaseResult3D {
+            name: lc.name.clone(),
+            results,
+        });
+    }
+
+    let case_refs: Vec<(usize, &AnalysisResults3D)> = case_results
+        .iter()
+        .enumerate()
+        .map(|(idx, cr)| (idx, &cr.results))
+        .collect();
+    let mut combo_names: Vec<String> = Vec::new();
+    let mut all_combined_results: Vec<AnalysisResults3D> = Vec::new();
+
+    for combo in &input.combinations {
+        let mut combo_factors = Vec::new();
+        for (case_name, &factor) in &combo.factors {
+            if let Some(&idx) = case_map.get(case_name) {
+                combo_factors.push(CombinationFactor {
+                    case_id: idx,
+                    factor,
+                });
+            }
+        }
+
+        if let Some(combined) = combine_results_3d_refs(&combo_factors, &case_refs) {
+            all_combined_results.push(combined);
+            combo_names.push(combo.name.clone());
+        }
+    }
+
+    let envelope = compute_envelope_3d(&all_combined_results)
+        .ok_or_else(|| "Failed to compute envelope".to_string())?;
+
+    let combination_results = combo_names
+        .into_iter()
+        .zip(all_combined_results)
+        .map(|(name, results)| CombinedResult3D { name, results })
+        .collect();
+
+    Ok(MultiCaseResult3D {
+        case_results,
+        combination_results,
+        envelope,
+    })
+}
+
+/// Legacy per-case 3D multi-case path: one full `solve_3d` per load case.
+/// Retained for models with constraints (which delegate to the constrained
+/// solver per case load set).
+fn solve_multi_case_3d_per_case(input: &MultiCaseInput3D) -> Result<MultiCaseResult3D, String> {
     let mut case_results = Vec::new();
     let mut case_map: HashMap<String, usize> = HashMap::new();
 
@@ -213,7 +284,12 @@ pub fn solve_multi_case_3d(input: &MultiCaseInput3D) -> Result<MultiCaseResult3D
         });
     }
 
-    let mut combination_results = Vec::new();
+    let case_refs: Vec<(usize, &AnalysisResults3D)> = case_results
+        .iter()
+        .enumerate()
+        .map(|(idx, cr)| (idx, &cr.results))
+        .collect();
+    let mut combo_names: Vec<String> = Vec::new();
     let mut all_combined_results: Vec<AnalysisResults3D> = Vec::new();
 
     for combo in &input.combinations {
@@ -227,29 +303,20 @@ pub fn solve_multi_case_3d(input: &MultiCaseInput3D) -> Result<MultiCaseResult3D
             }
         }
 
-        let cases: Vec<CaseEntry3D> = case_results.iter().enumerate()
-            .map(|(idx, cr)| CaseEntry3D {
-                case_id: idx,
-                results: cr.results.clone(),
-            })
-            .collect();
-
-        let combo_input = CombinationInput3D {
-            factors: combo_factors,
-            cases,
-        };
-
-        if let Some(combined) = combine_results_3d(&combo_input) {
-            all_combined_results.push(combined.clone());
-            combination_results.push(CombinedResult3D {
-                name: combo.name.clone(),
-                results: combined,
-            });
+        if let Some(combined) = combine_results_3d_refs(&combo_factors, &case_refs) {
+            all_combined_results.push(combined);
+            combo_names.push(combo.name.clone());
         }
     }
 
     let envelope = compute_envelope_3d(&all_combined_results)
         .ok_or_else(|| "Failed to compute envelope".to_string())?;
+
+    let combination_results = combo_names
+        .into_iter()
+        .zip(all_combined_results)
+        .map(|(name, results)| CombinedResult3D { name, results })
+        .collect();
 
     Ok(MultiCaseResult3D {
         case_results,

--- a/engine/src/solver/sparse_assembly.rs
+++ b/engine/src/solver/sparse_assembly.rs
@@ -168,7 +168,7 @@ pub fn assemble_2d_sparse(input: &SolverInput, dof_num: &DofNumbering) -> Triple
                 diag_vals[elem_dofs[i]] += k_glob[i * ndof + i];
             }
 
-            assemble_element_loads_2d(input, elem, &k_local, &t, l, e, sec, node_i, &elem_dofs, &mut f_global);
+            assemble_element_loads_2d(&input.loads, elem, &t, l, e, sec, &elem_dofs, &mut f_global);
         }
     }
 
@@ -501,8 +501,9 @@ pub fn assemble_elements_parallel_2d(input: &SolverInput, dof_num: &DofNumbering
 
 use super::assembly::SparseAssemblyResult3D;
 
+use super::assembly::InclinedTransformData;
 #[cfg(feature = "parallel")]
-use super::assembly::{InclinedTransformData, apply_inclined_transform_triplets, inclined_rotation_matrix};
+use super::assembly::inclined_rotation_matrix;
 
 #[cfg(feature = "parallel")]
 const DOF_MAP_12_TO_14: [usize; 12] = [0, 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12];
@@ -514,7 +515,6 @@ struct ElementContribution3D {
     trip_cols: Vec<usize>,
     trip_vals: Vec<f64>,
     diag_contributions: Vec<(usize, f64)>,
-    force_contributions: Vec<(usize, f64)>,
     diagnostics: Vec<AssemblyDiagnostic>,
 }
 
@@ -585,13 +585,14 @@ fn scatter_triplets(
     }
 }
 
-/// Parallel 3D sparse assembly using rayon.
+/// Parallel 3D sparse stiffness assembly using rayon (load-independent).
+/// The force vector is built separately by `assemble_load_vector_3d_sparse_parallel`.
 ///
 /// Each element computes its stiffness independently, collecting local triplets.
-/// After the parallel phase, nodal loads / springs / inclined transforms /
-/// diagnostics are processed sequentially.
+/// After the parallel phase, springs / inclined transforms / diagnostics are
+/// processed sequentially.
 #[cfg(feature = "parallel")]
-pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering, build_k_full: bool) -> SparseAssemblyResult3D {
+pub fn assemble_stiffness_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering, build_k_full: bool) -> super::assembly::StiffnessSparseAssembly3D {
     use rayon::prelude::*;
     use crate::element;
     use crate::element::compute_local_axes_3d;
@@ -607,7 +608,6 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
         input.materials.values().map(|m| (m.id, m)).collect();
     let sec_map: std::collections::HashMap<usize, &SolverSection3D> =
         input.sections.values().map(|s| (s.id, s)).collect();
-    let load_index = build_load_index_3d(&input.loads);
 
     // Collect all elements into unified vec, sorted by ID for deterministic assembly.
     // HashMap iteration order is randomized in Rust; without sorting, triplet
@@ -637,7 +637,6 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
         let mut trip_cols = Vec::new();
         let mut trip_vals = Vec::new();
         let mut diag = Vec::new();
-        let mut forces = Vec::new();
         let mut diagnostics = Vec::new();
 
         match any_elem {
@@ -677,23 +676,6 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
                             }
                         }
                     }
-                    // Assemble thermal FEF for truss elements
-                    if let Some(elem_loads) = load_index.get(&elem.id) {
-                        for load in elem_loads {
-                            if let SolverLoad3D::Thermal(tl) = load {
-                                let alpha = 12e-6;
-                                let fx = e * sec.a * alpha * tl.dt_uniform;
-                                for k in 0..3 {
-                                    if let Some(&d) = dof_num.map.get(&(elem.node_i, k)) {
-                                        forces.push((d, -fx * dir[k]));
-                                    }
-                                    if let Some(&d) = dof_num.map.get(&(elem.node_j, k)) {
-                                        forces.push((d, fx * dir[k]));
-                                    }
-                                }
-                            }
-                        }
-                    }
                 } else {
                     let (ex, ey, ez) = compute_local_axes_3d(
                         node_i.x, node_i.y, node_i.z, node_j.x, node_j.y, node_j.z,
@@ -721,51 +703,6 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
                         let k_glob = transform_stiffness(&k_local, &t, 14);
                         let ndof = elem_dofs.len();
                         scatter_triplets(&k_glob, &elem_dofs, ndof, nf, &mut trip_rows, &mut trip_cols, &mut trip_vals, &mut diag);
-                        // Warping element loads
-                        if let Some(elem_loads) = load_index.get(&elem.id) {
-                            for load in elem_loads {
-                                match load {
-                                    SolverLoad3D::Distributed(dl) => {
-                                        let a = dl.a.unwrap_or(0.0);
-                                        let b = dl.b.unwrap_or(l);
-                                        let is_full = (a.abs() < 1e-12) && ((b - l).abs() < 1e-12);
-                                        let mut fef12 = if is_full {
-                                            element::fef_distributed_3d(dl.q_yi, dl.q_yj, dl.q_zi, dl.q_zj, l)
-                                        } else {
-                                            element::fef_partial_distributed_3d(dl.q_yi, dl.q_yj, dl.q_zi, dl.q_zj, a, b, l)
-                                        };
-                                        adjust_fef_for_hinges_3d(&mut fef12, l, Hinge3D::from_elem(elem), phi_y, phi_z);
-                                        let fef14 = element::expand_fef_12_to_14(&fef12);
-                                        let fef_global = transform_force(&fef14, &t, 14);
-                                        for (i, &dof) in elem_dofs.iter().enumerate() { forces.push((dof, fef_global[i])); }
-                                    }
-                                    SolverLoad3D::PointOnElement(pl) => {
-                                        let fef_y = element::fef_point_load_2d(pl.py, 0.0, 0.0, pl.a, l);
-                                        let mut fef12 = [0.0; 12];
-                                        fef12[1] = fef_y[1]; fef12[5] = fef_y[2];
-                                        fef12[7] = fef_y[4]; fef12[11] = fef_y[5];
-                                        let fef_z = element::fef_point_load_2d(pl.pz, 0.0, 0.0, pl.a, l);
-                                        fef12[2] = fef_z[1]; fef12[4] = -fef_z[2];
-                                        fef12[8] = fef_z[4]; fef12[10] = -fef_z[5];
-                                        adjust_fef_for_hinges_3d(&mut fef12, l, Hinge3D::from_elem(elem), phi_y, phi_z);
-                                        let fef14 = element::expand_fef_12_to_14(&fef12);
-                                        let fef_global = transform_force(&fef14, &t, 14);
-                                        for (i, &dof) in elem_dofs.iter().enumerate() { forces.push((dof, fef_global[i])); }
-                                    }
-                                    SolverLoad3D::Thermal(tl) => {
-                                        let alpha = 12e-6;
-                                        let hy = if sec.a > 1e-15 { (12.0 * sec.iz / sec.a).sqrt() } else { 0.1 };
-                                        let hz = if sec.a > 1e-15 { (12.0 * sec.iy / sec.a).sqrt() } else { 0.1 };
-                                        let mut fef12 = element::fef_thermal_3d(e, sec.a, sec.iy, sec.iz, l, tl.dt_uniform, tl.dt_gradient_y, tl.dt_gradient_z, alpha, hy, hz);
-                                        adjust_fef_for_hinges_3d(&mut fef12, l, Hinge3D::from_elem(elem), phi_y, phi_z);
-                                        let fef14 = element::expand_fef_12_to_14(&fef12);
-                                        let fef_global = transform_force(&fef14, &t, 14);
-                                        for (i, &dof) in elem_dofs.iter().enumerate() { forces.push((dof, fef_global[i])); }
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
                     } else if dof_num.dofs_per_node >= 7 {
                         let k_local = element::frame_local_stiffness_3d(
                             e, sec.a, sec.iy, sec.iz, sec.j, l, g,
@@ -785,48 +722,6 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
                             }
                             if gi < nf { diag.push((gi, k_glob[i * 12 + i])); }
                         }
-                        // Mapped element loads (12→14 DOF)
-                        if let Some(elem_loads) = load_index.get(&elem.id) {
-                            for load in elem_loads {
-                                match load {
-                                    SolverLoad3D::Distributed(dl) => {
-                                        let a = dl.a.unwrap_or(0.0);
-                                        let b = dl.b.unwrap_or(l);
-                                        let is_full = (a.abs() < 1e-12) && ((b - l).abs() < 1e-12);
-                                        let mut fef = if is_full {
-                                            element::fef_distributed_3d(dl.q_yi, dl.q_yj, dl.q_zi, dl.q_zj, l)
-                                        } else {
-                                            element::fef_partial_distributed_3d(dl.q_yi, dl.q_yj, dl.q_zi, dl.q_zj, a, b, l)
-                                        };
-                                        adjust_fef_for_hinges_3d(&mut fef, l, Hinge3D::from_elem(elem), phi_y, phi_z);
-                                        let fef_global = transform_force(&fef, &t, 12);
-                                        for i in 0..12 { forces.push((elem_dofs[DOF_MAP_12_TO_14[i]], fef_global[i])); }
-                                    }
-                                    SolverLoad3D::PointOnElement(pl) => {
-                                        let fef_y = element::fef_point_load_2d(pl.py, 0.0, 0.0, pl.a, l);
-                                        let mut fef = [0.0; 12];
-                                        fef[1] = fef_y[1]; fef[5] = fef_y[2];
-                                        fef[7] = fef_y[4]; fef[11] = fef_y[5];
-                                        let fef_z = element::fef_point_load_2d(pl.pz, 0.0, 0.0, pl.a, l);
-                                        fef[2] = fef_z[1]; fef[4] = -fef_z[2];
-                                        fef[8] = fef_z[4]; fef[10] = -fef_z[5];
-                                        adjust_fef_for_hinges_3d(&mut fef, l, Hinge3D::from_elem(elem), phi_y, phi_z);
-                                        let fef_global = transform_force(&fef, &t, 12);
-                                        for i in 0..12 { forces.push((elem_dofs[DOF_MAP_12_TO_14[i]], fef_global[i])); }
-                                    }
-                                    SolverLoad3D::Thermal(tl) => {
-                                        let alpha = 12e-6;
-                                        let hy = if sec.a > 1e-15 { (12.0 * sec.iz / sec.a).sqrt() } else { 0.1 };
-                                        let hz = if sec.a > 1e-15 { (12.0 * sec.iy / sec.a).sqrt() } else { 0.1 };
-                                        let mut fef = element::fef_thermal_3d(e, sec.a, sec.iy, sec.iz, l, tl.dt_uniform, tl.dt_gradient_y, tl.dt_gradient_z, alpha, hy, hz);
-                                        adjust_fef_for_hinges_3d(&mut fef, l, Hinge3D::from_elem(elem), phi_y, phi_z);
-                                        let fef_global = transform_force(&fef, &t, 12);
-                                        for i in 0..12 { forces.push((elem_dofs[DOF_MAP_12_TO_14[i]], fef_global[i])); }
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
                     } else {
                         let k_local = element::frame_local_stiffness_3d(
                             e, sec.a, sec.iy, sec.iz, sec.j, l, g,
@@ -837,55 +732,13 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
                         let k_glob = transform_stiffness(&k_local, &t, 12);
                         let ndof = elem_dofs.len();
                         scatter_triplets(&k_glob, &elem_dofs, ndof, nf, &mut trip_rows, &mut trip_cols, &mut trip_vals, &mut diag);
-                        // Standard 12-DOF element loads
-                        if let Some(elem_loads) = load_index.get(&elem.id) {
-                            for load in elem_loads {
-                                match load {
-                                    SolverLoad3D::Distributed(dl) => {
-                                        let a = dl.a.unwrap_or(0.0);
-                                        let b = dl.b.unwrap_or(l);
-                                        let is_full = (a.abs() < 1e-12) && ((b - l).abs() < 1e-12);
-                                        let mut fef = if is_full {
-                                            element::fef_distributed_3d(dl.q_yi, dl.q_yj, dl.q_zi, dl.q_zj, l)
-                                        } else {
-                                            element::fef_partial_distributed_3d(dl.q_yi, dl.q_yj, dl.q_zi, dl.q_zj, a, b, l)
-                                        };
-                                        adjust_fef_for_hinges_3d(&mut fef, l, Hinge3D::from_elem(elem), phi_y, phi_z);
-                                        let fef_global = transform_force(&fef, &t, 12);
-                                        for (i, &dof) in elem_dofs.iter().enumerate() { forces.push((dof, fef_global[i])); }
-                                    }
-                                    SolverLoad3D::PointOnElement(pl) => {
-                                        let fef_y = element::fef_point_load_2d(pl.py, 0.0, 0.0, pl.a, l);
-                                        let mut fef = [0.0; 12];
-                                        fef[1] = fef_y[1]; fef[5] = fef_y[2];
-                                        fef[7] = fef_y[4]; fef[11] = fef_y[5];
-                                        let fef_z = element::fef_point_load_2d(pl.pz, 0.0, 0.0, pl.a, l);
-                                        fef[2] = fef_z[1]; fef[4] = -fef_z[2];
-                                        fef[8] = fef_z[4]; fef[10] = -fef_z[5];
-                                        adjust_fef_for_hinges_3d(&mut fef, l, Hinge3D::from_elem(elem), phi_y, phi_z);
-                                        let fef_global = transform_force(&fef, &t, 12);
-                                        for (i, &dof) in elem_dofs.iter().enumerate() { forces.push((dof, fef_global[i])); }
-                                    }
-                                    SolverLoad3D::Thermal(tl) => {
-                                        let alpha = 12e-6;
-                                        let hy = if sec.a > 1e-15 { (12.0 * sec.iz / sec.a).sqrt() } else { 0.1 };
-                                        let hz = if sec.a > 1e-15 { (12.0 * sec.iy / sec.a).sqrt() } else { 0.1 };
-                                        let mut fef = element::fef_thermal_3d(e, sec.a, sec.iy, sec.iz, l, tl.dt_uniform, tl.dt_gradient_y, tl.dt_gradient_z, alpha, hy, hz);
-                                        adjust_fef_for_hinges_3d(&mut fef, l, Hinge3D::from_elem(elem), phi_y, phi_z);
-                                        let fef_global = transform_force(&fef, &t, 12);
-                                        for (i, &dof) in elem_dofs.iter().enumerate() { forces.push((dof, fef_global[i])); }
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
                     }
                 }
             }
 
             AnyElement3D::Connector(conn) => {
-                let ni = match node_map.get(&conn.node_i) { Some(n) => n, None => return ElementContribution3D { trip_rows, trip_cols, trip_vals, diag_contributions: diag, force_contributions: forces, diagnostics } };
-                let nj_node = match node_map.get(&conn.node_j) { Some(n) => n, None => return ElementContribution3D { trip_rows, trip_cols, trip_vals, diag_contributions: diag, force_contributions: forces, diagnostics } };
+                let ni = match node_map.get(&conn.node_i) { Some(n) => n, None => return ElementContribution3D { trip_rows, trip_cols, trip_vals, diag_contributions: diag, diagnostics } };
+                let nj_node = match node_map.get(&conn.node_j) { Some(n) => n, None => return ElementContribution3D { trip_rows, trip_cols, trip_vals, diag_contributions: diag, diagnostics } };
                 let dx = nj_node.x - ni.x;
                 let dy = nj_node.y - ni.y;
                 let dz = nj_node.z - ni.z;
@@ -921,27 +774,6 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
                 let plate_dofs = dof_num.plate_element_dofs(&plate.nodes);
                 let ndof = plate_dofs.len();
                 scatter_triplets(&k_glob, &plate_dofs, ndof, nf, &mut trip_rows, &mut trip_cols, &mut trip_vals, &mut diag);
-                // Plate loads
-                if let Some(elem_loads) = load_index.get(&plate.id) {
-                    for load in elem_loads {
-                        match load {
-                            SolverLoad3D::Pressure(pl) => {
-                                let f_press = element::plate_pressure_load(&coords, pl.pressure);
-                                for (i, &dof) in plate_dofs.iter().enumerate() {
-                                    if i < f_press.len() { forces.push((dof, f_press[i])); }
-                                }
-                            }
-                            SolverLoad3D::PlateThermal(tl) => {
-                                let alpha = tl.alpha.unwrap_or(12e-6);
-                                let f_th = element::plate_thermal_load(&coords, e, nu, plate.thickness, alpha, tl.dt_uniform, tl.dt_gradient);
-                                for (i, &dof) in plate_dofs.iter().enumerate() {
-                                    if i < f_th.len() { forces.push((dof, f_th[i])); }
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                }
                 // Plate diagnostics
                 let (aspect_ratio, _skew, min_angle) = element::plate_element_quality(&coords);
                 if aspect_ratio > 10.0 {
@@ -975,39 +807,6 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
                 let quad_dofs = dof_num.quad_element_dofs(&quad.nodes);
                 let ndof = quad_dofs.len();
                 scatter_triplets(&k_glob, &quad_dofs, ndof, nf, &mut trip_rows, &mut trip_cols, &mut trip_vals, &mut diag);
-                // Quad loads
-                if let Some(elem_loads) = load_index.get(&quad.id) {
-                    for load in elem_loads {
-                        match load {
-                            SolverLoad3D::QuadPressure(pl) => {
-                                let f_press = element::quad::quad_pressure_load(&coords, pl.pressure);
-                                for (i, &dof) in quad_dofs.iter().enumerate() {
-                                    if i < f_press.len() { forces.push((dof, f_press[i])); }
-                                }
-                            }
-                            SolverLoad3D::QuadThermal(tl) => {
-                                let alpha = tl.alpha.unwrap_or(1.2e-5);
-                                let f_th = element::quad::quad_thermal_load(&coords, e, nu, quad.thickness, alpha, tl.dt_uniform, tl.dt_gradient);
-                                for (i, &dof) in quad_dofs.iter().enumerate() {
-                                    if i < f_th.len() { forces.push((dof, f_th[i])); }
-                                }
-                            }
-                            SolverLoad3D::QuadSelfWeight(sw) => {
-                                let f_sw = element::quad::quad_self_weight_load(&coords, sw.density, quad.thickness, sw.gx, sw.gy, sw.gz);
-                                for (i, &dof) in quad_dofs.iter().enumerate() {
-                                    if i < f_sw.len() { forces.push((dof, f_sw[i])); }
-                                }
-                            }
-                            SolverLoad3D::QuadEdge(el) => {
-                                let f_edge = element::quad::quad_edge_load(&coords, el.edge, el.qn, el.qt);
-                                for (i, &dof) in quad_dofs.iter().enumerate() {
-                                    if i < f_edge.len() { forces.push((dof, f_edge[i])); }
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                }
                 // Quad diagnostics
                 let qm = element::quad::quad_quality_metrics(&coords);
                 let (_, _, has_neg_j) = element::quad::quad_check_jacobian(&coords);
@@ -1059,40 +858,6 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
                 let q9_dofs = dof_num.quad9_element_dofs(&q9.nodes);
                 let ndof = q9_dofs.len();
                 scatter_triplets(&k_glob, &q9_dofs, ndof, nf, &mut trip_rows, &mut trip_cols, &mut trip_vals, &mut diag);
-                // Quad9 loads
-                if let Some(elem_loads) = load_index.get(&q9.id) {
-                    for load in elem_loads {
-                        match load {
-                            SolverLoad3D::Quad9Pressure(pl) => {
-                                let f_p = element::quad9::quad9_pressure_load(&coords, pl.pressure);
-                                let dofs = &q9_dofs;
-                                for (i, &dof) in dofs.iter().enumerate() {
-                                    if i < f_p.len() { forces.push((dof, f_p[i])); }
-                                }
-                            }
-                            SolverLoad3D::Quad9Thermal(tl) => {
-                                let alpha = tl.alpha.unwrap_or(1.2e-5);
-                                let f_th = element::quad9::quad9_thermal_load(&coords, e, nu, q9.thickness, alpha, tl.dt_uniform, tl.dt_gradient);
-                                for (i, &dof) in q9_dofs.iter().enumerate() {
-                                    if i < f_th.len() { forces.push((dof, f_th[i])); }
-                                }
-                            }
-                            SolverLoad3D::Quad9SelfWeight(sw) => {
-                                let f_sw = element::quad9::quad9_self_weight_load(&coords, sw.density, q9.thickness, sw.gx, sw.gy, sw.gz);
-                                for (i, &dof) in q9_dofs.iter().enumerate() {
-                                    if i < f_sw.len() { forces.push((dof, f_sw[i])); }
-                                }
-                            }
-                            SolverLoad3D::Quad9Edge(el) => {
-                                let f_edge = element::quad9::quad9_edge_load(&coords, el.edge, el.qn, el.qt);
-                                for (i, &dof) in q9_dofs.iter().enumerate() {
-                                    if i < f_edge.len() { forces.push((dof, f_edge[i])); }
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                }
                 // Quad9 diagnostics
                 let (_, _, has_neg_j) = element::quad9::quad9_check_jacobian(&coords);
                 if has_neg_j {
@@ -1113,26 +878,6 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
                 let ss_dofs = dof_num.solid_shell_element_dofs(&ss.nodes);
                 let ndof = ss_dofs.len();
                 scatter_triplets(&k_elem, &ss_dofs, ndof, nf, &mut trip_rows, &mut trip_cols, &mut trip_vals, &mut diag);
-                // Solid-shell loads
-                if let Some(elem_loads) = load_index.get(&ss.id) {
-                    for load in elem_loads {
-                        match load {
-                            SolverLoad3D::SolidShellPressure(pl) => {
-                                let f_p = element::solid_shell::solid_shell_pressure_load(&coords, pl.pressure);
-                                for (i, &dof) in ss_dofs.iter().enumerate() {
-                                    if i < f_p.len() { forces.push((dof, f_p[i])); }
-                                }
-                            }
-                            SolverLoad3D::SolidShellSelfWeight(sw) => {
-                                let f_sw = element::solid_shell::solid_shell_self_weight_load(&coords, sw.density, sw.gx, sw.gy, sw.gz);
-                                for (i, &dof) in ss_dofs.iter().enumerate() {
-                                    if i < f_sw.len() { forces.push((dof, f_sw[i])); }
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                }
             }
 
             AnyElement3D::CurvedShell(cs) => {
@@ -1145,39 +890,6 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
                 let cs_dofs = dof_num.quad_element_dofs(&cs.nodes);
                 let ndof = cs_dofs.len();
                 scatter_triplets(&k_elem, &cs_dofs, ndof, nf, &mut trip_rows, &mut trip_cols, &mut trip_vals, &mut diag);
-                // Curved shell loads
-                if let Some(elem_loads) = load_index.get(&cs.id) {
-                    for load in elem_loads {
-                        match load {
-                            SolverLoad3D::CurvedShellPressure(pl) => {
-                                let f_p = element::curved_shell::curved_shell_pressure_load(&coords, &dirs, cs.thickness, pl.pressure);
-                                for (i, &dof) in cs_dofs.iter().enumerate() {
-                                    if i < f_p.len() { forces.push((dof, f_p[i])); }
-                                }
-                            }
-                            SolverLoad3D::CurvedShellThermal(tl) => {
-                                let alpha = tl.alpha.unwrap_or(1.2e-5);
-                                let f_th = element::curved_shell::curved_shell_thermal_load(&coords, &dirs, e, nu, cs.thickness, alpha, tl.dt_uniform, tl.dt_gradient);
-                                for (i, &dof) in cs_dofs.iter().enumerate() {
-                                    if i < f_th.len() { forces.push((dof, f_th[i])); }
-                                }
-                            }
-                            SolverLoad3D::CurvedShellSelfWeight(sw) => {
-                                let f_sw = element::curved_shell::curved_shell_self_weight_load(&coords, &dirs, sw.density, cs.thickness, sw.gx, sw.gy, sw.gz);
-                                for (i, &dof) in cs_dofs.iter().enumerate() {
-                                    if i < f_sw.len() { forces.push((dof, f_sw[i])); }
-                                }
-                            }
-                            SolverLoad3D::CurvedShellEdge(el) => {
-                                let f_e = element::curved_shell::curved_shell_edge_load(&coords, &dirs, cs.thickness, el.edge, el.qn, el.qt);
-                                for (i, &dof) in cs_dofs.iter().enumerate() {
-                                    if i < f_e.len() { forces.push((dof, f_e[i])); }
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                }
             }
         }
 
@@ -1186,7 +898,6 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
             trip_cols,
             trip_vals,
             diag_contributions: diag,
-            force_contributions: forces,
             diagnostics,
         }
     }).collect();
@@ -1197,7 +908,6 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
     let mut trip_rows = Vec::with_capacity(total_triplets + 256);
     let mut trip_cols = Vec::with_capacity(total_triplets + 256);
     let mut trip_vals = Vec::with_capacity(total_triplets + 256);
-    let mut f_global = vec![0.0; n];
     let mut diag_vals = vec![0.0f64; nf];
     let mut max_diag = 0.0f64;
     let mut diagnostics = Vec::new();
@@ -1209,32 +919,7 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
         for &(d, v) in &contrib.diag_contributions {
             diag_vals[d] += v;
         }
-        for &(d, v) in &contrib.force_contributions {
-            f_global[d] += v;
-        }
         diagnostics.extend_from_slice(&contrib.diagnostics);
-    }
-
-    // Nodal loads (not element-bound, sequential)
-    for load in &input.loads {
-        if let SolverLoad3D::Nodal(nl) = load {
-            let forces = [nl.fx, nl.fy, nl.fz, nl.mx, nl.my, nl.mz];
-            for (i, &f) in forces.iter().enumerate() {
-                if i < dof_num.dofs_per_node {
-                    if let Some(&d) = dof_num.map.get(&(nl.node_id, i)) { f_global[d] += f; }
-                }
-            }
-            if let Some(bw) = nl.bw {
-                if bw.abs() > 1e-15 {
-                    if let Some(&d) = dof_num.map.get(&(nl.node_id, 6)) { f_global[d] += bw; }
-                }
-            }
-        }
-        if let SolverLoad3D::Bimoment(bl) = load {
-            if bl.bimoment.abs() > 1e-15 {
-                if let Some(&d) = dof_num.map.get(&(bl.node_id, 6)) { f_global[d] += bl.bimoment; }
-            }
-        }
     }
 
     // Spring stiffness
@@ -1278,7 +963,8 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
         }
     }
 
-    // Inclined support transforms
+    // Inclined support transforms (stiffness triplets only; the force vector
+    // rotation happens in `assemble_load_vector_3d_sparse_parallel`)
     let mut inclined_transforms = Vec::new();
     for sup in input.supports.values() {
         if sup.is_inclined.unwrap_or(false) {
@@ -1292,9 +978,9 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
                         dof_num.map.get(&(sup.node_id, 2)),
                     ) {
                         let dofs = [d0, d1, d2];
-                        apply_inclined_transform_triplets(
+                        super::assembly::apply_inclined_transform_triplets_k(
                             &mut trip_rows, &mut trip_cols, &mut trip_vals,
-                            &mut f_global, &dofs, &r,
+                            &dofs, &r,
                         );
                         inclined_transforms.push(InclinedTransformData { node_id: sup.node_id, dofs, r });
                     }
@@ -1339,16 +1025,521 @@ pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering
     let mut k_ff = CscMatrix::from_triplets(nf, &ff_rows, &ff_cols, &ff_vals);
     k_ff.drop_below_threshold(1e-30);
 
-    SparseAssemblyResult3D {
-        k_ff, k_full, f: f_global, max_diag_k: max_diag,
+    super::assembly::StiffnessSparseAssembly3D {
+        k_ff, k_full, max_diag_k: max_diag,
         artificial_dofs: artificial_dofs_3d, inclined_transforms, diagnostics,
     }
+}
+
+/// Parallel 3D sparse assembly using rayon: stiffness + force vector.
+#[cfg(feature = "parallel")]
+pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering, build_k_full: bool) -> SparseAssemblyResult3D {
+    let stiff = assemble_stiffness_sparse_3d_parallel(input, dof_num, build_k_full);
+    // Force vector: built by the shared load-vector builder (same order as the
+    // fused assembly produced: element contributions in unified sorted order,
+    // then nodal/bimoment loads, then inclined rotations).
+    let f = assemble_load_vector_3d_sparse_parallel(input, &input.loads, dof_num, &stiff.inclined_transforms);
+    SparseAssemblyResult3D {
+        k_ff: stiff.k_ff,
+        k_full: stiff.k_full,
+        f,
+        max_diag_k: stiff.max_diag_k,
+        artificial_dofs: stiff.artificial_dofs,
+        inclined_transforms: stiff.inclined_transforms,
+        diagnostics: stiff.diagnostics,
+    }
+}
+
+/// Assemble the global force vector for 3D for a given set of loads,
+/// parallel-sparse flavor (with inclined support rotations applied).
+/// Mirrors the contribution order of `assemble_sparse_3d_parallel`: unified
+/// ID-sorted element list with inline per-element loads, then nodal/bimoment
+/// loads, then inclined rotations. Produces exactly the same `f`.
+#[cfg(feature = "parallel")]
+pub fn assemble_load_vector_3d_sparse_parallel(
+    input: &SolverInput3D,
+    loads: &[SolverLoad3D],
+    dof_num: &DofNumbering,
+    inclined_transforms: &[InclinedTransformData],
+) -> Vec<f64> {
+    use crate::element;
+    use crate::element::compute_local_axes_3d;
+
+    let n = dof_num.n_total;
+    let left_hand = input.left_hand.unwrap_or(false);
+
+    let node_map: std::collections::HashMap<usize, &SolverNode3D> =
+        input.nodes.values().map(|n| (n.id, n)).collect();
+    let mat_map: std::collections::HashMap<usize, &SolverMaterial> =
+        input.materials.values().map(|m| (m.id, m)).collect();
+    let sec_map: std::collections::HashMap<usize, &SolverSection3D> =
+        input.sections.values().map(|s| (s.id, s)).collect();
+    let load_index = build_load_index_3d(loads);
+
+    // Unified element list, sorted by ID (same order as the parallel assembler).
+    let mut all_elements: Vec<AnyElement3D> = Vec::new();
+    for e in input.elements.values() { all_elements.push(AnyElement3D::Frame(e)); }
+    for p in input.plates.values() { all_elements.push(AnyElement3D::Plate(p)); }
+    for q in input.quads.values() { all_elements.push(AnyElement3D::Quad(q)); }
+    for q9 in input.quad9s.values() { all_elements.push(AnyElement3D::Quad9(q9)); }
+    for ss in input.solid_shells.values() { all_elements.push(AnyElement3D::SolidShell(ss)); }
+    for cs in input.curved_shells.values() { all_elements.push(AnyElement3D::CurvedShell(cs)); }
+    for conn in input.connectors.values() { all_elements.push(AnyElement3D::Connector(conn)); }
+    all_elements.sort_by_key(|e| match e {
+        AnyElement3D::Frame(f) => f.id,
+        AnyElement3D::Plate(p) => p.id,
+        AnyElement3D::Quad(q) => q.id,
+        AnyElement3D::Quad9(q) => q.id,
+        AnyElement3D::SolidShell(s) => s.id,
+        AnyElement3D::CurvedShell(c) => c.id,
+        AnyElement3D::Connector(c) => c.id,
+    });
+
+    let mut f_global = vec![0.0; n];
+
+    for any_elem in &all_elements {
+        match any_elem {
+            AnyElement3D::Frame(elem) => {
+                let node_i = node_map[&elem.node_i];
+                let node_j = node_map[&elem.node_j];
+                let mat = mat_map[&elem.material_id];
+                let sec = sec_map[&elem.section_id];
+                let dx = node_j.x - node_i.x;
+                let dy = node_j.y - node_i.y;
+                let dz = node_j.z - node_i.z;
+                let l = (dx * dx + dy * dy + dz * dz).sqrt();
+                let e = mat.e * 1000.0;
+                let g = e / (2.0 * (1.0 + mat.nu));
+
+                if elem.elem_type == "truss" || elem.elem_type == "cable" {
+                    let dir = [dx / l, dy / l, dz / l];
+                    // Assemble thermal FEF for truss elements
+                    if let Some(elem_loads) = load_index.get(&elem.id) {
+                        for load in elem_loads {
+                            if let SolverLoad3D::Thermal(tl) = load {
+                                let alpha = 12e-6;
+                                let fx = e * sec.a * alpha * tl.dt_uniform;
+                                for k in 0..3 {
+                                    if let Some(&d) = dof_num.map.get(&(elem.node_i, k)) {
+                                        f_global[d] += -fx * dir[k];
+                                    }
+                                    if let Some(&d) = dof_num.map.get(&(elem.node_j, k)) {
+                                        f_global[d] += fx * dir[k];
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    let (ex, ey, ez) = compute_local_axes_3d(
+                        node_i.x, node_i.y, node_i.z, node_j.x, node_j.y, node_j.z,
+                        elem.local_yx, elem.local_yy, elem.local_yz, elem.roll_angle, left_hand,
+                    );
+                    let elem_dofs = dof_num.element_dofs(elem.node_i, elem.node_j);
+                    let has_cw = sec.cw.map_or(false, |cw| cw > 0.0);
+
+                    let (phi_y, phi_z) = if sec.as_y.is_some() || sec.as_z.is_some() {
+                        let l2 = l * l;
+                        let py = sec.as_y.map(|ay| 12.0 * e * sec.iy / (g * ay * l2)).unwrap_or(0.0);
+                        let pz = sec.as_z.map(|az| 12.0 * e * sec.iz / (g * az * l2)).unwrap_or(0.0);
+                        (py, pz)
+                    } else {
+                        (0.0, 0.0)
+                    };
+
+                    if has_cw && dof_num.dofs_per_node >= 7 {
+                        let t = element::frame_transform_3d_warping(&ex, &ey, &ez);
+                        // Warping element loads
+                        if let Some(elem_loads) = load_index.get(&elem.id) {
+                            for load in elem_loads {
+                                match load {
+                                    SolverLoad3D::Distributed(dl) => {
+                                        let a = dl.a.unwrap_or(0.0);
+                                        let b = dl.b.unwrap_or(l);
+                                        let is_full = (a.abs() < 1e-12) && ((b - l).abs() < 1e-12);
+                                        let mut fef12 = if is_full {
+                                            element::fef_distributed_3d(dl.q_yi, dl.q_yj, dl.q_zi, dl.q_zj, l)
+                                        } else {
+                                            element::fef_partial_distributed_3d(dl.q_yi, dl.q_yj, dl.q_zi, dl.q_zj, a, b, l)
+                                        };
+                                        adjust_fef_for_hinges_3d(&mut fef12, l, Hinge3D::from_elem(elem), phi_y, phi_z);
+                                        let fef14 = element::expand_fef_12_to_14(&fef12);
+                                        let fef_global = transform_force(&fef14, &t, 14);
+                                        for (i, &dof) in elem_dofs.iter().enumerate() { f_global[dof] += fef_global[i]; }
+                                    }
+                                    SolverLoad3D::PointOnElement(pl) => {
+                                        let fef_y = element::fef_point_load_2d(pl.py, 0.0, 0.0, pl.a, l);
+                                        let mut fef12 = [0.0; 12];
+                                        fef12[1] = fef_y[1]; fef12[5] = fef_y[2];
+                                        fef12[7] = fef_y[4]; fef12[11] = fef_y[5];
+                                        let fef_z = element::fef_point_load_2d(pl.pz, 0.0, 0.0, pl.a, l);
+                                        fef12[2] = fef_z[1]; fef12[4] = -fef_z[2];
+                                        fef12[8] = fef_z[4]; fef12[10] = -fef_z[5];
+                                        adjust_fef_for_hinges_3d(&mut fef12, l, Hinge3D::from_elem(elem), phi_y, phi_z);
+                                        let fef14 = element::expand_fef_12_to_14(&fef12);
+                                        let fef_global = transform_force(&fef14, &t, 14);
+                                        for (i, &dof) in elem_dofs.iter().enumerate() { f_global[dof] += fef_global[i]; }
+                                    }
+                                    SolverLoad3D::Thermal(tl) => {
+                                        let alpha = 12e-6;
+                                        let hy = if sec.a > 1e-15 { (12.0 * sec.iz / sec.a).sqrt() } else { 0.1 };
+                                        let hz = if sec.a > 1e-15 { (12.0 * sec.iy / sec.a).sqrt() } else { 0.1 };
+                                        let mut fef12 = element::fef_thermal_3d(e, sec.a, sec.iy, sec.iz, l, tl.dt_uniform, tl.dt_gradient_y, tl.dt_gradient_z, alpha, hy, hz);
+                                        adjust_fef_for_hinges_3d(&mut fef12, l, Hinge3D::from_elem(elem), phi_y, phi_z);
+                                        let fef14 = element::expand_fef_12_to_14(&fef12);
+                                        let fef_global = transform_force(&fef14, &t, 14);
+                                        for (i, &dof) in elem_dofs.iter().enumerate() { f_global[dof] += fef_global[i]; }
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                    } else if dof_num.dofs_per_node >= 7 {
+                        let t = element::frame_transform_3d(&ex, &ey, &ez);
+                        // Mapped element loads (12→14 DOF)
+                        if let Some(elem_loads) = load_index.get(&elem.id) {
+                            for load in elem_loads {
+                                match load {
+                                    SolverLoad3D::Distributed(dl) => {
+                                        let a = dl.a.unwrap_or(0.0);
+                                        let b = dl.b.unwrap_or(l);
+                                        let is_full = (a.abs() < 1e-12) && ((b - l).abs() < 1e-12);
+                                        let mut fef = if is_full {
+                                            element::fef_distributed_3d(dl.q_yi, dl.q_yj, dl.q_zi, dl.q_zj, l)
+                                        } else {
+                                            element::fef_partial_distributed_3d(dl.q_yi, dl.q_yj, dl.q_zi, dl.q_zj, a, b, l)
+                                        };
+                                        adjust_fef_for_hinges_3d(&mut fef, l, Hinge3D::from_elem(elem), phi_y, phi_z);
+                                        let fef_global = transform_force(&fef, &t, 12);
+                                        for i in 0..12 { f_global[elem_dofs[DOF_MAP_12_TO_14[i]]] += fef_global[i]; }
+                                    }
+                                    SolverLoad3D::PointOnElement(pl) => {
+                                        let fef_y = element::fef_point_load_2d(pl.py, 0.0, 0.0, pl.a, l);
+                                        let mut fef = [0.0; 12];
+                                        fef[1] = fef_y[1]; fef[5] = fef_y[2];
+                                        fef[7] = fef_y[4]; fef[11] = fef_y[5];
+                                        let fef_z = element::fef_point_load_2d(pl.pz, 0.0, 0.0, pl.a, l);
+                                        fef[2] = fef_z[1]; fef[4] = -fef_z[2];
+                                        fef[8] = fef_z[4]; fef[10] = -fef_z[5];
+                                        adjust_fef_for_hinges_3d(&mut fef, l, Hinge3D::from_elem(elem), phi_y, phi_z);
+                                        let fef_global = transform_force(&fef, &t, 12);
+                                        for i in 0..12 { f_global[elem_dofs[DOF_MAP_12_TO_14[i]]] += fef_global[i]; }
+                                    }
+                                    SolverLoad3D::Thermal(tl) => {
+                                        let alpha = 12e-6;
+                                        let hy = if sec.a > 1e-15 { (12.0 * sec.iz / sec.a).sqrt() } else { 0.1 };
+                                        let hz = if sec.a > 1e-15 { (12.0 * sec.iy / sec.a).sqrt() } else { 0.1 };
+                                        let mut fef = element::fef_thermal_3d(e, sec.a, sec.iy, sec.iz, l, tl.dt_uniform, tl.dt_gradient_y, tl.dt_gradient_z, alpha, hy, hz);
+                                        adjust_fef_for_hinges_3d(&mut fef, l, Hinge3D::from_elem(elem), phi_y, phi_z);
+                                        let fef_global = transform_force(&fef, &t, 12);
+                                        for i in 0..12 { f_global[elem_dofs[DOF_MAP_12_TO_14[i]]] += fef_global[i]; }
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                    } else {
+                        let t = element::frame_transform_3d(&ex, &ey, &ez);
+                        // Standard 12-DOF element loads
+                        if let Some(elem_loads) = load_index.get(&elem.id) {
+                            for load in elem_loads {
+                                match load {
+                                    SolverLoad3D::Distributed(dl) => {
+                                        let a = dl.a.unwrap_or(0.0);
+                                        let b = dl.b.unwrap_or(l);
+                                        let is_full = (a.abs() < 1e-12) && ((b - l).abs() < 1e-12);
+                                        let mut fef = if is_full {
+                                            element::fef_distributed_3d(dl.q_yi, dl.q_yj, dl.q_zi, dl.q_zj, l)
+                                        } else {
+                                            element::fef_partial_distributed_3d(dl.q_yi, dl.q_yj, dl.q_zi, dl.q_zj, a, b, l)
+                                        };
+                                        adjust_fef_for_hinges_3d(&mut fef, l, Hinge3D::from_elem(elem), phi_y, phi_z);
+                                        let fef_global = transform_force(&fef, &t, 12);
+                                        for (i, &dof) in elem_dofs.iter().enumerate() { f_global[dof] += fef_global[i]; }
+                                    }
+                                    SolverLoad3D::PointOnElement(pl) => {
+                                        let fef_y = element::fef_point_load_2d(pl.py, 0.0, 0.0, pl.a, l);
+                                        let mut fef = [0.0; 12];
+                                        fef[1] = fef_y[1]; fef[5] = fef_y[2];
+                                        fef[7] = fef_y[4]; fef[11] = fef_y[5];
+                                        let fef_z = element::fef_point_load_2d(pl.pz, 0.0, 0.0, pl.a, l);
+                                        fef[2] = fef_z[1]; fef[4] = -fef_z[2];
+                                        fef[8] = fef_z[4]; fef[10] = -fef_z[5];
+                                        adjust_fef_for_hinges_3d(&mut fef, l, Hinge3D::from_elem(elem), phi_y, phi_z);
+                                        let fef_global = transform_force(&fef, &t, 12);
+                                        for (i, &dof) in elem_dofs.iter().enumerate() { f_global[dof] += fef_global[i]; }
+                                    }
+                                    SolverLoad3D::Thermal(tl) => {
+                                        let alpha = 12e-6;
+                                        let hy = if sec.a > 1e-15 { (12.0 * sec.iz / sec.a).sqrt() } else { 0.1 };
+                                        let hz = if sec.a > 1e-15 { (12.0 * sec.iy / sec.a).sqrt() } else { 0.1 };
+                                        let mut fef = element::fef_thermal_3d(e, sec.a, sec.iy, sec.iz, l, tl.dt_uniform, tl.dt_gradient_y, tl.dt_gradient_z, alpha, hy, hz);
+                                        adjust_fef_for_hinges_3d(&mut fef, l, Hinge3D::from_elem(elem), phi_y, phi_z);
+                                        let fef_global = transform_force(&fef, &t, 12);
+                                        for (i, &dof) in elem_dofs.iter().enumerate() { f_global[dof] += fef_global[i]; }
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            AnyElement3D::Plate(plate) => {
+                let mat = mat_map[&plate.material_id];
+                let e = mat.e * 1000.0;
+                let nu = mat.nu;
+                let n0 = node_map[&plate.nodes[0]];
+                let n1 = node_map[&plate.nodes[1]];
+                let n2 = node_map[&plate.nodes[2]];
+                let coords = [[n0.x, n0.y, n0.z], [n1.x, n1.y, n1.z], [n2.x, n2.y, n2.z]];
+                let plate_dofs = dof_num.plate_element_dofs(&plate.nodes);
+                // Plate loads
+                if let Some(elem_loads) = load_index.get(&plate.id) {
+                    for load in elem_loads {
+                        match load {
+                            SolverLoad3D::Pressure(pl) => {
+                                let f_press = element::plate_pressure_load(&coords, pl.pressure);
+                                for (i, &dof) in plate_dofs.iter().enumerate() {
+                                    if i < f_press.len() { f_global[dof] += f_press[i]; }
+                                }
+                            }
+                            SolverLoad3D::PlateThermal(tl) => {
+                                let alpha = tl.alpha.unwrap_or(12e-6);
+                                let f_th = element::plate_thermal_load(&coords, e, nu, plate.thickness, alpha, tl.dt_uniform, tl.dt_gradient);
+                                for (i, &dof) in plate_dofs.iter().enumerate() {
+                                    if i < f_th.len() { f_global[dof] += f_th[i]; }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+
+            AnyElement3D::Quad(quad) => {
+                let mat = mat_map[&quad.material_id];
+                let e = mat.e * 1000.0;
+                let nu = mat.nu;
+                let n0 = node_map[&quad.nodes[0]];
+                let n1 = node_map[&quad.nodes[1]];
+                let n2 = node_map[&quad.nodes[2]];
+                let n3 = node_map[&quad.nodes[3]];
+                let coords = [[n0.x, n0.y, n0.z], [n1.x, n1.y, n1.z], [n2.x, n2.y, n2.z], [n3.x, n3.y, n3.z]];
+                let quad_dofs = dof_num.quad_element_dofs(&quad.nodes);
+                // Quad loads
+                if let Some(elem_loads) = load_index.get(&quad.id) {
+                    for load in elem_loads {
+                        match load {
+                            SolverLoad3D::QuadPressure(pl) => {
+                                let f_press = element::quad::quad_pressure_load(&coords, pl.pressure);
+                                for (i, &dof) in quad_dofs.iter().enumerate() {
+                                    if i < f_press.len() { f_global[dof] += f_press[i]; }
+                                }
+                            }
+                            SolverLoad3D::QuadThermal(tl) => {
+                                let alpha = tl.alpha.unwrap_or(1.2e-5);
+                                let f_th = element::quad::quad_thermal_load(&coords, e, nu, quad.thickness, alpha, tl.dt_uniform, tl.dt_gradient);
+                                for (i, &dof) in quad_dofs.iter().enumerate() {
+                                    if i < f_th.len() { f_global[dof] += f_th[i]; }
+                                }
+                            }
+                            SolverLoad3D::QuadSelfWeight(sw) => {
+                                let f_sw = element::quad::quad_self_weight_load(&coords, sw.density, quad.thickness, sw.gx, sw.gy, sw.gz);
+                                for (i, &dof) in quad_dofs.iter().enumerate() {
+                                    if i < f_sw.len() { f_global[dof] += f_sw[i]; }
+                                }
+                            }
+                            SolverLoad3D::QuadEdge(el) => {
+                                let f_edge = element::quad::quad_edge_load(&coords, el.edge, el.qn, el.qt);
+                                for (i, &dof) in quad_dofs.iter().enumerate() {
+                                    if i < f_edge.len() { f_global[dof] += f_edge[i]; }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+
+            AnyElement3D::Quad9(q9) => {
+                let mat = mat_map[&q9.material_id];
+                let e = mat.e * 1000.0;
+                let nu = mat.nu;
+                let coords = quad9_node_coords(&node_map, q9);
+                let q9_dofs = dof_num.quad9_element_dofs(&q9.nodes);
+                // Quad9 loads
+                if let Some(elem_loads) = load_index.get(&q9.id) {
+                    for load in elem_loads {
+                        match load {
+                            SolverLoad3D::Quad9Pressure(pl) => {
+                                let f_p = element::quad9::quad9_pressure_load(&coords, pl.pressure);
+                                let dofs = &q9_dofs;
+                                for (i, &dof) in dofs.iter().enumerate() {
+                                    if i < f_p.len() { f_global[dof] += f_p[i]; }
+                                }
+                            }
+                            SolverLoad3D::Quad9Thermal(tl) => {
+                                let alpha = tl.alpha.unwrap_or(1.2e-5);
+                                let f_th = element::quad9::quad9_thermal_load(&coords, e, nu, q9.thickness, alpha, tl.dt_uniform, tl.dt_gradient);
+                                for (i, &dof) in q9_dofs.iter().enumerate() {
+                                    if i < f_th.len() { f_global[dof] += f_th[i]; }
+                                }
+                            }
+                            SolverLoad3D::Quad9SelfWeight(sw) => {
+                                let f_sw = element::quad9::quad9_self_weight_load(&coords, sw.density, q9.thickness, sw.gx, sw.gy, sw.gz);
+                                for (i, &dof) in q9_dofs.iter().enumerate() {
+                                    if i < f_sw.len() { f_global[dof] += f_sw[i]; }
+                                }
+                            }
+                            SolverLoad3D::Quad9Edge(el) => {
+                                let f_edge = element::quad9::quad9_edge_load(&coords, el.edge, el.qn, el.qt);
+                                for (i, &dof) in q9_dofs.iter().enumerate() {
+                                    if i < f_edge.len() { f_global[dof] += f_edge[i]; }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+
+            AnyElement3D::SolidShell(ss) => {
+                let coords = solid_shell_node_coords(&node_map, ss);
+                let ss_dofs = dof_num.solid_shell_element_dofs(&ss.nodes);
+                // Solid-shell loads
+                if let Some(elem_loads) = load_index.get(&ss.id) {
+                    for load in elem_loads {
+                        match load {
+                            SolverLoad3D::SolidShellPressure(pl) => {
+                                let f_p = element::solid_shell::solid_shell_pressure_load(&coords, pl.pressure);
+                                for (i, &dof) in ss_dofs.iter().enumerate() {
+                                    if i < f_p.len() { f_global[dof] += f_p[i]; }
+                                }
+                            }
+                            SolverLoad3D::SolidShellSelfWeight(sw) => {
+                                let f_sw = element::solid_shell::solid_shell_self_weight_load(&coords, sw.density, sw.gx, sw.gy, sw.gz);
+                                for (i, &dof) in ss_dofs.iter().enumerate() {
+                                    if i < f_sw.len() { f_global[dof] += f_sw[i]; }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+
+            AnyElement3D::CurvedShell(cs) => {
+                let mat = mat_map[&cs.material_id];
+                let e = mat.e * 1000.0;
+                let nu = mat.nu;
+                let coords = curved_shell_node_coords(&node_map, cs);
+                let dirs = cs.normals.unwrap_or_else(|| element::curved_shell::compute_element_directors(&coords));
+                let cs_dofs = dof_num.quad_element_dofs(&cs.nodes);
+                // Curved shell loads
+                if let Some(elem_loads) = load_index.get(&cs.id) {
+                    for load in elem_loads {
+                        match load {
+                            SolverLoad3D::CurvedShellPressure(pl) => {
+                                let f_p = element::curved_shell::curved_shell_pressure_load(&coords, &dirs, cs.thickness, pl.pressure);
+                                for (i, &dof) in cs_dofs.iter().enumerate() {
+                                    if i < f_p.len() { f_global[dof] += f_p[i]; }
+                                }
+                            }
+                            SolverLoad3D::CurvedShellThermal(tl) => {
+                                let alpha = tl.alpha.unwrap_or(1.2e-5);
+                                let f_th = element::curved_shell::curved_shell_thermal_load(&coords, &dirs, e, nu, cs.thickness, alpha, tl.dt_uniform, tl.dt_gradient);
+                                for (i, &dof) in cs_dofs.iter().enumerate() {
+                                    if i < f_th.len() { f_global[dof] += f_th[i]; }
+                                }
+                            }
+                            SolverLoad3D::CurvedShellSelfWeight(sw) => {
+                                let f_sw = element::curved_shell::curved_shell_self_weight_load(&coords, &dirs, sw.density, cs.thickness, sw.gx, sw.gy, sw.gz);
+                                for (i, &dof) in cs_dofs.iter().enumerate() {
+                                    if i < f_sw.len() { f_global[dof] += f_sw[i]; }
+                                }
+                            }
+                            SolverLoad3D::CurvedShellEdge(el) => {
+                                let f_e = element::curved_shell::curved_shell_edge_load(&coords, &dirs, cs.thickness, el.edge, el.qn, el.qt);
+                                for (i, &dof) in cs_dofs.iter().enumerate() {
+                                    if i < f_e.len() { f_global[dof] += f_e[i]; }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+
+            AnyElement3D::Connector(_) => {}
+        }
+    }
+
+    // Nodal loads (not element-bound)
+    for load in loads {
+        if let SolverLoad3D::Nodal(nl) = load {
+            let forces = [nl.fx, nl.fy, nl.fz, nl.mx, nl.my, nl.mz];
+            for (i, &f) in forces.iter().enumerate() {
+                if i < dof_num.dofs_per_node {
+                    if let Some(&d) = dof_num.map.get(&(nl.node_id, i)) { f_global[d] += f; }
+                }
+            }
+            if let Some(bw) = nl.bw {
+                if bw.abs() > 1e-15 {
+                    if let Some(&d) = dof_num.map.get(&(nl.node_id, 6)) { f_global[d] += bw; }
+                }
+            }
+        }
+        if let SolverLoad3D::Bimoment(bl) = load {
+            if bl.bimoment.abs() > 1e-15 {
+                if let Some(&d) = dof_num.map.get(&(bl.node_id, 6)) { f_global[d] += bl.bimoment; }
+            }
+        }
+    }
+
+    // Apply inclined support rotations to the force vector
+    for it in inclined_transforms {
+        super::assembly::rotate_inclined_f_triplets(&mut f_global, &it.dofs, &it.r);
+    }
+
+    f_global
+}
+
+/// Build the 3D sparse-path global force vector for a given set of loads,
+/// matching whichever assembler `assemble_sparse_3d_parallel` resolves to in
+/// this build configuration (parallel or sequential fallback).
+#[cfg(feature = "parallel")]
+pub fn assemble_load_vector_sparse_3d(
+    input: &SolverInput3D,
+    loads: &[SolverLoad3D],
+    dof_num: &DofNumbering,
+    inclined_transforms: &[InclinedTransformData],
+) -> Vec<f64> {
+    assemble_load_vector_3d_sparse_parallel(input, loads, dof_num, inclined_transforms)
+}
+
+/// Non-parallel fallback for `assemble_load_vector_sparse_3d`.
+#[cfg(not(feature = "parallel"))]
+pub fn assemble_load_vector_sparse_3d(
+    input: &SolverInput3D,
+    loads: &[SolverLoad3D],
+    dof_num: &DofNumbering,
+    inclined_transforms: &[InclinedTransformData],
+) -> Vec<f64> {
+    super::assembly::assemble_load_vector_3d_sparse(input, loads, dof_num, inclined_transforms)
 }
 
 /// Non-parallel fallback for `assemble_sparse_3d_parallel`.
 #[cfg(not(feature = "parallel"))]
 pub fn assemble_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering, build_k_full: bool) -> SparseAssemblyResult3D {
     super::assembly::assemble_sparse_3d(input, dof_num, build_k_full)
+}
+
+/// Non-parallel fallback for `assemble_stiffness_sparse_3d_parallel`.
+#[cfg(not(feature = "parallel"))]
+pub fn assemble_stiffness_sparse_3d_parallel(input: &SolverInput3D, dof_num: &DofNumbering, build_k_full: bool) -> super::assembly::StiffnessSparseAssembly3D {
+    super::assembly::assemble_stiffness_sparse_3d(input, dof_num, build_k_full)
 }
 
 /// Coordinate helpers for the parallel path (avoid name collision with assembly.rs).

--- a/engine/src/solver/staged.rs
+++ b/engine/src/solver/staged.rs
@@ -358,7 +358,7 @@ fn assemble_staged_2d(
 
             // Assemble element loads (FEF) for this stage's loads
             assemble_element_loads_2d(
-                stage_input, elem, &k_local, &t, l, e, sec, node_i, &elem_dofs, &mut f_global,
+                &stage_input.loads, elem, &t, l, e, sec, &elem_dofs, &mut f_global,
             );
         }
     }

--- a/engine/tests/integration/main.rs
+++ b/engine/tests/integration/main.rs
@@ -13,6 +13,7 @@ mod foundation_check;
 mod harmonic;
 mod influence_3d;
 mod load_cases;
+mod multi_case_parity;
 mod masonry_check;
 mod material_nonlinear_3d;
 mod moving_loads_3d;

--- a/engine/tests/integration/multi_case_parity.rs
+++ b/engine/tests/integration/multi_case_parity.rs
@@ -1,0 +1,828 @@
+/// Bit-for-bit parity tests for the prepared (factorization-reuse) multi-case solver.
+///
+/// For each model, results from `solve_multi_case_*` (assemble + factorize once,
+/// rebuild only the load vector per case) are compared against the legacy
+/// behavior: one full `solve_*` per case, combined manually with
+/// `combine_results*`. All f64 comparisons are exact (`==`) — the new path is
+/// required to reproduce the per-case path bit-for-bit.
+///
+/// Coverage: 2D dense, 2D sparse (nf >= 64), 3D dense, 3D sparse with shell
+/// quads; distributed / nodal / point-on-element / thermal loads, prescribed
+/// support displacements, and a 1-case multi-case ≡ single solve check.
+
+use dedaliano_engine::postprocess::combinations::*;
+use dedaliano_engine::solver::linear::{solve_2d, solve_3d};
+use dedaliano_engine::solver::load_cases::*;
+use dedaliano_engine::types::*;
+use std::collections::HashMap;
+
+// ==================== Comparison helpers (exact, bit-for-bit) ====================
+
+fn assert_f64_eq(a: f64, b: f64, what: &str) {
+    assert!(a == b, "mismatch at {}: {} vs {} (diff {:e})", what, a, b, (a - b).abs());
+}
+
+fn assert_results_eq(a: &AnalysisResults, b: &AnalysisResults, ctx: &str) {
+    assert_eq!(a.displacements.len(), b.displacements.len(), "{}: displacement count", ctx);
+    for (da, db) in a.displacements.iter().zip(&b.displacements) {
+        assert_eq!(da.node_id, db.node_id, "{}: disp node_id", ctx);
+        assert_f64_eq(da.ux, db.ux, &format!("{} disp node {} ux", ctx, da.node_id));
+        assert_f64_eq(da.uz, db.uz, &format!("{} disp node {} uz", ctx, da.node_id));
+        assert_f64_eq(da.ry, db.ry, &format!("{} disp node {} ry", ctx, da.node_id));
+    }
+    assert_eq!(a.reactions.len(), b.reactions.len(), "{}: reaction count", ctx);
+    for (ra, rb) in a.reactions.iter().zip(&b.reactions) {
+        assert_eq!(ra.node_id, rb.node_id, "{}: reaction node_id", ctx);
+        assert_f64_eq(ra.rx, rb.rx, &format!("{} reaction node {} rx", ctx, ra.node_id));
+        assert_f64_eq(ra.rz, rb.rz, &format!("{} reaction node {} rz", ctx, ra.node_id));
+        assert_f64_eq(ra.my, rb.my, &format!("{} reaction node {} my", ctx, ra.node_id));
+    }
+    assert_eq!(a.element_forces.len(), b.element_forces.len(), "{}: element_forces count", ctx);
+    for (ea, eb) in a.element_forces.iter().zip(&b.element_forces) {
+        assert_eq!(ea.element_id, eb.element_id, "{}: ef element_id", ctx);
+        let c = format!("{} ef {}", ctx, ea.element_id);
+        assert_f64_eq(ea.n_start, eb.n_start, &format!("{} n_start", c));
+        assert_f64_eq(ea.n_end, eb.n_end, &format!("{} n_end", c));
+        assert_f64_eq(ea.v_start, eb.v_start, &format!("{} v_start", c));
+        assert_f64_eq(ea.v_end, eb.v_end, &format!("{} v_end", c));
+        assert_f64_eq(ea.m_start, eb.m_start, &format!("{} m_start", c));
+        assert_f64_eq(ea.m_end, eb.m_end, &format!("{} m_end", c));
+        assert_f64_eq(ea.length, eb.length, &format!("{} length", c));
+        assert_f64_eq(ea.q_i, eb.q_i, &format!("{} q_i", c));
+        assert_f64_eq(ea.q_j, eb.q_j, &format!("{} q_j", c));
+        assert_eq!(ea.hinge_start, eb.hinge_start, "{} hinge_start", c);
+        assert_eq!(ea.hinge_end, eb.hinge_end, "{} hinge_end", c);
+        assert_eq!(ea.point_loads.len(), eb.point_loads.len(), "{} point_loads len", c);
+        for (pa, pb) in ea.point_loads.iter().zip(&eb.point_loads) {
+            assert_f64_eq(pa.a, pb.a, &format!("{} pl a", c));
+            assert_f64_eq(pa.p, pb.p, &format!("{} pl p", c));
+        }
+        assert_eq!(ea.distributed_loads.len(), eb.distributed_loads.len(), "{} dist_loads len", c);
+        for (dla, dlb) in ea.distributed_loads.iter().zip(&eb.distributed_loads) {
+            assert_f64_eq(dla.q_i, dlb.q_i, &format!("{} dl q_i", c));
+            assert_f64_eq(dla.q_j, dlb.q_j, &format!("{} dl q_j", c));
+            assert_f64_eq(dla.a, dlb.a, &format!("{} dl a", c));
+            assert_f64_eq(dla.b, dlb.b, &format!("{} dl b", c));
+        }
+    }
+}
+
+fn assert_results_3d_eq(a: &AnalysisResults3D, b: &AnalysisResults3D, ctx: &str) {
+    assert_eq!(a.displacements.len(), b.displacements.len(), "{}: displacement count", ctx);
+    for (da, db) in a.displacements.iter().zip(&b.displacements) {
+        assert_eq!(da.node_id, db.node_id, "{}: disp node_id", ctx);
+        let c = format!("{} disp node {}", ctx, da.node_id);
+        assert_f64_eq(da.ux, db.ux, &format!("{} ux", c));
+        assert_f64_eq(da.uy, db.uy, &format!("{} uy", c));
+        assert_f64_eq(da.uz, db.uz, &format!("{} uz", c));
+        assert_f64_eq(da.rx, db.rx, &format!("{} rx", c));
+        assert_f64_eq(da.ry, db.ry, &format!("{} ry", c));
+        assert_f64_eq(da.rz, db.rz, &format!("{} rz", c));
+        assert_eq!(da.warping, db.warping, "{} warping", c);
+    }
+    assert_eq!(a.reactions.len(), b.reactions.len(), "{}: reaction count", ctx);
+    for (ra, rb) in a.reactions.iter().zip(&b.reactions) {
+        assert_eq!(ra.node_id, rb.node_id, "{}: reaction node_id", ctx);
+        let c = format!("{} reaction node {}", ctx, ra.node_id);
+        assert_f64_eq(ra.fx, rb.fx, &format!("{} fx", c));
+        assert_f64_eq(ra.fy, rb.fy, &format!("{} fy", c));
+        assert_f64_eq(ra.fz, rb.fz, &format!("{} fz", c));
+        assert_f64_eq(ra.mx, rb.mx, &format!("{} mx", c));
+        assert_f64_eq(ra.my, rb.my, &format!("{} my", c));
+        assert_f64_eq(ra.mz, rb.mz, &format!("{} mz", c));
+        assert_eq!(ra.bimoment, rb.bimoment, "{} bimoment", c);
+    }
+    assert_eq!(a.element_forces.len(), b.element_forces.len(), "{}: element_forces count", ctx);
+    for (ea, eb) in a.element_forces.iter().zip(&b.element_forces) {
+        assert_eq!(ea.element_id, eb.element_id, "{}: ef element_id", ctx);
+        let c = format!("{} ef {}", ctx, ea.element_id);
+        assert_f64_eq(ea.length, eb.length, &format!("{} length", c));
+        assert_f64_eq(ea.n_start, eb.n_start, &format!("{} n_start", c));
+        assert_f64_eq(ea.n_end, eb.n_end, &format!("{} n_end", c));
+        assert_f64_eq(ea.vy_start, eb.vy_start, &format!("{} vy_start", c));
+        assert_f64_eq(ea.vy_end, eb.vy_end, &format!("{} vy_end", c));
+        assert_f64_eq(ea.vz_start, eb.vz_start, &format!("{} vz_start", c));
+        assert_f64_eq(ea.vz_end, eb.vz_end, &format!("{} vz_end", c));
+        assert_f64_eq(ea.mx_start, eb.mx_start, &format!("{} mx_start", c));
+        assert_f64_eq(ea.mx_end, eb.mx_end, &format!("{} mx_end", c));
+        assert_f64_eq(ea.my_start, eb.my_start, &format!("{} my_start", c));
+        assert_f64_eq(ea.my_end, eb.my_end, &format!("{} my_end", c));
+        assert_f64_eq(ea.mz_start, eb.mz_start, &format!("{} mz_start", c));
+        assert_f64_eq(ea.mz_end, eb.mz_end, &format!("{} mz_end", c));
+        assert_f64_eq(ea.q_yi, eb.q_yi, &format!("{} q_yi", c));
+        assert_f64_eq(ea.q_yj, eb.q_yj, &format!("{} q_yj", c));
+        assert_f64_eq(ea.q_zi, eb.q_zi, &format!("{} q_zi", c));
+        assert_f64_eq(ea.q_zj, eb.q_zj, &format!("{} q_zj", c));
+        assert_eq!(ea.distributed_loads_y.len(), eb.distributed_loads_y.len(), "{} dly len", c);
+        for (x, y) in ea.distributed_loads_y.iter().zip(&eb.distributed_loads_y) {
+            assert_f64_eq(x.q_i, y.q_i, &format!("{} dly q_i", c));
+            assert_f64_eq(x.q_j, y.q_j, &format!("{} dly q_j", c));
+            assert_f64_eq(x.a, y.a, &format!("{} dly a", c));
+            assert_f64_eq(x.b, y.b, &format!("{} dly b", c));
+        }
+        assert_eq!(ea.distributed_loads_z.len(), eb.distributed_loads_z.len(), "{} dlz len", c);
+        for (x, y) in ea.distributed_loads_z.iter().zip(&eb.distributed_loads_z) {
+            assert_f64_eq(x.q_i, y.q_i, &format!("{} dlz q_i", c));
+            assert_f64_eq(x.q_j, y.q_j, &format!("{} dlz q_j", c));
+            assert_f64_eq(x.a, y.a, &format!("{} dlz a", c));
+            assert_f64_eq(x.b, y.b, &format!("{} dlz b", c));
+        }
+        assert_eq!(ea.point_loads_y.len(), eb.point_loads_y.len(), "{} ply len", c);
+        for (x, y) in ea.point_loads_y.iter().zip(&eb.point_loads_y) {
+            assert_f64_eq(x.a, y.a, &format!("{} ply a", c));
+            assert_f64_eq(x.p, y.p, &format!("{} ply p", c));
+        }
+        assert_eq!(ea.point_loads_z.len(), eb.point_loads_z.len(), "{} plz len", c);
+        for (x, y) in ea.point_loads_z.iter().zip(&eb.point_loads_z) {
+            assert_f64_eq(x.a, y.a, &format!("{} plz a", c));
+            assert_f64_eq(x.p, y.p, &format!("{} plz p", c));
+        }
+    }
+    assert_eq!(a.quad_stresses.len(), b.quad_stresses.len(), "{}: quad_stresses count", ctx);
+    for (qa, qb) in a.quad_stresses.iter().zip(&b.quad_stresses) {
+        assert_eq!(qa.element_id, qb.element_id, "{}: qs element_id", ctx);
+        let c = format!("{} qs {}", ctx, qa.element_id);
+        assert_f64_eq(qa.sigma_xx, qb.sigma_xx, &format!("{} sigma_xx", c));
+        assert_f64_eq(qa.sigma_yy, qb.sigma_yy, &format!("{} sigma_yy", c));
+        assert_f64_eq(qa.tau_xy, qb.tau_xy, &format!("{} tau_xy", c));
+        assert_f64_eq(qa.von_mises, qb.von_mises, &format!("{} von_mises", c));
+    }
+}
+
+// ==================== Legacy per-case reference path ====================
+
+fn reference_2d(input: &MultiCaseInput) -> (Vec<AnalysisResults>, Vec<(String, AnalysisResults)>) {
+    let mut cases = Vec::new();
+    let mut case_map: HashMap<String, usize> = HashMap::new();
+    for (idx, lc) in input.load_cases.iter().enumerate() {
+        let case_input = SolverInput {
+            nodes: input.solver.nodes.clone(),
+            materials: input.solver.materials.clone(),
+            sections: input.solver.sections.clone(),
+            elements: input.solver.elements.clone(),
+            supports: input.solver.supports.clone(),
+            loads: lc.loads.clone(),
+            constraints: vec![],
+            connectors: HashMap::new(),
+        };
+        cases.push(solve_2d(&case_input).expect("reference solve_2d failed"));
+        case_map.insert(lc.name.clone(), idx);
+    }
+    let mut combos = Vec::new();
+    for combo in &input.combinations {
+        let factors: Vec<CombinationFactor> = combo.factors.iter()
+            .filter_map(|(name, &factor)| case_map.get(name)
+                .map(|&idx| CombinationFactor { case_id: idx, factor }))
+            .collect();
+        let cases: Vec<CaseEntry> = cases.iter().enumerate()
+            .map(|(idx, r)| CaseEntry { case_id: idx, results: r.clone() })
+            .collect();
+        let combined = combine_results(&CombinationInput { factors, cases }).unwrap();
+        combos.push((combo.name.clone(), combined));
+    }
+    (cases, combos)
+}
+
+fn reference_3d(input: &MultiCaseInput3D) -> (Vec<AnalysisResults3D>, Vec<(String, AnalysisResults3D)>) {
+    let mut cases = Vec::new();
+    let mut case_map: HashMap<String, usize> = HashMap::new();
+    for (idx, lc) in input.load_cases.iter().enumerate() {
+        let case_input = SolverInput3D {
+            nodes: input.solver.nodes.clone(),
+            materials: input.solver.materials.clone(),
+            sections: input.solver.sections.clone(),
+            elements: input.solver.elements.clone(),
+            supports: input.solver.supports.clone(),
+            loads: lc.loads.clone(),
+            left_hand: input.solver.left_hand,
+            plates: input.solver.plates.clone(),
+            quads: input.solver.quads.clone(),
+            quad9s: input.solver.quad9s.clone(),
+            solid_shells: input.solver.solid_shells.clone(),
+            curved_shells: input.solver.curved_shells.clone(),
+            curved_beams: input.solver.curved_beams.clone(),
+            constraints: input.solver.constraints.clone(),
+            connectors: HashMap::new(),
+        };
+        cases.push(solve_3d(&case_input).expect("reference solve_3d failed"));
+        case_map.insert(lc.name.clone(), idx);
+    }
+    let mut combos = Vec::new();
+    for combo in &input.combinations {
+        let factors: Vec<CombinationFactor> = combo.factors.iter()
+            .filter_map(|(name, &factor)| case_map.get(name)
+                .map(|&idx| CombinationFactor { case_id: idx, factor }))
+            .collect();
+        let cases: Vec<CaseEntry3D> = cases.iter().enumerate()
+            .map(|(idx, r)| CaseEntry3D { case_id: idx, results: r.clone() })
+            .collect();
+        let combined = combine_results_3d(&CombinationInput3D { factors, cases }).unwrap();
+        combos.push((combo.name.clone(), combined));
+    }
+    (cases, combos)
+}
+
+// ==================== Model builders ====================
+
+fn sup_2d(id: usize, node_id: usize, kind: &str) -> SolverSupport {
+    SolverSupport {
+        id, node_id, support_type: kind.to_string(),
+        kx: None, ky: None, kz: None, dx: None, dz: None, dry: None, angle: None,
+    }
+}
+
+/// 2D three-span beam (dense path, nf < 64) with a prescribed-displacement
+/// support and an inclined roller (exercises the 2D inclined transform path).
+fn make_frame_2d_dense() -> SolverInput {
+    let mut nodes = HashMap::new();
+    for (id, x) in [(1, 0.0), (2, 3.0), (3, 7.0), (4, 10.0)] {
+        nodes.insert(id.to_string(), SolverNode { id, x, z: 0.0 });
+    }
+    let mut materials = HashMap::new();
+    materials.insert("1".to_string(), SolverMaterial { id: 1, e: 200e6, nu: 0.3 });
+    let mut sections = HashMap::new();
+    sections.insert("1".to_string(), SolverSection { id: 1, a: 0.05, iz: 1.0e-4, as_y: None });
+
+    let mut elements = HashMap::new();
+    for (id, ni, nj) in [(1, 1, 2), (2, 2, 3), (3, 3, 4)] {
+        elements.insert(id.to_string(), SolverElement {
+            id, elem_type: "frame".to_string(),
+            node_i: ni, node_j: nj,
+            material_id: 1, section_id: 1,
+            hinge_start: false, hinge_end: false,
+        });
+    }
+
+    let mut supports = HashMap::new();
+    supports.insert("1".to_string(), sup_2d(1, 1, "pinned"));
+    supports.insert("2".to_string(), sup_2d(2, 4, "rollerX"));
+    // Prescribed settlement at node 4 (K_fr·u_r coupling exercised per case)
+    let mut s4 = sup_2d(3, 4, "rollerX");
+    s4.dz = Some(-0.005);
+    supports.insert("3".to_string(), s4);
+    // Inclined roller at node 2 with prescribed displacement along the normal
+    let mut s2 = sup_2d(4, 2, "inclinedRoller");
+    s2.angle = Some(0.35);
+    s2.dx = Some(0.002);
+    s2.dz = Some(-0.001);
+    supports.insert("4".to_string(), s2);
+
+    SolverInput {
+        nodes, materials, sections, elements, supports,
+        loads: vec![], constraints: vec![], connectors: HashMap::new(),
+    }
+}
+
+/// 2D 30-element continuous beam (sparse path, nf = 89 >= 64).
+fn make_beam_2d_sparse() -> SolverInput {
+    let n_elem = 30;
+    let mut nodes = HashMap::new();
+    for i in 0..=n_elem {
+        let id = i + 1;
+        nodes.insert(id.to_string(), SolverNode { id, x: i as f64 * 0.5, z: 0.0 });
+    }
+    let mut materials = HashMap::new();
+    materials.insert("1".to_string(), SolverMaterial { id: 1, e: 200e6, nu: 0.3 });
+    let mut sections = HashMap::new();
+    sections.insert("1".to_string(), SolverSection { id: 1, a: 0.04, iz: 8.0e-5, as_y: None });
+
+    let mut elements = HashMap::new();
+    for i in 1..=n_elem {
+        elements.insert(i.to_string(), SolverElement {
+            id: i, elem_type: "frame".to_string(),
+            node_i: i, node_j: i + 1,
+            material_id: 1, section_id: 1,
+            hinge_start: false, hinge_end: false,
+        });
+    }
+
+    let mut supports = HashMap::new();
+    supports.insert("1".to_string(), sup_2d(1, 1, "pinned"));
+    supports.insert("2".to_string(), sup_2d(2, 16, "rollerX"));
+    supports.insert("3".to_string(), sup_2d(3, 31, "rollerX"));
+
+    SolverInput {
+        nodes, materials, sections, elements, supports,
+        loads: vec![], constraints: vec![], connectors: HashMap::new(),
+    }
+}
+
+fn sup_3d(node_id: usize, all_fixed: bool) -> SolverSupport3D {
+    SolverSupport3D {
+        node_id,
+        rx: all_fixed, ry: all_fixed, rz: all_fixed,
+        rrx: all_fixed, rry: all_fixed, rrz: all_fixed,
+        kx: None, ky: None, kz: None,
+        krx: None, kry: None, krz: None,
+        dx: None, dy: None, dz: None,
+        drx: None, dry: None, drz: None,
+        rw: None, kw: None,
+        normal_x: None, normal_y: None, normal_z: None,
+        is_inclined: None,
+    }
+}
+
+fn frame_elem_3d(id: usize, ni: usize, nj: usize) -> SolverElement3D {
+    SolverElement3D {
+        id, elem_type: "frame".to_string(),
+        node_i: ni, node_j: nj,
+        material_id: 1, section_id: 1,
+        release_my_start: false, release_my_end: false,
+        release_mz_start: false, release_mz_end: false,
+        release_t_start: false, release_t_end: false,
+        local_yx: None, local_yy: None, local_yz: None,
+        roll_angle: None,
+    }
+}
+
+fn section_3d() -> SolverSection3D {
+    SolverSection3D {
+        id: 1, name: None, a: 0.09,
+        iy: 6.75e-4, iz: 6.75e-4, j: 1.0e-3,
+        cw: None, as_y: None, as_z: None,
+    }
+}
+
+/// 3D dense model (nf = 6 < 64): one quad plate on a fixed frame column.
+fn make_mixed_3d_dense() -> SolverInput3D {
+    let mut nodes = HashMap::new();
+    // Quad nodes (slab at z = 3)
+    nodes.insert("1".to_string(), SolverNode3D { id: 1, x: 0.0, y: 0.0, z: 3.0 });
+    nodes.insert("2".to_string(), SolverNode3D { id: 2, x: 4.0, y: 0.0, z: 3.0 });
+    nodes.insert("3".to_string(), SolverNode3D { id: 3, x: 4.0, y: 4.0, z: 3.0 });
+    nodes.insert("4".to_string(), SolverNode3D { id: 4, x: 0.0, y: 4.0, z: 3.0 });
+    // Column base
+    nodes.insert("5".to_string(), SolverNode3D { id: 5, x: 0.0, y: 0.0, z: 0.0 });
+
+    let mut materials = HashMap::new();
+    materials.insert("1".to_string(), SolverMaterial { id: 1, e: 30_000.0, nu: 0.2 });
+
+    let mut sections = HashMap::new();
+    sections.insert("1".to_string(), section_3d());
+
+    let mut elements = HashMap::new();
+    elements.insert("1".to_string(), frame_elem_3d(1, 5, 1));
+
+    let mut quads = HashMap::new();
+    quads.insert("1".to_string(), SolverQuadElement {
+        id: 1, nodes: [1, 2, 3, 4], material_id: 1, thickness: 0.2,
+    });
+
+    let mut supports = HashMap::new();
+    supports.insert("2".to_string(), sup_3d(2, true));
+    supports.insert("3".to_string(), sup_3d(3, true));
+    supports.insert("4".to_string(), sup_3d(4, true));
+    let mut s5 = sup_3d(5, true);
+    s5.dz = Some(-0.004); // prescribed settlement at the column base
+    supports.insert("5".to_string(), s5);
+
+    SolverInput3D {
+        nodes, materials, sections, elements, supports,
+        loads: vec![],
+        constraints: vec![], left_hand: None,
+        plates: HashMap::new(), quads, quad9s: HashMap::new(),
+        solid_shells: HashMap::new(), curved_shells: HashMap::new(),
+        curved_beams: vec![],
+        connectors: HashMap::new(),
+    }
+}
+
+/// 3D sparse model (nf = 150 >= 64): 4×4 quad slab on 4 fixed frame columns.
+fn make_frame_slab_3d_sparse() -> SolverInput3D {
+    let nx = 4;
+    let ny = 4;
+    let lx = 8.0;
+    let ly = 8.0;
+    let slab_z = 3.0;
+
+    let mut nodes = HashMap::new();
+    let mut nid = 1;
+    // Slab grid nodes
+    let mut grid = vec![vec![0usize; ny + 1]; nx + 1];
+    for i in 0..=nx {
+        for j in 0..=ny {
+            let x = (i as f64 / nx as f64) * lx;
+            let y = (j as f64 / ny as f64) * ly;
+            nodes.insert(nid.to_string(), SolverNode3D { id: nid, x, y, z: slab_z });
+            grid[i][j] = nid;
+            nid += 1;
+        }
+    }
+    // Column base nodes
+    let base_xy = [(0.0, 0.0), (lx, 0.0), (lx, ly), (0.0, ly)];
+    let mut base_ids = Vec::new();
+    for &(x, y) in &base_xy {
+        nodes.insert(nid.to_string(), SolverNode3D { id: nid, x, y, z: 0.0 });
+        base_ids.push(nid);
+        nid += 1;
+    }
+
+    let mut materials = HashMap::new();
+    materials.insert("1".to_string(), SolverMaterial { id: 1, e: 30_000.0, nu: 0.2 });
+
+    let mut sections = HashMap::new();
+    sections.insert("1".to_string(), section_3d());
+
+    // Frame columns at the slab corners
+    let corner_nodes = [grid[0][0], grid[nx][0], grid[nx][ny], grid[0][ny]];
+    let mut elements = HashMap::new();
+    let mut eid = 1;
+    for (&base, &top) in base_ids.iter().zip(corner_nodes.iter()) {
+        elements.insert(eid.to_string(), frame_elem_3d(eid, base, top));
+        eid += 1;
+    }
+    let n_frames = eid - 1;
+
+    // Quad slab
+    let mut quads = HashMap::new();
+    let mut qid = 1000;
+    for i in 0..nx {
+        for j in 0..ny {
+            quads.insert(qid.to_string(), SolverQuadElement {
+                id: qid,
+                nodes: [grid[i][j], grid[i + 1][j], grid[i + 1][j + 1], grid[i][j + 1]],
+                material_id: 1,
+                thickness: 0.2,
+            });
+            qid += 1;
+        }
+    }
+    let n_quads = qid - 1000;
+
+    let mut supports = HashMap::new();
+    for (k, &base) in base_ids.iter().enumerate() {
+        let mut s = sup_3d(base, true);
+        if k == 0 {
+            s.dz = Some(-0.006); // prescribed settlement at one base
+            s.drx = Some(0.002);
+        }
+        supports.insert(base.to_string(), s);
+    }
+
+    // sanity for the test author
+    assert_eq!(n_frames, 4);
+    assert_eq!(n_quads, 16);
+
+    SolverInput3D {
+        nodes, materials, sections, elements, supports,
+        loads: vec![],
+        constraints: vec![], left_hand: None,
+        plates: HashMap::new(), quads, quad9s: HashMap::new(),
+        solid_shells: HashMap::new(), curved_shells: HashMap::new(),
+        curved_beams: vec![],
+        connectors: HashMap::new(),
+    }
+}
+
+// ==================== 2D tests ====================
+
+#[test]
+fn parity_2d_dense_multi_case() {
+    let input = MultiCaseInput {
+        solver: make_frame_2d_dense(),
+        load_cases: vec![
+            LoadCase {
+                name: "Dead".to_string(),
+                loads: vec![
+                    SolverLoad::Distributed(SolverDistributedLoad {
+                        element_id: 1, q_i: -5.0, q_j: -5.0, a: None, b: None,
+                    }),
+                    SolverLoad::Distributed(SolverDistributedLoad {
+                        element_id: 2, q_i: -5.0, q_j: -3.0, a: None, b: None,
+                    }),
+                    SolverLoad::Distributed(SolverDistributedLoad {
+                        element_id: 3, q_i: -4.0, q_j: -4.0, a: Some(0.5), b: Some(2.5),
+                    }),
+                ],
+            },
+            LoadCase {
+                name: "Live".to_string(),
+                loads: vec![
+                    SolverLoad::Nodal(SolverNodalLoad { node_id: 2, fx: 0.0, fz: -20.0, my: 0.0 }),
+                    SolverLoad::Nodal(SolverNodalLoad { node_id: 3, fx: 0.0, fz: -10.0, my: 3.0 }),
+                    SolverLoad::PointOnElement(SolverPointLoadOnElement {
+                        element_id: 2, a: 2.0, p: -15.0, px: None, my: None,
+                    }),
+                ],
+            },
+            LoadCase {
+                name: "Thermal".to_string(),
+                loads: vec![
+                    SolverLoad::Thermal(SolverThermalLoad {
+                        element_id: 1, dt_uniform: 15.0, dt_gradient: 8.0,
+                    }),
+                    SolverLoad::Thermal(SolverThermalLoad {
+                        element_id: 3, dt_uniform: -10.0, dt_gradient: 0.0,
+                    }),
+                ],
+            },
+            LoadCase {
+                name: "Wind".to_string(),
+                loads: vec![
+                    SolverLoad::Nodal(SolverNodalLoad { node_id: 3, fx: 8.0, fz: 0.0, my: 0.0 }),
+                ],
+            },
+        ],
+        combinations: vec![
+            CombinationDef {
+                name: "1.2D + 1.6L".to_string(),
+                factors: [("Dead", 1.2), ("Live", 1.6)].iter()
+                    .map(|(n, f)| (n.to_string(), *f)).collect(),
+            },
+            CombinationDef {
+                name: "D + T + W".to_string(),
+                factors: [("Dead", 1.0), ("Thermal", 1.0), ("Wind", 1.0)].iter()
+                    .map(|(n, f)| (n.to_string(), *f)).collect(),
+            },
+        ],
+    };
+
+    let multi = solve_multi_case_2d(&input).unwrap();
+    let (ref_cases, ref_combos) = reference_2d(&input);
+
+    assert_eq!(multi.case_results.len(), ref_cases.len());
+    for (mc, rc) in multi.case_results.iter().zip(&ref_cases) {
+        assert_results_eq(&mc.results, rc, &format!("case '{}'", mc.name));
+    }
+    assert_eq!(multi.combination_results.len(), ref_combos.len());
+    for (mc, (name, rc)) in multi.combination_results.iter().zip(&ref_combos) {
+        assert_eq!(&mc.name, name);
+        assert_results_eq(&mc.results, rc, &format!("combo '{}'", mc.name));
+    }
+}
+
+#[test]
+fn parity_2d_sparse_multi_case() {
+    let input = MultiCaseInput {
+        solver: make_beam_2d_sparse(),
+        load_cases: vec![
+            LoadCase {
+                name: "Dead".to_string(),
+                loads: (1..=30).map(|eid| SolverLoad::Distributed(SolverDistributedLoad {
+                    element_id: eid, q_i: -6.0, q_j: -6.0, a: None, b: None,
+                })).collect(),
+            },
+            LoadCase {
+                name: "Live".to_string(),
+                loads: vec![
+                    SolverLoad::Nodal(SolverNodalLoad { node_id: 8, fx: 0.0, fz: -25.0, my: 0.0 }),
+                    SolverLoad::Nodal(SolverNodalLoad { node_id: 22, fx: 0.0, fz: -25.0, my: 0.0 }),
+                    SolverLoad::PointOnElement(SolverPointLoadOnElement {
+                        element_id: 20, a: 0.25, p: -12.0, px: Some(-2.0), my: None,
+                    }),
+                ],
+            },
+            LoadCase {
+                name: "Thermal".to_string(),
+                loads: vec![
+                    SolverLoad::Thermal(SolverThermalLoad {
+                        element_id: 5, dt_uniform: 20.0, dt_gradient: 12.0,
+                    }),
+                    SolverLoad::Thermal(SolverThermalLoad {
+                        element_id: 25, dt_uniform: 0.0, dt_gradient: -15.0,
+                    }),
+                ],
+            },
+        ],
+        combinations: vec![
+            CombinationDef {
+                name: "1.2D + 1.6L".to_string(),
+                factors: [("Dead", 1.2), ("Live", 1.6)].iter()
+                    .map(|(n, f)| (n.to_string(), *f)).collect(),
+            },
+            CombinationDef {
+                name: "D + T".to_string(),
+                factors: [("Dead", 1.0), ("Thermal", 1.0)].iter()
+                    .map(|(n, f)| (n.to_string(), *f)).collect(),
+            },
+        ],
+    };
+
+    let multi = solve_multi_case_2d(&input).unwrap();
+    // Confirm we are on the sparse path (nf = 89 >= 64)
+    assert_eq!(
+        multi.case_results[0].results.solver_run_meta.as_ref().unwrap().solver_path,
+        "sparse_cholesky",
+        "expected the sparse path for nf >= 64"
+    );
+
+    let (ref_cases, ref_combos) = reference_2d(&input);
+    for (mc, rc) in multi.case_results.iter().zip(&ref_cases) {
+        assert_results_eq(&mc.results, rc, &format!("case '{}'", mc.name));
+    }
+    for (mc, (name, rc)) in multi.combination_results.iter().zip(&ref_combos) {
+        assert_eq!(&mc.name, name);
+        assert_results_eq(&mc.results, rc, &format!("combo '{}'", mc.name));
+    }
+}
+
+// ==================== 3D tests ====================
+
+#[test]
+fn parity_3d_dense_multi_case() {
+    let input = MultiCaseInput3D {
+        solver: make_mixed_3d_dense(),
+        load_cases: vec![
+            LoadCase3D {
+                name: "Gravity".to_string(),
+                loads: vec![
+                    SolverLoad3D::Nodal(SolverNodalLoad3D {
+                        node_id: 1, fx: 0.0, fy: 0.0, fz: -30.0,
+                        mx: 0.0, my: 0.0, mz: 0.0, bw: None,
+                    }),
+                    SolverLoad3D::Distributed(SolverDistributedLoad3D {
+                        element_id: 1, q_yi: -2.0, q_yj: -2.0, q_zi: 0.0, q_zj: 0.0,
+                        a: None, b: None,
+                    }),
+                ],
+            },
+            LoadCase3D {
+                name: "SlabPressure".to_string(),
+                loads: vec![
+                    SolverLoad3D::QuadPressure(SolverPressureLoad { element_id: 1, pressure: -3.0 }),
+                ],
+            },
+            LoadCase3D {
+                name: "Thermal".to_string(),
+                loads: vec![
+                    SolverLoad3D::Thermal(SolverThermalLoad3D {
+                        element_id: 1, dt_uniform: 12.0, dt_gradient_y: 6.0, dt_gradient_z: 0.0,
+                    }),
+                    SolverLoad3D::QuadThermal(SolverPlateThermalLoad {
+                        element_id: 1, dt_uniform: 10.0, dt_gradient: 5.0, alpha: None,
+                    }),
+                ],
+            },
+        ],
+        combinations: vec![
+            CombinationDef {
+                name: "G + P".to_string(),
+                factors: [("Gravity", 1.0), ("SlabPressure", 1.0)].iter()
+                    .map(|(n, f)| (n.to_string(), *f)).collect(),
+            },
+            CombinationDef {
+                name: "1.2G + 1.5P + 0.9T".to_string(),
+                factors: [("Gravity", 1.2), ("SlabPressure", 1.5), ("Thermal", 0.9)].iter()
+                    .map(|(n, f)| (n.to_string(), *f)).collect(),
+            },
+        ],
+    };
+
+    let multi = solve_multi_case_3d(&input).unwrap();
+    assert_eq!(
+        multi.case_results[0].results.solver_run_meta.as_ref().unwrap().solver_path,
+        "dense_lu",
+        "expected the dense path for nf < 64"
+    );
+
+    let (ref_cases, ref_combos) = reference_3d(&input);
+    for (mc, rc) in multi.case_results.iter().zip(&ref_cases) {
+        assert_results_3d_eq(&mc.results, rc, &format!("case '{}'", mc.name));
+    }
+    for (mc, (name, rc)) in multi.combination_results.iter().zip(&ref_combos) {
+        assert_eq!(&mc.name, name);
+        assert_results_3d_eq(&mc.results, rc, &format!("combo '{}'", mc.name));
+    }
+}
+
+#[test]
+fn parity_3d_sparse_multi_case() {
+    let input = MultiCaseInput3D {
+        solver: make_frame_slab_3d_sparse(),
+        load_cases: vec![
+            LoadCase3D {
+                name: "Gravity".to_string(),
+                loads: vec![
+                    SolverLoad3D::Nodal(SolverNodalLoad3D {
+                        node_id: 13, fx: 0.0, fy: 0.0, fz: -40.0,
+                        mx: 0.0, my: 0.0, mz: 0.0, bw: None,
+                    }),
+                    SolverLoad3D::Distributed(SolverDistributedLoad3D {
+                        element_id: 1, q_yi: -3.0, q_yj: -3.0, q_zi: 0.0, q_zj: 0.0,
+                        a: None, b: None,
+                    }),
+                    SolverLoad3D::Distributed(SolverDistributedLoad3D {
+                        element_id: 3, q_yi: 0.0, q_yj: 0.0, q_zi: -1.5, q_zj: -2.5,
+                        a: Some(0.5), b: Some(2.0),
+                    }),
+                ],
+            },
+            LoadCase3D {
+                name: "SlabPressure".to_string(),
+                loads: (1000..1016).map(|qid| SolverLoad3D::QuadPressure(
+                    SolverPressureLoad { element_id: qid, pressure: -2.5 },
+                )).collect(),
+            },
+            LoadCase3D {
+                name: "Thermal".to_string(),
+                loads: vec![
+                    SolverLoad3D::Thermal(SolverThermalLoad3D {
+                        element_id: 2, dt_uniform: 18.0, dt_gradient_y: 4.0, dt_gradient_z: -3.0,
+                    }),
+                    SolverLoad3D::QuadThermal(SolverPlateThermalLoad {
+                        element_id: 1006, dt_uniform: 15.0, dt_gradient: 6.0, alpha: None,
+                    }),
+                ],
+            },
+            LoadCase3D {
+                name: "Wind".to_string(),
+                loads: vec![
+                    SolverLoad3D::Nodal(SolverNodalLoad3D {
+                        node_id: 5, fx: 12.0, fy: 0.0, fz: 0.0,
+                        mx: 0.0, my: 0.0, mz: 0.0, bw: None,
+                    }),
+                    SolverLoad3D::PointOnElement(SolverPointLoad3D {
+                        element_id: 4, a: 1.5, py: 8.0, pz: 0.0,
+                    }),
+                ],
+            },
+        ],
+        combinations: vec![
+            CombinationDef {
+                name: "1.2G + 1.6P".to_string(),
+                factors: [("Gravity", 1.2), ("SlabPressure", 1.6)].iter()
+                    .map(|(n, f)| (n.to_string(), *f)).collect(),
+            },
+            CombinationDef {
+                name: "G + P + T + W".to_string(),
+                factors: [("Gravity", 1.0), ("SlabPressure", 1.0), ("Thermal", 1.0), ("Wind", 1.0)].iter()
+                    .map(|(n, f)| (n.to_string(), *f)).collect(),
+            },
+        ],
+    };
+
+    let multi = solve_multi_case_3d(&input).unwrap();
+    assert_eq!(
+        multi.case_results[0].results.solver_run_meta.as_ref().unwrap().solver_path,
+        "sparse_cholesky",
+        "expected the sparse path for nf >= 64"
+    );
+
+    let (ref_cases, ref_combos) = reference_3d(&input);
+    for (mc, rc) in multi.case_results.iter().zip(&ref_cases) {
+        assert_results_3d_eq(&mc.results, rc, &format!("case '{}'", mc.name));
+    }
+    for (mc, (name, rc)) in multi.combination_results.iter().zip(&ref_combos) {
+        assert_eq!(&mc.name, name);
+        assert_results_3d_eq(&mc.results, rc, &format!("combo '{}'", mc.name));
+    }
+}
+
+// ==================== Single-case ≡ single solve ====================
+
+#[test]
+fn single_case_2d_matches_single_solve() {
+    let solver = make_frame_2d_dense();
+    let loads = vec![
+        SolverLoad::Distributed(SolverDistributedLoad {
+            element_id: 2, q_i: -7.0, q_j: -5.0, a: None, b: None,
+        }),
+        SolverLoad::Nodal(SolverNodalLoad { node_id: 3, fx: 0.0, fz: -15.0, my: 2.0 }),
+    ];
+
+    let mut case_input = solver.clone();
+    case_input.loads = loads.clone();
+    let direct = solve_2d(&case_input).unwrap();
+
+    let input = MultiCaseInput {
+        solver,
+        load_cases: vec![LoadCase { name: "Only".to_string(), loads }],
+        combinations: vec![CombinationDef {
+            name: "1.0 Only".to_string(),
+            factors: [("Only".to_string(), 1.0)].into_iter().collect(),
+        }],
+    };
+    let multi = solve_multi_case_2d(&input).unwrap();
+
+    assert_eq!(multi.case_results.len(), 1);
+    assert_results_eq(&multi.case_results[0].results, &direct, "single case");
+}
+
+#[test]
+fn single_case_3d_matches_single_solve() {
+    let solver = make_frame_slab_3d_sparse();
+    let loads = vec![
+        SolverLoad3D::QuadPressure(SolverPressureLoad { element_id: 1003, pressure: -4.0 }),
+        SolverLoad3D::Nodal(SolverNodalLoad3D {
+            node_id: 7, fx: 0.0, fy: 5.0, fz: -10.0,
+            mx: 0.0, my: 0.0, mz: 0.0, bw: None,
+        }),
+    ];
+
+    let mut case_input = solver.clone();
+    case_input.loads = loads.clone();
+    let direct = solve_3d(&case_input).unwrap();
+
+    let input = MultiCaseInput3D {
+        solver,
+        load_cases: vec![LoadCase3D { name: "Only".to_string(), loads }],
+        combinations: vec![CombinationDef {
+            name: "1.0 Only".to_string(),
+            factors: [("Only".to_string(), 1.0)].into_iter().collect(),
+        }],
+    };
+    let multi = solve_multi_case_3d(&input).unwrap();
+
+    assert_eq!(multi.case_results.len(), 1);
+    assert_results_3d_eq(&multi.case_results[0].results, &direct, "single case 3d");
+}


### PR DESCRIPTION
solve_multi_case_2d/3d ran a full solve_* per load case (assembly + validation + factorization each) even though K is identical across cases — only the load vector changes. At 4/16 cases on a 3D frame (nf=240) the naive loop costs 3.9/16.1ms vs 1.6/2.8ms now (2.4x/5.8x, bench multi_case), and the waste grows linearly with case count.

- linear.rs: split solve_2d/solve_3d into prepare_static_* (DOF numbering, validation, stiffness-only assembly, block extraction with K_fr*u_r, conditioning, one factorization — dense Cholesky / sparse symbolic+numeric with the diagonal-shift regularization retry / LU fallback) and solve_loads(&loads) (validate case loads, rebuild only the load vector, apply prescribed-displacement RHS correction per case, triangular solve with the stored factor, identical postprocess). Public API unchanged.
- assembly.rs / sparse_assembly.rs: split each fused assembler into a K part
  + a load-vector builder (thin composition preserves bit-identical outputs); inclined transforms split into K-rotation and f-rotation helpers.
- lu.rs: lu_solve = lu_factor + lu_apply.
- load_cases.rs: prepare once, solve_loads per case; drop per-case model clones and per-combination results.clone() (new combine_results*_refs). 3D with constraints keeps the legacy per-case path.
- tests/integration/multi_case_parity.rs: exact == parity (every f64 of displacements/reactions/element forces/quad stresses) vs N full solves, dense+sparse x 2D+3D, thermal/prescribed/point loads; 1-case == single solve. Full suite green (5925 passed); clippy clean; parallel-feature lib tests green.