### PR TITLE
perf(engine): reuse one factorization for moving loads and influence …

### DIFF
--- a/engine/benches/solver_bench.rs
+++ b/engine/benches/solver_bench.rs
@@ -1238,6 +1238,107 @@ fn bench_multi_case(c: &mut Criterion) {
     group.finish();
 }
 
+// ─── Moving loads / influence line factorization reuse ─────
+
+fn bench_moving_influence_reuse(c: &mut Criterion) {
+    use dedaliano_engine::postprocess::influence::{
+        compute_influence_line, influence_unit_loads_2d, InfluenceLineInput,
+    };
+    use dedaliano_engine::solver::moving_loads::{build_load_path, moving_loads_at_position_2d};
+
+    let mut group = c.benchmark_group("moving_influence_reuse");
+    group.sample_size(20);
+
+    let train = LoadTrain {
+        name: "HL93".to_string(),
+        axles: vec![
+            Axle { offset: 0.0, weight: 35.0 },
+            Axle { offset: 4.3, weight: 145.0 },
+            Axle { offset: 8.6, weight: 145.0 },
+        ],
+    };
+    let step = 0.25;
+
+    // Moving loads 2D: n=16 → dense path (nf=48), n=64 → sparse path (nf=192)
+    for n in [16usize, 64] {
+        let solver = make_ss_beam(n);
+        let path = build_load_path(&solver, None).unwrap();
+        let total_length: f64 = path.iter().map(|s| s.length).sum();
+        let max_offset: f64 = train.axles.iter().map(|a| a.offset).fold(0.0, f64::max);
+
+        // Legacy: clone + full solve per position
+        group.bench_with_input(BenchmarkId::new("moving_2d_legacy", n), &solver, |b, solver| {
+            b.iter(|| {
+                let mut pos = -max_offset;
+                while pos <= total_length + 1e-10 {
+                    let loads = moving_loads_at_position_2d(solver, &train, &path, pos, total_length);
+                    let mut mi = solver.clone();
+                    mi.loads = loads;
+                    criterion::black_box(linear::solve_2d(&mi).unwrap());
+                    pos += step;
+                }
+            });
+        });
+
+        // Prepared: production path (prepare once + solve_loads per position)
+        let input = MovingLoadInput {
+            solver,
+            train: train.clone(),
+            step: Some(step),
+            path_element_ids: None,
+        };
+        group.bench_with_input(BenchmarkId::new("moving_2d_prepared", n), &input, |b, input| {
+            b.iter(|| moving_loads::solve_moving_loads_2d(input).unwrap());
+        });
+    }
+
+    // Influence line 2D: unit load at 11 points on each of n elements
+    let n_pts = 10usize;
+    for n in [16usize, 64] {
+        let solver = make_ss_beam(n);
+        let node_pos: HashMap<usize, (f64, f64)> =
+            solver.nodes.values().map(|nd| (nd.id, (nd.x, nd.z))).collect();
+
+        // Legacy: full solve per sampled point
+        group.bench_with_input(BenchmarkId::new("influence_2d_legacy", n), &solver, |b, solver| {
+            b.iter(|| {
+                let base = SolverInput { loads: vec![], ..solver.clone() };
+                for elem in solver.elements.values() {
+                    let (nix, niy) = node_pos[&elem.node_i];
+                    let (njx, njy) = node_pos[&elem.node_j];
+                    let dx = njx - nix;
+                    let dy = njy - niy;
+                    let l = (dx * dx + dy * dy).sqrt();
+                    let cos_theta = dx / l;
+                    let sin_theta = dy / l;
+                    for k in 0..=n_pts {
+                        let t = k as f64 / n_pts as f64;
+                        let loads = influence_unit_loads_2d(elem, t * l, t, cos_theta, sin_theta);
+                        let mut trial = base.clone();
+                        trial.loads = loads;
+                        criterion::black_box(linear::solve_2d(&trial).unwrap());
+                    }
+                }
+            });
+        });
+
+        // Prepared: production path
+        let input = InfluenceLineInput {
+            solver,
+            quantity: "M".to_string(),
+            target_node_id: None,
+            target_element_id: Some(1),
+            target_position: 0.5,
+            n_points_per_element: n_pts,
+        };
+        group.bench_with_input(BenchmarkId::new("influence_2d_prepared", n), &input, |b, input| {
+            b.iter(|| compute_influence_line(input).unwrap());
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_json_roundtrip,
@@ -1253,6 +1354,7 @@ criterion_group!(
     bench_modal_3d,
     bench_pdelta_3d,
     bench_multi_case,
+    bench_moving_influence_reuse,
     bench_moving_loads,
     bench_cable,
     bench_constraints,

--- a/engine/src/postprocess/influence.rs
+++ b/engine/src/postprocess/influence.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::solver::linear::{solve_2d, solve_3d};
+use crate::solver::linear::{prepare_static_2d, prepare_static_3d};
 use crate::postprocess::diagrams::compute_diagram_value_at;
 use crate::postprocess::diagrams_3d::evaluate_diagram_3d_at;
 use crate::element::compute_local_axes_3d;
@@ -49,6 +49,14 @@ fn default_n_points() -> usize { 20 }
 // ==================== Influence Line Computation ====================
 
 /// Compute influence line: move unit load P=1 (downward) across all elements.
+///
+/// The structure is prepared once (`prepare_static_2d`: assembly +
+/// factorization) and each sampled point reuses the factorization with a
+/// rebuilt unit-load vector.
+///
+/// Follow-up: a Müller-Breslau / adjoint formulation would need only one
+/// triangular solve per target quantity (nodal load at the target DOF) with
+/// ordinates read from K⁻¹-columns instead of one solve per sampled point.
 pub fn compute_influence_line(input: &InfluenceLineInput) -> Result<InfluenceLineResult, String> {
     if input.solver.nodes.len() < 2 {
         return Err("Need at least 2 nodes".into());
@@ -71,6 +79,10 @@ pub fn compute_influence_line(input: &InfluenceLineInput) -> Result<InfluenceLin
         constraints: vec![],
         connectors: HashMap::new(),
     };
+
+    // Prepare once; per-point failures (or a prepare failure) yield 0.0
+    // ordinates, exactly like the previous per-point full solves.
+    let prepared = prepare_static_2d(&base).ok();
 
     // Pre-compute node positions
     let node_pos: HashMap<usize, (f64, f64)> = input.solver.nodes.values()
@@ -96,49 +108,13 @@ pub fn compute_influence_line(input: &InfluenceLineInput) -> Result<InfluenceLin
             let wx = nix + t * dx;
             let wy = niy + t * dy;
 
-            // Unit load P=1 downward → perpendicular component
-            let p_perp = -cos_theta;
-            let p_axial = -sin_theta;
+            let loads = influence_unit_loads_2d(elem, a, t, cos_theta, sin_theta);
 
-            let mut loads: Vec<SolverLoad> = Vec::new();
-
-            if p_perp.abs() > 1e-10 {
-                loads.push(SolverLoad::PointOnElement(SolverPointLoadOnElement {
-                    element_id: elem.id,
-                    a,
-                    p: p_perp,
-                    px: None,
-                    my: None,
-                }));
-            }
-
-            if p_axial.abs() > 1e-10 {
-                let fi = p_axial * (1.0 - t);
-                let fj = p_axial * t;
-                loads.push(SolverLoad::Nodal(SolverNodalLoad {
-                    node_id: elem.node_i,
-                    fx: fi * cos_theta,
-                    fz: fi * sin_theta,
-                    my: 0.0,
-                }));
-                loads.push(SolverLoad::Nodal(SolverNodalLoad {
-                    node_id: elem.node_j,
-                    fx: fj * cos_theta,
-                    fz: fj * sin_theta,
-                    my: 0.0,
-                }));
-            }
-
-            let trial_input = SolverInput {
-                loads,
-                ..base.clone()
-            };
-
-            let value = match solve_2d(&trial_input) {
-                Ok(result) => {
+            let value = match prepared.as_ref().and_then(|p| p.solve_loads(&loads).ok()) {
+                Some(result) => {
                     extract_value(&input.quantity, input.target_node_id, input.target_element_id, input.target_position, &result)
                 }
-                Err(_) => 0.0,
+                None => 0.0,
             };
 
             points.push(InfluenceLinePoint {
@@ -160,7 +136,52 @@ pub fn compute_influence_line(input: &InfluenceLineInput) -> Result<InfluenceLin
     })
 }
 
-fn extract_value(
+/// Unit-load set at position `a = t·l` on a 2D element: perpendicular point
+/// load plus axial components as nodal loads at both element ends.
+pub fn influence_unit_loads_2d(
+    elem: &SolverElement,
+    a: f64,
+    t: f64,
+    cos_theta: f64,
+    sin_theta: f64,
+) -> Vec<SolverLoad> {
+    // Unit load P=1 downward → perpendicular component
+    let p_perp = -cos_theta;
+    let p_axial = -sin_theta;
+
+    let mut loads: Vec<SolverLoad> = Vec::new();
+
+    if p_perp.abs() > 1e-10 {
+        loads.push(SolverLoad::PointOnElement(SolverPointLoadOnElement {
+            element_id: elem.id,
+            a,
+            p: p_perp,
+            px: None,
+            my: None,
+        }));
+    }
+
+    if p_axial.abs() > 1e-10 {
+        let fi = p_axial * (1.0 - t);
+        let fj = p_axial * t;
+        loads.push(SolverLoad::Nodal(SolverNodalLoad {
+            node_id: elem.node_i,
+            fx: fi * cos_theta,
+            fz: fi * sin_theta,
+            my: 0.0,
+        }));
+        loads.push(SolverLoad::Nodal(SolverNodalLoad {
+            node_id: elem.node_j,
+            fx: fj * cos_theta,
+            fz: fj * sin_theta,
+            my: 0.0,
+        }));
+    }
+
+    loads
+}
+
+pub fn extract_value(
     quantity: &str,
     target_node_id: Option<usize>,
     target_element_id: Option<usize>,
@@ -244,6 +265,12 @@ pub struct InfluenceLineInput3D {
 }
 
 /// Compute 3D influence line: move unit gravity load P=1 across all frame elements.
+///
+/// The structure is prepared once (`prepare_static_3d`: curved-beam expansion,
+/// assembly, factorization) and each sampled point reuses the factorization
+/// with a rebuilt unit-load vector. Same follow-up as the 2D variant: a
+/// Müller-Breslau / adjoint formulation would need one solve per target
+/// quantity instead of one per sampled point.
 pub fn compute_influence_line_3d(input: &InfluenceLineInput3D) -> Result<InfluenceLineResult3D, String> {
     if input.solver.nodes.len() < 2 {
         return Err("Need at least 2 nodes".into());
@@ -277,6 +304,10 @@ pub fn compute_influence_line_3d(input: &InfluenceLineInput3D) -> Result<Influen
         curved_beams: input.solver.curved_beams.clone(),
         connectors: HashMap::new(),
     };
+
+    // Prepare once; per-point failures (or a prepare failure) yield 0.0
+    // ordinates, exactly like the previous per-point full solves.
+    let prepared = prepare_static_3d(&base).ok();
 
     let node_pos: HashMap<usize, (f64, f64, f64)> = input.solver.nodes.values()
         .map(|n| (n.id, (n.x, n.y, n.z)))
@@ -316,32 +347,17 @@ pub fn compute_influence_line_3d(input: &InfluenceLineInput3D) -> Result<Influen
             let wy = niy + t * dy;
             let wz = niz + t * dz;
 
-            let mut loads: Vec<SolverLoad3D> = Vec::new();
+            let loads = influence_unit_loads_3d(elem.id, a, g_local_y, g_local_z);
 
-            // Apply unit load as point-on-element in local Y/Z
-            if g_local_y.abs() > 1e-10 || g_local_z.abs() > 1e-10 {
-                loads.push(SolverLoad3D::PointOnElement(SolverPointLoad3D {
-                    element_id: elem.id,
-                    a,
-                    py: g_local_y,
-                    pz: g_local_z,
-                }));
-            }
-
-            let trial_input = SolverInput3D {
-                loads,
-                ..base.clone()
-            };
-
-            let value = match solve_3d(&trial_input) {
-                Ok(result) => extract_value_3d(
+            let value = match prepared.as_ref().and_then(|p| p.solve_loads(&loads).ok()) {
+                Some(result) => extract_value_3d(
                     &input.quantity,
                     input.target_node_id,
                     input.target_element_id,
                     input.target_position,
                     &result,
                 ),
-                Err(_) => 0.0,
+                None => 0.0,
             };
 
             points.push(InfluenceLinePoint3D {
@@ -364,7 +380,22 @@ pub fn compute_influence_line_3d(input: &InfluenceLineInput3D) -> Result<Influen
     })
 }
 
-fn extract_value_3d(
+/// Unit gravity load at position `a` on a 3D element, already projected into
+/// local Y/Z components.
+pub fn influence_unit_loads_3d(elem_id: usize, a: f64, g_local_y: f64, g_local_z: f64) -> Vec<SolverLoad3D> {
+    let mut loads: Vec<SolverLoad3D> = Vec::new();
+    if g_local_y.abs() > 1e-10 || g_local_z.abs() > 1e-10 {
+        loads.push(SolverLoad3D::PointOnElement(SolverPointLoad3D {
+            element_id: elem_id,
+            a,
+            py: g_local_y,
+            pz: g_local_z,
+        }));
+    }
+    loads
+}
+
+pub fn extract_value_3d(
     quantity: &str,
     target_node_id: Option<usize>,
     target_element_id: Option<usize>,

--- a/engine/src/solver/moving_loads.rs
+++ b/engine/src/solver/moving_loads.rs
@@ -1,4 +1,5 @@
 use crate::types::*;
+use crate::solver::linear::{prepare_static_2d, prepare_static_3d, solve_2d, solve_3d};
 use std::collections::HashMap;
 
 /// Moving loads analysis result.
@@ -64,59 +65,36 @@ pub fn solve_moving_loads_2d(input: &MovingLoadInput) -> Result<MovingLoadEnvelo
     let mut pos = start_pos;
     let mut num_positions = 0;
 
+    // Prepare the structure once (assembly + factorization of K); each
+    // position then reuses the factorization, rebuilding only its load vector.
+    // Models with constraints keep the legacy per-position full solve (the
+    // constrained solver handles each position's loads itself).
+    let prep_input = if solver_input.constraints.is_empty() {
+        let mut pi = solver_input.clone();
+        pi.loads = vec![];
+        Some(pi)
+    } else {
+        None
+    };
+    let prepared = prep_input.as_ref().and_then(|pi| prepare_static_2d(pi).ok());
+
     while pos <= end_pos + 1e-10 {
         num_positions += 1;
 
         // Build loads for this position
-        let mut loads = base_loads(solver_input);
-
-        for axle in &train.axles {
-            let axle_pos = pos + axle.offset;
-            if axle_pos < -1e-10 || axle_pos > total_length + 1e-10 {
-                continue;
-            }
-
-            // Find which segment this axle is on
-            if let Some((seg, local_pos)) = find_segment(&path, axle_pos) {
-                // Decompose weight into perpendicular component (point on element)
-                // and axial component (nodal load in element direction)
-                let perp_force = -axle.weight; // Downward force
-
-                // Add as point load on element in local Y direction
-                loads.push(SolverLoad::PointOnElement(SolverPointLoadOnElement {
-                    element_id: seg.element_id,
-                    a: local_pos,
-                    p: perp_force * seg.cos.powi(2).max(0.0).sqrt().copysign(1.0),
-                    px: None,
-                    my: None,
-                }));
-
-                // For vertical loads on non-horizontal members, add axial component as well
-                // Simplified: project downward force onto element axes
-                if seg.sin.abs() > 1e-6 {
-                    // Perpendicular component (transverse to element)
-                    let p_perp = -axle.weight * seg.cos;
-                    // Axial component
-                    let p_axial = -axle.weight * seg.sin;
-
-                    // Replace the simple load with proper decomposition
-                    loads.pop(); // Remove the one we just added
-                    loads.push(SolverLoad::PointOnElement(SolverPointLoadOnElement {
-                        element_id: seg.element_id,
-                        a: local_pos,
-                        p: p_perp,
-                        px: Some(p_axial),
-                        my: None,
-                    }));
-                }
-            }
-        }
+        let loads = moving_loads_at_position_2d(solver_input, train, &path, pos, total_length);
 
         // Solve with these loads
-        let mut modified_input = solver_input.clone();
-        modified_input.loads = loads;
+        let results = match &prepared {
+            Some(p) => p.solve_loads(&loads).ok(),
+            None => {
+                let mut modified_input = solver_input.clone();
+                modified_input.loads = loads;
+                solve_2d(&modified_input).ok()
+            }
+        };
 
-        if let Ok(results) = super::linear::solve_2d(&modified_input) {
+        if let Some(results) = results {
             // Update envelopes
             for ef in &results.element_forces {
                 if let Some(env) = envelopes.get_mut(&ef.element_id.to_string()) {
@@ -148,7 +126,64 @@ pub fn solve_moving_loads_2d(input: &MovingLoadInput) -> Result<MovingLoadEnvelo
     })
 }
 
-fn build_load_path(
+/// Build the load set for one train position: permanent loads (nodal,
+/// distributed, thermal) plus the equivalent point loads of every axle
+/// currently on the path.
+pub fn moving_loads_at_position_2d(
+    solver_input: &SolverInput,
+    train: &LoadTrain,
+    path: &[PathSegment],
+    pos: f64,
+    total_length: f64,
+) -> Vec<SolverLoad> {
+    let mut loads = base_loads(solver_input);
+
+    for axle in &train.axles {
+        let axle_pos = pos + axle.offset;
+        if axle_pos < -1e-10 || axle_pos > total_length + 1e-10 {
+            continue;
+        }
+
+        // Find which segment this axle is on
+        if let Some((seg, local_pos)) = find_segment(path, axle_pos) {
+            // Decompose weight into perpendicular component (point on element)
+            // and axial component (nodal load in element direction)
+            let perp_force = -axle.weight; // Downward force
+
+            // Add as point load on element in local Y direction
+            loads.push(SolverLoad::PointOnElement(SolverPointLoadOnElement {
+                element_id: seg.element_id,
+                a: local_pos,
+                p: perp_force * seg.cos.powi(2).max(0.0).sqrt().copysign(1.0),
+                px: None,
+                my: None,
+            }));
+
+            // For vertical loads on non-horizontal members, add axial component as well
+            // Simplified: project downward force onto element axes
+            if seg.sin.abs() > 1e-6 {
+                // Perpendicular component (transverse to element)
+                let p_perp = -axle.weight * seg.cos;
+                // Axial component
+                let p_axial = -axle.weight * seg.sin;
+
+                // Replace the simple load with proper decomposition
+                loads.pop(); // Remove the one we just added
+                loads.push(SolverLoad::PointOnElement(SolverPointLoadOnElement {
+                    element_id: seg.element_id,
+                    a: local_pos,
+                    p: p_perp,
+                    px: Some(p_axial),
+                    my: None,
+                }));
+            }
+        }
+    }
+
+    loads
+}
+
+pub fn build_load_path(
     input: &SolverInput,
     path_element_ids: Option<&[usize]>,
 ) -> Result<Vec<PathSegment>, String> {
@@ -297,69 +332,40 @@ pub fn solve_moving_loads_3d(input: &MovingLoadInput3D) -> Result<MovingLoadEnve
         });
     }
 
-    // Build lookup maps to avoid O(n) linear scans per element
-    let node_by_id: HashMap<usize, &SolverNode3D> = solver_input.nodes.values().map(|n| (n.id, n)).collect();
-    let elem_by_id: HashMap<usize, &SolverElement3D> = solver_input.elements.values().map(|e| (e.id, e)).collect();
-
     let start_pos = -max_offset;
     let end_pos = total_length;
     let mut pos = start_pos;
     let mut num_positions = 0;
 
+    // Prepare the structure once (assembly + factorization of K); each
+    // position then reuses the factorization, rebuilding only its load vector.
+    // Models with constraints keep the legacy per-position full solve.
+    let prep_input = if solver_input.constraints.is_empty() {
+        let mut pi = solver_input.clone();
+        pi.loads = vec![];
+        Some(pi)
+    } else {
+        None
+    };
+    let prepared = prep_input.as_ref().and_then(|pi| prepare_static_3d(pi).ok());
+
     while pos <= end_pos + 1e-10 {
         num_positions += 1;
 
         // Build loads for this position
-        let mut loads = base_loads_3d(solver_input);
-
-        for axle in &train.axles {
-            let axle_pos = pos + axle.offset;
-            if axle_pos < -1e-10 || axle_pos > total_length + 1e-10 {
-                continue;
-            }
-
-            if let Some((seg, local_pos)) = find_segment_3d(&path, axle_pos) {
-                // Gravity vector in global coordinates
-                let (gx, gy, gz) = match gravity {
-                    "y" => (0.0, -axle.weight, 0.0),
-                    _ => (0.0, 0.0, -axle.weight), // "z" default
-                };
-
-                // Element direction vector (local x-axis in global frame)
-                let _ex = [seg.dir_x, seg.dir_y, seg.dir_z];
-
-                // Compute the element's local axes using the same function as the solver
-                if let Some(&elem) = elem_by_id.get(&seg.element_id) {
-                    let ni = node_by_id[&elem.node_i];
-                    let nj = node_by_id[&elem.node_j];
-                    let left_hand = solver_input.left_hand.unwrap_or(false);
-                    let (_lex, ley, lez) = crate::element::compute_local_axes_3d(
-                        ni.x, ni.y, ni.z, nj.x, nj.y, nj.z,
-                        elem.local_yx, elem.local_yy, elem.local_yz,
-                        elem.roll_angle, left_hand,
-                    );
-
-                    // Project gravity force onto local axes
-                    // py = gravity · local_y, pz = gravity · local_z
-                    let py = gx * ley[0] + gy * ley[1] + gz * ley[2];
-                    let pz = gx * lez[0] + gy * lez[1] + gz * lez[2];
-
-                    // Apply as point-on-element load (proper FEF treatment)
-                    loads.push(SolverLoad3D::PointOnElement(SolverPointLoad3D {
-                        element_id: seg.element_id,
-                        a: local_pos,
-                        py,
-                        pz,
-                    }));
-                }
-            }
-        }
+        let loads = moving_loads_at_position_3d(solver_input, train, gravity, &path, pos, total_length);
 
         // Solve with these loads
-        let mut modified_input = solver_input.clone();
-        modified_input.loads = loads;
+        let results = match &prepared {
+            Some(p) => p.solve_loads(&loads).ok(),
+            None => {
+                let mut modified_input = solver_input.clone();
+                modified_input.loads = loads;
+                solve_3d(&modified_input).ok()
+            }
+        };
 
-        if let Ok(results) = super::linear::solve_3d(&modified_input) {
+        if let Some(results) = results {
             for ef in &results.element_forces {
                 if let Some(env) = envelopes.get_mut(&ef.element_id.to_string()) {
                     env.n_max_pos = env.n_max_pos.max(ef.n_start.max(ef.n_end));
@@ -389,7 +395,67 @@ pub fn solve_moving_loads_3d(input: &MovingLoadInput3D) -> Result<MovingLoadEnve
     })
 }
 
-fn build_load_path_3d(
+/// Build the load set for one train position in 3D: permanent loads plus the
+/// axle weights projected onto each path element's local axes as
+/// point-on-element loads.
+pub fn moving_loads_at_position_3d(
+    solver_input: &SolverInput3D,
+    train: &LoadTrain,
+    gravity: &str,
+    path: &[PathSegment3D],
+    pos: f64,
+    total_length: f64,
+) -> Vec<SolverLoad3D> {
+    let mut loads = base_loads_3d(solver_input);
+
+    // Lookup maps for local-axis projection
+    let node_by_id: HashMap<usize, &SolverNode3D> = solver_input.nodes.values().map(|n| (n.id, n)).collect();
+    let elem_by_id: HashMap<usize, &SolverElement3D> = solver_input.elements.values().map(|e| (e.id, e)).collect();
+
+    for axle in &train.axles {
+        let axle_pos = pos + axle.offset;
+        if axle_pos < -1e-10 || axle_pos > total_length + 1e-10 {
+            continue;
+        }
+
+        if let Some((seg, local_pos)) = find_segment_3d(path, axle_pos) {
+            // Gravity vector in global coordinates
+            let (gx, gy, gz) = match gravity {
+                "y" => (0.0, -axle.weight, 0.0),
+                _ => (0.0, 0.0, -axle.weight), // "z" default
+            };
+
+            // Compute the element's local axes using the same function as the solver
+            if let Some(&elem) = elem_by_id.get(&seg.element_id) {
+                let ni = node_by_id[&elem.node_i];
+                let nj = node_by_id[&elem.node_j];
+                let left_hand = solver_input.left_hand.unwrap_or(false);
+                let (_lex, ley, lez) = crate::element::compute_local_axes_3d(
+                    ni.x, ni.y, ni.z, nj.x, nj.y, nj.z,
+                    elem.local_yx, elem.local_yy, elem.local_yz,
+                    elem.roll_angle, left_hand,
+                );
+
+                // Project gravity force onto local axes
+                // py = gravity · local_y, pz = gravity · local_z
+                let py = gx * ley[0] + gy * ley[1] + gz * ley[2];
+                let pz = gx * lez[0] + gy * lez[1] + gz * lez[2];
+
+                // Apply as point-on-element load (proper FEF treatment)
+                loads.push(SolverLoad3D::PointOnElement(SolverPointLoad3D {
+                    element_id: seg.element_id,
+                    a: local_pos,
+                    py,
+                    pz,
+                }));
+            }
+        }
+    }
+
+    loads
+}
+
+pub fn build_load_path_3d(
     input: &SolverInput3D,
     path_element_ids: Option<&[usize]>,
 ) -> Result<Vec<PathSegment3D>, String> {

--- a/engine/tests/integration/main.rs
+++ b/engine/tests/integration/main.rs
@@ -14,6 +14,7 @@ mod harmonic;
 mod influence_3d;
 mod load_cases;
 mod multi_case_parity;
+mod moving_influence_parity;
 mod masonry_check;
 mod material_nonlinear_3d;
 mod moving_loads_3d;

--- a/engine/tests/integration/moving_influence_parity.rs
+++ b/engine/tests/integration/moving_influence_parity.rs
@@ -1,0 +1,452 @@
+/// Bit-for-bit parity tests for the prepared (factorization-reuse) moving-load
+/// and influence-line paths.
+///
+/// Production code now prepares the structure once (`prepare_static_2d/3d`)
+/// and reuses the factorization per train position / sampled unit load. The
+/// legacy reference below runs one full `solve_2d`/`solve_3d` per position or
+/// point, over exactly the same load sets (built with the same public
+/// helpers). All f64 comparisons are exact (`==`).
+
+use dedaliano_engine::postprocess::influence::*;
+use dedaliano_engine::solver::linear::{solve_2d, solve_3d};
+use dedaliano_engine::solver::moving_loads::*;
+use dedaliano_engine::types::*;
+use std::collections::HashMap;
+
+fn assert_f64_eq(a: f64, b: f64, what: &str) {
+    assert!(a == b, "mismatch at {}: {} vs {} (diff {:e})", what, a, b, (a - b).abs());
+}
+
+// ==================== Model builders ====================
+
+fn sup_2d(id: usize, node_id: usize, kind: &str) -> SolverSupport {
+    SolverSupport {
+        id, node_id, support_type: kind.to_string(),
+        kx: None, ky: None, kz: None, dx: None, dz: None, dry: None, angle: None,
+    }
+}
+
+/// 2D three-element beam, last element inclined, with a permanent distributed
+/// load (exercises base-load carry-over in moving loads).
+fn make_beam_2d_inclined() -> SolverInput {
+    let mut nodes = HashMap::new();
+    nodes.insert("1".to_string(), SolverNode { id: 1, x: 0.0, z: 0.0 });
+    nodes.insert("2".to_string(), SolverNode { id: 2, x: 4.0, z: 0.0 });
+    nodes.insert("3".to_string(), SolverNode { id: 3, x: 8.0, z: 0.0 });
+    nodes.insert("4".to_string(), SolverNode { id: 4, x: 12.0, z: 3.0 });
+
+    let mut materials = HashMap::new();
+    materials.insert("1".to_string(), SolverMaterial { id: 1, e: 200e6, nu: 0.3 });
+
+    let mut sections = HashMap::new();
+    sections.insert("1".to_string(), SolverSection { id: 1, a: 0.05, iz: 1.0e-4, as_y: None });
+
+    let mut elements = HashMap::new();
+    for (id, ni, nj) in [(1, 1, 2), (2, 2, 3), (3, 3, 4)] {
+        elements.insert(id.to_string(), SolverElement {
+            id, elem_type: "frame".to_string(),
+            node_i: ni, node_j: nj,
+            material_id: 1, section_id: 1,
+            hinge_start: false, hinge_end: false,
+        });
+    }
+
+    let mut supports = HashMap::new();
+    supports.insert("1".to_string(), sup_2d(1, 1, "pinned"));
+    supports.insert("2".to_string(), sup_2d(2, 2, "rollerX"));
+    supports.insert("3".to_string(), sup_2d(3, 4, "rollerX"));
+
+    let loads = vec![
+        SolverLoad::Distributed(SolverDistributedLoad {
+            element_id: 1, q_i: -2.0, q_j: -2.0, a: None, b: None,
+        }),
+        SolverLoad::Thermal(SolverThermalLoad { element_id: 2, dt_uniform: 5.0, dt_gradient: 0.0 }),
+    ];
+
+    SolverInput {
+        nodes, materials, sections, elements, supports,
+        loads, constraints: vec![], connectors: HashMap::new(),
+    }
+}
+
+fn sup_3d(node_id: usize, rx: bool, ry: bool, rz: bool, rrx: bool, rry: bool, rrz: bool) -> SolverSupport3D {
+    SolverSupport3D {
+        node_id, rx, ry, rz, rrx, rry, rrz,
+        kx: None, ky: None, kz: None,
+        krx: None, kry: None, krz: None,
+        dx: None, dy: None, dz: None,
+        drx: None, dry: None, drz: None,
+        rw: None, kw: None,
+        normal_x: None, normal_y: None, normal_z: None,
+        is_inclined: None,
+    }
+}
+
+/// 3D three-element beam along X, last element inclined up in Z.
+fn make_beam_3d_inclined() -> SolverInput3D {
+    let mut nodes = HashMap::new();
+    nodes.insert("1".to_string(), SolverNode3D { id: 1, x: 0.0, y: 0.0, z: 0.0 });
+    nodes.insert("2".to_string(), SolverNode3D { id: 2, x: 4.0, y: 0.0, z: 0.0 });
+    nodes.insert("3".to_string(), SolverNode3D { id: 3, x: 8.0, y: 0.0, z: 0.0 });
+    nodes.insert("4".to_string(), SolverNode3D { id: 4, x: 12.0, y: 0.0, z: 3.0 });
+
+    let mut materials = HashMap::new();
+    materials.insert("1".to_string(), SolverMaterial { id: 1, e: 200_000.0, nu: 0.3 });
+
+    let mut sections = HashMap::new();
+    sections.insert("1".to_string(), SolverSection3D {
+        id: 1, name: None, a: 0.05,
+        iy: 1.0e-4, iz: 5.0e-5, j: 1.5e-4,
+        cw: None, as_y: None, as_z: None,
+    });
+
+    let mut elements = HashMap::new();
+    for (id, ni, nj) in [(1, 1, 2), (2, 2, 3), (3, 3, 4)] {
+        elements.insert(id.to_string(), SolverElement3D {
+            id, elem_type: "frame".to_string(),
+            node_i: ni, node_j: nj,
+            material_id: 1, section_id: 1,
+            release_my_start: false, release_my_end: false,
+            release_mz_start: false, release_mz_end: false,
+            release_t_start: false, release_t_end: false,
+            local_yx: None, local_yy: None, local_yz: None,
+            roll_angle: None,
+        });
+    }
+
+    let mut supports = HashMap::new();
+    supports.insert("1".to_string(), sup_3d(1, true, true, true, true, false, false));
+    supports.insert("2".to_string(), sup_3d(4, false, true, true, true, false, false));
+
+    let loads = vec![
+        SolverLoad3D::Distributed(SolverDistributedLoad3D {
+            element_id: 1, q_yi: 0.0, q_yj: 0.0, q_zi: -1.5, q_zj: -1.5,
+            a: None, b: None,
+        }),
+    ];
+
+    SolverInput3D {
+        nodes, materials, sections, elements, supports,
+        loads,
+        constraints: vec![], left_hand: None,
+        plates: HashMap::new(), quads: HashMap::new(), quad9s: HashMap::new(),
+        solid_shells: HashMap::new(), curved_shells: HashMap::new(),
+        curved_beams: vec![],
+        connectors: HashMap::new(),
+    }
+}
+
+fn train_3axle() -> LoadTrain {
+    LoadTrain {
+        name: "T3".to_string(),
+        axles: vec![
+            Axle { offset: 0.0, weight: 100.0 },
+            Axle { offset: 2.0, weight: 150.0 },
+            Axle { offset: 5.0, weight: 80.0 },
+        ],
+    }
+}
+
+// ==================== Legacy references (full solve per position/point) ====================
+
+fn legacy_moving_2d(input: &MovingLoadInput) -> MovingLoadEnvelope {
+    let solver_input = &input.solver;
+    let train = &input.train;
+    let step = input.step.unwrap_or(0.25);
+    let path = build_load_path(solver_input, input.path_element_ids.as_deref()).unwrap();
+    let total_length: f64 = path.iter().map(|s| s.length).sum();
+    let max_offset: f64 = train.axles.iter().map(|a| a.offset).fold(0.0, f64::max);
+
+    let mut envelopes: HashMap<String, ElementEnvelope> = HashMap::new();
+    for elem in solver_input.elements.values() {
+        envelopes.insert(elem.id.to_string(), ElementEnvelope {
+            m_max_pos: 0.0, m_max_neg: 0.0,
+            v_max_pos: 0.0, v_max_neg: 0.0,
+            n_max_pos: 0.0, n_max_neg: 0.0,
+        });
+    }
+
+    let mut pos = -max_offset;
+    let mut num_positions = 0;
+    while pos <= total_length + 1e-10 {
+        num_positions += 1;
+        let loads = moving_loads_at_position_2d(solver_input, train, &path, pos, total_length);
+        let mut modified_input = solver_input.clone();
+        modified_input.loads = loads;
+        if let Ok(results) = solve_2d(&modified_input) {
+            for ef in &results.element_forces {
+                if let Some(env) = envelopes.get_mut(&ef.element_id.to_string()) {
+                    let m_max = ef.m_start.max(ef.m_end);
+                    let m_min = ef.m_start.min(ef.m_end);
+                    let v_max = ef.v_start.max(ef.v_end);
+                    let v_min = ef.v_start.min(ef.v_end);
+                    let n_max = ef.n_start.max(ef.n_end);
+                    let n_min = ef.n_start.min(ef.n_end);
+                    env.m_max_pos = env.m_max_pos.max(m_max);
+                    env.m_max_neg = env.m_max_neg.min(m_min);
+                    env.v_max_pos = env.v_max_pos.max(v_max);
+                    env.v_max_neg = env.v_max_neg.min(v_min);
+                    env.n_max_pos = env.n_max_pos.max(n_max);
+                    env.n_max_neg = env.n_max_neg.min(n_min);
+                }
+            }
+        }
+        pos += step;
+    }
+
+    MovingLoadEnvelope { elements: envelopes, train: train.clone(), path, num_positions }
+}
+
+fn legacy_moving_3d(input: &MovingLoadInput3D) -> MovingLoadEnvelope3D {
+    let solver_input = &input.solver;
+    let train = &input.train;
+    let step = input.step.unwrap_or(0.25);
+    let gravity = input.gravity_direction.as_deref().unwrap_or("z");
+    let path = build_load_path_3d(solver_input, input.path_element_ids.as_deref()).unwrap();
+    let total_length: f64 = path.iter().map(|s| s.length).sum();
+    let max_offset: f64 = train.axles.iter().map(|a| a.offset).fold(0.0, f64::max);
+
+    let mut envelopes: HashMap<String, ElementEnvelope3D> = HashMap::new();
+    for elem in solver_input.elements.values() {
+        envelopes.insert(elem.id.to_string(), ElementEnvelope3D {
+            n_max_pos: 0.0, n_max_neg: 0.0,
+            vy_max_pos: 0.0, vy_max_neg: 0.0,
+            vz_max_pos: 0.0, vz_max_neg: 0.0,
+            my_max_pos: 0.0, my_max_neg: 0.0,
+            mz_max_pos: 0.0, mz_max_neg: 0.0,
+            mx_max_pos: 0.0, mx_max_neg: 0.0,
+        });
+    }
+
+    let mut pos = -max_offset;
+    let mut num_positions = 0;
+    while pos <= total_length + 1e-10 {
+        num_positions += 1;
+        let loads = moving_loads_at_position_3d(solver_input, train, gravity, &path, pos, total_length);
+        let mut modified_input = solver_input.clone();
+        modified_input.loads = loads;
+        if let Ok(results) = solve_3d(&modified_input) {
+            for ef in &results.element_forces {
+                if let Some(env) = envelopes.get_mut(&ef.element_id.to_string()) {
+                    env.n_max_pos = env.n_max_pos.max(ef.n_start.max(ef.n_end));
+                    env.n_max_neg = env.n_max_neg.min(ef.n_start.min(ef.n_end));
+                    env.vy_max_pos = env.vy_max_pos.max(ef.vy_start.max(ef.vy_end));
+                    env.vy_max_neg = env.vy_max_neg.min(ef.vy_start.min(ef.vy_end));
+                    env.vz_max_pos = env.vz_max_pos.max(ef.vz_start.max(ef.vz_end));
+                    env.vz_max_neg = env.vz_max_neg.min(ef.vz_start.min(ef.vz_end));
+                    env.my_max_pos = env.my_max_pos.max(ef.my_start.max(ef.my_end));
+                    env.my_max_neg = env.my_max_neg.min(ef.my_start.min(ef.my_end));
+                    env.mz_max_pos = env.mz_max_pos.max(ef.mz_start.max(ef.mz_end));
+                    env.mz_max_neg = env.mz_max_neg.min(ef.mz_start.min(ef.mz_end));
+                    env.mx_max_pos = env.mx_max_pos.max(ef.mx_start.max(ef.mx_end));
+                    env.mx_max_neg = env.mx_max_neg.min(ef.mx_start.min(ef.mx_end));
+                }
+            }
+        }
+        pos += step;
+    }
+
+    MovingLoadEnvelope3D { elements: envelopes, train: train.clone(), path, num_positions }
+}
+
+// ==================== Moving loads parity ====================
+
+#[test]
+fn parity_moving_loads_2d() {
+    let input = MovingLoadInput {
+        solver: make_beam_2d_inclined(),
+        train: train_3axle(),
+        step: Some(0.7),
+        path_element_ids: None,
+    };
+
+    let new = solve_moving_loads_2d(&input).unwrap();
+    let legacy = legacy_moving_2d(&input);
+
+    assert_eq!(new.num_positions, legacy.num_positions);
+    assert!(new.num_positions > 20, "expected many positions, got {}", new.num_positions);
+    assert_eq!(new.elements.len(), legacy.elements.len());
+    for (eid, a) in &new.elements {
+        let b = legacy.elements.get(eid).expect("missing element in legacy");
+        let c = format!("element {}", eid);
+        assert_f64_eq(a.m_max_pos, b.m_max_pos, &format!("{} m_max_pos", c));
+        assert_f64_eq(a.m_max_neg, b.m_max_neg, &format!("{} m_max_neg", c));
+        assert_f64_eq(a.v_max_pos, b.v_max_pos, &format!("{} v_max_pos", c));
+        assert_f64_eq(a.v_max_neg, b.v_max_neg, &format!("{} v_max_neg", c));
+        assert_f64_eq(a.n_max_pos, b.n_max_pos, &format!("{} n_max_pos", c));
+        assert_f64_eq(a.n_max_neg, b.n_max_neg, &format!("{} n_max_neg", c));
+    }
+    // Sanity: envelopes actually moved off zero somewhere
+    let any_nonzero = new.elements.values()
+        .any(|e| e.m_max_pos != 0.0 || e.m_max_neg != 0.0 || e.v_max_pos != 0.0 || e.n_max_neg != 0.0);
+    assert!(any_nonzero, "envelopes unexpectedly all zero");
+}
+
+#[test]
+fn parity_moving_loads_3d() {
+    let input = MovingLoadInput3D {
+        solver: make_beam_3d_inclined(),
+        train: LoadTrain {
+            name: "T2".to_string(),
+            axles: vec![
+                Axle { offset: 0.0, weight: 100.0 },
+                Axle { offset: 3.0, weight: 140.0 },
+            ],
+        },
+        step: Some(0.8),
+        path_element_ids: None,
+        gravity_direction: None,
+    };
+
+    let new = solve_moving_loads_3d(&input).unwrap();
+    let legacy = legacy_moving_3d(&input);
+
+    assert_eq!(new.num_positions, legacy.num_positions);
+    assert!(new.num_positions > 15, "expected many positions, got {}", new.num_positions);
+    for (eid, a) in &new.elements {
+        let b = legacy.elements.get(eid).expect("missing element in legacy");
+        let c = format!("element {}", eid);
+        assert_f64_eq(a.n_max_pos, b.n_max_pos, &format!("{} n_max_pos", c));
+        assert_f64_eq(a.n_max_neg, b.n_max_neg, &format!("{} n_max_neg", c));
+        assert_f64_eq(a.vy_max_pos, b.vy_max_pos, &format!("{} vy_max_pos", c));
+        assert_f64_eq(a.vy_max_neg, b.vy_max_neg, &format!("{} vy_max_neg", c));
+        assert_f64_eq(a.vz_max_pos, b.vz_max_pos, &format!("{} vz_max_pos", c));
+        assert_f64_eq(a.vz_max_neg, b.vz_max_neg, &format!("{} vz_max_neg", c));
+        assert_f64_eq(a.my_max_pos, b.my_max_pos, &format!("{} my_max_pos", c));
+        assert_f64_eq(a.my_max_neg, b.my_max_neg, &format!("{} my_max_neg", c));
+        assert_f64_eq(a.mz_max_pos, b.mz_max_pos, &format!("{} mz_max_pos", c));
+        assert_f64_eq(a.mz_max_neg, b.mz_max_neg, &format!("{} mz_max_neg", c));
+        assert_f64_eq(a.mx_max_pos, b.mx_max_pos, &format!("{} mx_max_pos", c));
+        assert_f64_eq(a.mx_max_neg, b.mx_max_neg, &format!("{} mx_max_neg", c));
+    }
+    let any_nonzero = new.elements.values()
+        .any(|e| e.mz_max_pos != 0.0 || e.mz_max_neg != 0.0 || e.vz_max_pos != 0.0 || e.n_max_neg != 0.0);
+    assert!(any_nonzero, "envelopes unexpectedly all zero");
+}
+
+// ==================== Influence line parity ====================
+
+#[test]
+fn parity_influence_line_2d() {
+    for (quantity, node, elem_id) in [("Ry", Some(1), None), ("M", None, Some(1))] {
+        let input = InfluenceLineInput {
+            solver: make_beam_2d_inclined(),
+            quantity: quantity.to_string(),
+            target_node_id: node,
+            target_element_id: elem_id,
+            target_position: 0.5,
+            n_points_per_element: 8,
+        };
+
+        let new = compute_influence_line(&input).unwrap();
+
+        // Legacy: one full solve per sampled point
+        let base = SolverInput { loads: vec![], ..input.solver.clone() };
+        let node_pos: HashMap<usize, (f64, f64)> = input.solver.nodes.values()
+            .map(|n| (n.id, (n.x, n.z)))
+            .collect();
+        let mut legacy_points = Vec::new();
+        for elem in input.solver.elements.values() {
+            let (nix, niy) = *node_pos.get(&elem.node_i).unwrap();
+            let (njx, njy) = *node_pos.get(&elem.node_j).unwrap();
+            let dx = njx - nix;
+            let dy = njy - niy;
+            let l = (dx * dx + dy * dy).sqrt();
+            if l < 1e-6 { continue; }
+            let cos_theta = dx / l;
+            let sin_theta = dy / l;
+            for k in 0..=input.n_points_per_element {
+                let t = k as f64 / input.n_points_per_element as f64;
+                let a = t * l;
+                let loads = influence_unit_loads_2d(elem, a, t, cos_theta, sin_theta);
+                let mut trial = base.clone();
+                trial.loads = loads;
+                let value = match solve_2d(&trial) {
+                    Ok(result) => extract_value(&input.quantity, input.target_node_id, input.target_element_id, input.target_position, &result),
+                    Err(_) => 0.0,
+                };
+                legacy_points.push((nix + t * dx, niy + t * dy, elem.id, t, value));
+            }
+        }
+
+        assert_eq!(new.points.len(), legacy_points.len(), "point count for {}", quantity);
+        for (p, (lx, ly, le, lt, lv)) in new.points.iter().zip(&legacy_points) {
+            let c = format!("{} elem {} t {}", quantity, le, lt);
+            assert_f64_eq(p.x, *lx, &format!("{} x", c));
+            assert_f64_eq(p.y, *ly, &format!("{} y", c));
+            assert_eq!(p.element_id, *le, "{} element_id", c);
+            assert_f64_eq(p.t, *lt, &format!("{} t", c));
+            assert_f64_eq(p.value, *lv, &format!("{} value", c));
+        }
+        let any_nonzero = new.points.iter().any(|p| p.value != 0.0);
+        assert!(any_nonzero, "influence line unexpectedly all zero for {}", quantity);
+    }
+}
+
+#[test]
+fn parity_influence_line_3d() {
+    for (quantity, node, elem_id) in [("Fz", Some(1), None), ("My_diag", None, Some(1))] {
+        let input = InfluenceLineInput3D {
+            solver: make_beam_3d_inclined(),
+            quantity: quantity.to_string(),
+            target_node_id: node,
+            target_element_id: elem_id,
+            target_position: 0.5,
+            n_points_per_element: 8,
+            gravity_direction: None,
+        };
+
+        let new = compute_influence_line_3d(&input).unwrap();
+
+        // Legacy: one full solve per sampled point
+        let base = SolverInput3D { loads: vec![], ..input.solver.clone() };
+        let node_pos: HashMap<usize, (f64, f64, f64)> = input.solver.nodes.values()
+            .map(|n| (n.id, (n.x, n.y, n.z)))
+            .collect();
+        let gravity_dir = [0.0_f64, 0.0, -1.0];
+        let mut legacy_points = Vec::new();
+        for elem in input.solver.elements.values() {
+            if elem.elem_type != "frame" && elem.elem_type != "beam" { continue; }
+            let (nix, niy, niz) = *node_pos.get(&elem.node_i).unwrap();
+            let (njx, njy, njz) = *node_pos.get(&elem.node_j).unwrap();
+            let dx = njx - nix;
+            let dy = njy - niy;
+            let dz = njz - niz;
+            let l = (dx * dx + dy * dy + dz * dz).sqrt();
+            if l < 1e-6 { continue; }
+            let left_hand = input.solver.left_hand.unwrap_or(false);
+            let (_ex, ey, ez) = dedaliano_engine::element::compute_local_axes_3d(
+                nix, niy, niz, njx, njy, njz,
+                elem.local_yx, elem.local_yy, elem.local_yz,
+                elem.roll_angle, left_hand,
+            );
+            let g_local_y = gravity_dir[0] * ey[0] + gravity_dir[1] * ey[1] + gravity_dir[2] * ey[2];
+            let g_local_z = gravity_dir[0] * ez[0] + gravity_dir[1] * ez[1] + gravity_dir[2] * ez[2];
+            for k in 0..=input.n_points_per_element {
+                let t = k as f64 / input.n_points_per_element as f64;
+                let a = t * l;
+                let loads = influence_unit_loads_3d(elem.id, a, g_local_y, g_local_z);
+                let mut trial = base.clone();
+                trial.loads = loads;
+                let value = match solve_3d(&trial) {
+                    Ok(result) => extract_value_3d(&input.quantity, input.target_node_id, input.target_element_id, input.target_position, &result),
+                    Err(_) => 0.0,
+                };
+                legacy_points.push((nix + t * dx, niy + t * dy, niz + t * dz, elem.id, t, value));
+            }
+        }
+
+        assert_eq!(new.points.len(), legacy_points.len(), "point count for {}", quantity);
+        for (p, (lx, ly, lz, le, lt, lv)) in new.points.iter().zip(&legacy_points) {
+            let c = format!("{} elem {} t {}", quantity, le, lt);
+            assert_f64_eq(p.x, *lx, &format!("{} x", c));
+            assert_f64_eq(p.y, *ly, &format!("{} y", c));
+            assert_f64_eq(p.z, *lz, &format!("{} z", c));
+            assert_eq!(p.element_id, *le, "{} element_id", c);
+            assert_f64_eq(p.t, *lt, &format!("{} t", c));
+            assert_f64_eq(p.value, *lv, &format!("{} value", c));
+        }
+        let any_nonzero = new.points.iter().any(|p| p.value != 0.0);
+        assert!(any_nonzero, "influence line unexpectedly all zero for {}", quantity);
+    }
+}


### PR DESCRIPTION
…lines

Both workflows ran a full solve_* per train position / per sampled point (assembly + validation + factorization each). They now prepare once via the prepared-static API and only rebuild the RHS per position/point:

- moving_loads.rs: prepare_static_2d/3d once; per-position loads via new public moving_loads_at_position_2d/3d + solve_loads. Silent-skip and zeroed-envelope semantics preserved exactly; constrained models keep the legacy per-position loop.
- postprocess/influence.rs: one factorization + one solve_loads per sampled unit load (new influence_unit_loads_2d/3d helpers); per-point failure still yields a 0.0 ordinate. Muller-Breslau adjoint redesign noted as follow-up.

Parity: tests/integration/moving_influence_parity.rs — exact == on every f64 (envelopes, ordinates, num_positions) vs the legacy loop, 2D+3D, default and parallel builds; full suite 5925 green; clippy clean. Bench (moving_influence_reuse group): 2.1x moving 2D dense, 3.2x sparse, 3.9x influence dense, 6.4x influence sparse.