### PR TITLE
perf(web): batch 2D combos into one WASM call + cheaper worker/pool init

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "wasm": "cd ../engine && wasm-pack build --target web --out-dir ../web/src/lib/wasm",
+    "wasm": "cd ../engine && wasm-pack build --target web --out-dir ../web/src/lib/wasm --no-opt",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "wasm": "cd ../engine && wasm-pack build --target web --out-dir ../web/src/lib/wasm --no-opt",
+    "wasm": "cd ../engine && wasm-pack build --target web --out-dir ../web/src/lib/wasm",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/web/src/lib/engine/__tests__/solver-service-combos-2d.test.ts
+++ b/web/src/lib/engine/__tests__/solver-service-combos-2d.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Contract tests for solveCombinations2D after its reroute through the
+ * engine's batch multi-case API (solve_multi_case_2d). Pins:
+ *  - result shape + superposition math of the batch path,
+ *  - parity with the per-case path (validateAndSolve2D per case),
+ *  - the guards that keep constraint / duplicate-name models on the
+ *    id-keyed per-case path,
+ *  - error conditions still surfacing as string returns.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initSolver } from '../wasm-solver';
+import { solveCombinations2D, validateAndSolve2D, type ModelData } from '../solver-service';
+
+/** Cantilever: fixed at node 1, tip loads at node 2 split across two cases. */
+function beamModel(): ModelData {
+  return {
+    nodes: new Map([
+      [1, { id: 1, x: 0, y: 0 } as any],
+      [2, { id: 2, x: 5, y: 0 } as any],
+    ]),
+    elements: new Map([
+      [1, { id: 1, type: 'frame', nodeI: 1, nodeJ: 2, materialId: 1, sectionId: 1 } as any],
+    ]),
+    materials: new Map([[1, { id: 1, e: 200_000_000, nu: 0.3 } as any]]),
+    sections: new Map([[1, { id: 1, a: 0.01, iz: 1e-4 } as any]]),
+    supports: new Map([[1, { id: 1, nodeId: 1, type: 'fixed' } as any]]),
+    loads: [
+      { type: 'nodal', data: { id: 1, nodeId: 2, fx: 0, fz: -10, my: 0, caseId: 1 } } as any,
+      { type: 'nodal', data: { id: 2, nodeId: 2, fx: 4, fz: 0, my: 0, caseId: 2 } } as any,
+    ],
+  };
+}
+
+const cases = [
+  { id: 1, type: 'D', name: 'Dead' },
+  { id: 2, type: 'L', name: 'Live' },
+] as any;
+
+const combos = [
+  { id: 10, name: 'COMB1', factors: [{ caseId: 1, factor: 1.2 }, { caseId: 2, factor: 1.6 }] },
+] as any;
+
+describe('solveCombinations2D (multi-case batch path)', () => {
+  beforeAll(async () => { await initSolver(); });
+
+  it('returns perCase/perCombo/envelope with linear-superposition results', () => {
+    const r = solveCombinations2D(beamModel(), cases, combos);
+    expect(typeof r).not.toBe('string');
+    if (typeof r === 'string' || !r) return;
+    expect(r.perCase.size).toBe(2);
+    expect(r.perCombo.size).toBe(1);
+    // Case D (fz=-10 @ tip) → rz=+10 at the fixed end; case L (fx=+4) → rx=-4.
+    const combo = r.perCombo.get(10)!;
+    const reaction = combo.reactions.find(x => x.nodeId === 1)!;
+    expect(reaction.rz).toBeCloseTo(1.2 * 10, 8);
+    expect(reaction.rx).toBeCloseTo(1.6 * -4, 8);
+    expect(r.envelope).toBeTruthy();
+    expect(r.envelope.maxAbsResults).toBeTruthy();
+    expect(r.envelope.moment).toBeTruthy();
+  });
+
+  it('per-case results match the per-case solve path', () => {
+    const r = solveCombinations2D(beamModel(), cases, combos);
+    if (typeof r === 'string' || !r) throw new Error('expected result bundle');
+    for (const lc of cases as Array<{ id: number }>) {
+      const model = beamModel();
+      const direct = validateAndSolve2D({ ...model, loads: model.loads.filter(l => (l.data as any).caseId === lc.id) });
+      if (typeof direct === 'string' || !direct) throw new Error('direct solve failed');
+      const batched = r.perCase.get(lc.id)!;
+      expect(batched.reactions.length).toBe(direct.reactions.length);
+      for (let i = 0; i < direct.reactions.length; i++) {
+        expect(batched.reactions[i].nodeId).toBe(direct.reactions[i].nodeId);
+        expect(batched.reactions[i].rx).toBeCloseTo(direct.reactions[i].rx, 10);
+        expect(batched.reactions[i].rz).toBeCloseTo(direct.reactions[i].rz, 10);
+        expect(batched.reactions[i].my).toBeCloseTo(direct.reactions[i].my, 10);
+      }
+      expect(batched.displacements.length).toBe(direct.displacements.length);
+      expect(batched.elementForces.length).toBe(direct.elementForces.length);
+    }
+  });
+
+  it('constraint models still solve (guarded onto the per-case path)', () => {
+    const model = beamModel();
+    model.constraints = [{ type: 'equalDOF', masterNode: 1, slaveNode: 2, dofs: [0] } as any];
+    const oneCase = [{ id: 1, type: 'D', name: 'Dead' }] as any;
+    const oneCombo = [{ id: 10, name: 'C1', factors: [{ caseId: 1, factor: 1.4 }] }] as any;
+    const r = solveCombinations2D(model, oneCase, oneCombo);
+    expect(typeof r).not.toBe('string');
+    if (typeof r === 'string' || !r) return;
+    expect(r.perCase.size).toBe(1);
+    expect(r.perCombo.size).toBe(1);
+    const reaction = r.perCombo.get(10)!.reactions.find(x => x.nodeId === 1)!;
+    expect(reaction.rz).toBeCloseTo(1.4 * 10, 8);
+  });
+
+  it('duplicate case names stay correct (id-keyed per-case path)', () => {
+    const dupCases = [
+      { id: 1, type: 'D', name: 'Same' },
+      { id: 2, type: 'L', name: 'Same' },
+    ] as any;
+    const r = solveCombinations2D(beamModel(), dupCases, combos);
+    expect(typeof r).not.toBe('string');
+    if (typeof r === 'string' || !r) return;
+    expect(r.perCase.size).toBe(2);
+    const reaction = r.perCombo.get(10)!.reactions.find(x => x.nodeId === 1)!;
+    expect(reaction.rz).toBeCloseTo(1.2 * 10, 8);
+    expect(reaction.rx).toBeCloseTo(1.6 * -4, 8);
+  });
+
+  it('returns a string when there are no combinations', () => {
+    expect(typeof solveCombinations2D(beamModel(), cases, [])).toBe('string');
+  });
+
+  it('returns a string for an unstable model (fallback reproduces the validation error)', () => {
+    const model = beamModel();
+    model.supports = new Map([[1, { id: 1, nodeId: 1, type: 'rollerX' } as any]]);
+    expect(typeof solveCombinations2D(model, cases, combos)).toBe('string');
+  });
+
+  it('returns a string for an empty model', () => {
+    const model = beamModel();
+    model.nodes = new Map();
+    model.elements = new Map();
+    expect(typeof solveCombinations2D(model, cases, combos)).toBe('string');
+  });
+});

--- a/web/src/lib/engine/__tests__/solver-service-combos-2d.test.ts
+++ b/web/src/lib/engine/__tests__/solver-service-combos-2d.test.ts
@@ -125,3 +125,75 @@ describe('solveCombinations2D (multi-case batch path)', () => {
     expect(typeof solveCombinations2D(model, cases, combos)).toBe('string');
   });
 });
+
+describe('solveCombinations2D — preflight parity with the per-case path', () => {
+  beforeAll(async () => { await initSolver(); });
+
+  it('rejects 3D support types instead of solving with them ignored', () => {
+    const model = beamModel();
+    model.supports.set(2, { id: 2, nodeId: 2, type: 'fixed3d' } as any);
+    const r = solveCombinations2D(model, cases, combos);
+    expect(typeof r).toBe('string');
+    expect(r as string).toContain('fixed3d');
+  });
+
+  it('rejects 3D z-coords instead of silently projecting them', () => {
+    const model = beamModel();
+    (model.nodes.get(2) as any).z = 1.5;
+    const r = solveCombinations2D(model, cases, combos);
+    expect(typeof r).toBe('string');
+  });
+
+  it('rejects an orphan supported node instead of solving around it', () => {
+    const model = beamModel();
+    // Node 3 has a support but no element — legacy svc.disconnectedNode.
+    model.nodes.set(3, { id: 3, x: 9, y: 0 } as any);
+    model.supports.set(3, { id: 3, nodeId: 3, type: 'pinned' } as any);
+    const r = solveCombinations2D(model, cases, combos);
+    expect(typeof r).toBe('string');
+    expect(r as string).toContain('3');
+  });
+
+  it('accumulates duplicate case factors in a combo (legacy sum semantics)', () => {
+    const dupCombos = [
+      { id: 10, name: 'DUP', factors: [{ caseId: 1, factor: 1.0 }, { caseId: 1, factor: 0.5 }] },
+    ] as any;
+    const oneCase = [{ id: 1, type: 'D', name: 'Dead' }] as any;
+    const model = beamModel();
+    (model.loads as any) = model.loads.filter(l => (l.data as any).caseId === 1);
+    const r = solveCombinations2D(model, oneCase, dupCombos);
+    expect(typeof r).not.toBe('string');
+    if (typeof r === 'string' || !r) return;
+    // Case D: fz=-10 @ tip → rz=+10. Sum 1.0+0.5=1.5 → rz=15 (last-wins would give 5).
+    const reaction = r.perCombo.get(10)!.reactions.find(x => x.nodeId === 1)!;
+    expect(reaction.rz).toBeCloseTo(15, 8);
+  });
+
+  it('skips ghost combos while keeping valid ones (no zeroed combos)', () => {
+    const mixedCombos = [
+      { id: 10, name: 'VALID', factors: [{ caseId: 1, factor: 1.0 }] },
+      { id: 11, name: 'GHOST', factors: [{ caseId: 99, factor: 1.4 }] },
+    ] as any;
+    const oneCase = [{ id: 1, type: 'D', name: 'Dead' }] as any;
+    const model = beamModel();
+    (model.loads as any) = model.loads.filter(l => (l.data as any).caseId === 1);
+    const r = solveCombinations2D(model, oneCase, mixedCombos);
+    expect(typeof r).not.toBe('string');
+    if (typeof r === 'string' || !r) return;
+    expect(r.perCombo.has(10)).toBe(true);
+    expect(r.perCombo.has(11)).toBe(false);
+  });
+
+  it('all-ghost factors: same string error as the legacy path (no zeroed combo)', () => {
+    const ghostCombos = [
+      { id: 10, name: 'GHOST', factors: [{ caseId: 99, factor: 1.4 }] },
+    ] as any;
+    const oneCase = [{ id: 1, type: 'D', name: 'Dead' }] as any;
+    const model = beamModel();
+    (model.loads as any) = model.loads.filter(l => (l.data as any).caseId === 1);
+    const r = solveCombinations2D(model, oneCase, ghostCombos);
+    // The legacy path produces no combos → envelope error string, and the
+    // batch path must surface the same refusal rather than a zeroed combo.
+    expect(typeof r).toBe('string');
+  });
+});

--- a/web/src/lib/engine/solver-pool.ts
+++ b/web/src/lib/engine/solver-pool.ts
@@ -5,6 +5,8 @@
  * Distributes solve_3d calls across workers for parallel execution.
  */
 
+import { getWasmBytes } from './wasm-solver';
+
 interface PendingSolve {
   resolve: (json: string) => void;
   reject: (err: Error) => void;
@@ -17,7 +19,6 @@ interface PoolWorker {
 }
 
 let pool: PoolWorker[] = [];
-let wasmBytes: ArrayBuffer | null = null;
 let initPromise: Promise<void> | null = null;
 let nextId = 0;
 
@@ -30,19 +31,8 @@ const MAX_WORKERS = Math.min(
   8,
 );
 
-/** Fetch the WASM binary once for sharing with workers. */
-async function fetchWasmBytes(): Promise<ArrayBuffer> {
-  if (wasmBytes) return wasmBytes;
-  // The WASM binary is served alongside the JS glue code
-  // Use the same resolution path as the glue code
-  const wasmUrl = new URL('../wasm/dedaliano_engine_bg.wasm', import.meta.url);
-  const resp = await fetch(wasmUrl);
-  wasmBytes = await resp.arrayBuffer();
-  return wasmBytes;
-}
-
 /** Create a single worker and wait for it to become ready. */
-function createWorker(bytes: ArrayBuffer): Promise<PoolWorker> {
+function createWorker(wasmModule: WebAssembly.Module): Promise<PoolWorker> {
   return new Promise((resolve, reject) => {
     const worker = new Worker(
       new URL('./solver-worker.ts', import.meta.url),
@@ -76,8 +66,8 @@ function createWorker(bytes: ArrayBuffer): Promise<PoolWorker> {
       reject(new Error(`Worker error: ${err.message}`));
     };
 
-    // Send WASM bytes (copy, not transfer, since multiple workers need it)
-    worker.postMessage({ type: 'init', wasmBytes: bytes.slice(0) });
+    // Compiled module is structured-cloneable: no byte copy, no per-worker compile
+    worker.postMessage({ type: 'init', wasmModule });
   });
 }
 
@@ -89,9 +79,11 @@ export async function initPool(numWorkers?: number): Promise<void> {
   const count = numWorkers ?? MAX_WORKERS;
 
   initPromise = (async () => {
-    const bytes = await fetchWasmBytes();
+    // Compile once on the main thread (bytes shared with wasm-solver's init,
+    // so a single fetch); workers instantiate clones of the compiled module.
+    const wasmModule = await WebAssembly.compile(await getWasmBytes());
     const workers = await Promise.all(
-      Array.from({ length: count }, () => createWorker(bytes)),
+      Array.from({ length: count }, () => createWorker(wasmModule)),
     );
     pool = workers;
   })();

--- a/web/src/lib/engine/solver-pool.ts
+++ b/web/src/lib/engine/solver-pool.ts
@@ -79,13 +79,30 @@ export async function initPool(numWorkers?: number): Promise<void> {
   const count = numWorkers ?? MAX_WORKERS;
 
   initPromise = (async () => {
-    // Compile once on the main thread (bytes shared with wasm-solver's init,
-    // so a single fetch); workers instantiate clones of the compiled module.
-    const wasmModule = await WebAssembly.compile(await getWasmBytes());
-    const workers = await Promise.all(
-      Array.from({ length: count }, () => createWorker(wasmModule)),
-    );
-    pool = workers;
+    try {
+      // Compile once on the main thread (bytes shared with wasm-solver's init,
+      // so a single fetch); workers instantiate clones of the compiled module.
+      const wasmModule = await WebAssembly.compile(await getWasmBytes());
+      const settled = await Promise.allSettled(
+        Array.from({ length: count }, () => createWorker(wasmModule)),
+      );
+      const failed = settled.find((s): s is PromiseRejectedResult => s.status === 'rejected');
+      if (failed) {
+        // Terminate the workers that DID start (Promise.all would leak them),
+        // then rethrow into the reset path below.
+        for (const s of settled) {
+          if (s.status === 'fulfilled') s.value.worker.terminate();
+        }
+        throw failed.reason;
+      }
+      pool = settled.map(s => (s as PromiseFulfilledResult<PoolWorker>).value);
+    } catch (err) {
+      // Don't poison the pool: a rejected initPromise would make every later
+      // call re-await the same failure until reload. Reset so the next call
+      // retries.
+      initPromise = null;
+      throw err;
+    }
   })();
 
   return initPromise;

--- a/web/src/lib/engine/solver-service.ts
+++ b/web/src/lib/engine/solver-service.ts
@@ -1,7 +1,7 @@
 // Solver service — pure functions extracted from model.svelte.ts
 // Each function takes a ModelData parameter instead of accessing reactive store state.
 
-import { solve as solveStructure, solve3D as solve3DEngine, analyzeKinematics, combineResults, combineResults3D, computeEnvelope, computeEnvelope3D, solveMultiCase3D, serializeInput3D } from './wasm-solver';
+import { solve as solveStructure, solve3D as solve3DEngine, analyzeKinematics, combineResults, combineResults3D, computeEnvelope, computeEnvelope3D, solveMultiCase2D, solveMultiCase3D, input3DToWireObject } from './wasm-solver';
 import type { SolverInput, FullEnvelope, AnalysisResults } from './types';
 import { computeLocalAxes3D } from './local-axes-3d';
 import type { SolverInput3D, SolverLoad3D, AnalysisResults3D, FullEnvelope3D, Constraint3D } from './types-3d';
@@ -156,6 +156,76 @@ function buildSolverSupports2D(model: ModelData): Map<number, any> {
 }
 
 // ─── 2D: validateAndSolve2D ───────────────────────────────────────
+
+/** Build only the solver loads array for a 2D input. Shared by
+ *  validateAndSolve2D and the multi-case combo path so both produce
+ *  identical per-case loads on the wire. */
+function buildSolverLoads2D(model: ModelData, loads: Load[], includeSelfWeight: boolean): SolverInput['loads'] {
+  const solverLoads = loads.map(l => {
+    if (l.type === 'nodal') {
+      return {
+        type: 'nodal' as const,
+        data: { nodeId: l.data.nodeId, fx: l.data.fx, fz: l.data.fz ?? l.data.fy, my: l.data.my ?? l.data.mz },
+      };
+    } else if (l.type === 'distributed') {
+      const d = l.data as DistributedLoad;
+      const sd: { elementId: number; qI: number; qJ: number; a?: number; b?: number } = { elementId: d.elementId, qI: d.qI, qJ: d.qJ };
+      if (d.a !== undefined && d.a > 0) sd.a = d.a;
+      if (d.b !== undefined) sd.b = d.b;
+      return { type: 'distributed' as const, data: sd };
+    } else if (l.type === 'thermal') {
+      const d = l.data as ThermalLoad;
+      return { type: 'thermal' as const, data: { elementId: d.elementId, dtUniform: d.dtUniform, dtGradient: d.dtGradient } };
+    } else {
+      const d = l.data as PointLoadOnElement;
+      const spd: { elementId: number; a: number; p: number; px?: number; my?: number } = { elementId: d.elementId, a: d.a, p: d.p };
+      if (d.px !== undefined && d.px !== 0) spd.px = d.px;
+      if ((d.my ?? d.mz) !== undefined && (d.my ?? d.mz) !== 0) spd.my = d.my ?? d.mz;
+      return { type: 'pointOnElement' as const, data: spd };
+    }
+  });
+
+  // Add self-weight as distributed loads
+  if (includeSelfWeight) {
+    for (const elem of model.elements.values()) {
+      const mat = model.materials.get(elem.materialId);
+      const sec = model.sections.get(elem.sectionId);
+      const ni = model.nodes.get(elem.nodeI);
+      const nj = model.nodes.get(elem.nodeJ);
+      if (!mat || !sec || !ni || !nj) continue;
+
+      const dx = nj.x - ni.x;
+      const dy = nj.y - ni.y;
+      const L = Math.sqrt(dx * dx + dy * dy);
+      if (L < 1e-10) continue;
+
+      const sinTheta = dy / L;
+      const cosTheta = dx / L;
+      const w = mat.rho * sec.a;
+
+      const qPerp = -w * cosTheta;
+      if (Math.abs(qPerp) > 1e-10) {
+        solverLoads.push({
+          type: 'distributed' as const,
+          data: { elementId: elem.id, qI: qPerp, qJ: qPerp },
+        });
+      }
+
+      const qTangent = -w * sinTheta;
+      if (Math.abs(qTangent) > 1e-10) {
+        const Ft = qTangent * L / 2;
+        const fxNode = Ft * cosTheta;
+        const fzNode = Ft * sinTheta;
+        solverLoads.push(
+          { type: 'nodal' as const, data: { nodeId: elem.nodeI, fx: fxNode, fz: fzNode, my: 0 } },
+          { type: 'nodal' as const, data: { nodeId: elem.nodeJ, fx: fxNode, fz: fzNode, my: 0 } },
+        );
+      }
+    }
+  }
+
+  return solverLoads;
+}
 
 /**
  * Full 2D solve with all pre-solve validations.
@@ -496,69 +566,8 @@ export function validateAndSolve2D(
     }
   }
 
-  // Build solver loads array
-  const solverLoads = model.loads.map(l => {
-    if (l.type === 'nodal') {
-      return {
-        type: 'nodal' as const,
-        data: { nodeId: l.data.nodeId, fx: l.data.fx, fz: l.data.fz ?? l.data.fy, my: l.data.my ?? l.data.mz },
-      };
-    } else if (l.type === 'distributed') {
-      const d = l.data as DistributedLoad;
-      const sd: { elementId: number; qI: number; qJ: number; a?: number; b?: number } = { elementId: d.elementId, qI: d.qI, qJ: d.qJ };
-      if (d.a !== undefined && d.a > 0) sd.a = d.a;
-      if (d.b !== undefined) sd.b = d.b;
-      return { type: 'distributed' as const, data: sd };
-    } else if (l.type === 'thermal') {
-      const d = l.data as ThermalLoad;
-      return { type: 'thermal' as const, data: { elementId: d.elementId, dtUniform: d.dtUniform, dtGradient: d.dtGradient } };
-    } else {
-      const d = l.data as PointLoadOnElement;
-      const spd: { elementId: number; a: number; p: number; px?: number; my?: number } = { elementId: d.elementId, a: d.a, p: d.p };
-      if (d.px !== undefined && d.px !== 0) spd.px = d.px;
-      if ((d.my ?? d.mz) !== undefined && (d.my ?? d.mz) !== 0) spd.my = d.my ?? d.mz;
-      return { type: 'pointOnElement' as const, data: spd };
-    }
-  });
-
-  // Add self-weight as distributed loads
-  if (includeSelfWeight) {
-    for (const elem of model.elements.values()) {
-      const mat = model.materials.get(elem.materialId);
-      const sec = model.sections.get(elem.sectionId);
-      const ni = model.nodes.get(elem.nodeI);
-      const nj = model.nodes.get(elem.nodeJ);
-      if (!mat || !sec || !ni || !nj) continue;
-
-      const dx = nj.x - ni.x;
-      const dy = nj.y - ni.y;
-      const L = Math.sqrt(dx * dx + dy * dy);
-      if (L < 1e-10) continue;
-
-      const sinTheta = dy / L;
-      const cosTheta = dx / L;
-      const w = mat.rho * sec.a;
-
-      const qPerp = -w * cosTheta;
-      if (Math.abs(qPerp) > 1e-10) {
-        solverLoads.push({
-          type: 'distributed' as const,
-          data: { elementId: elem.id, qI: qPerp, qJ: qPerp },
-        });
-      }
-
-      const qTangent = -w * sinTheta;
-      if (Math.abs(qTangent) > 1e-10) {
-        const Ft = qTangent * L / 2;
-        const fxNode = Ft * cosTheta;
-        const fzNode = Ft * sinTheta;
-        solverLoads.push(
-          { type: 'nodal' as const, data: { nodeId: elem.nodeI, fx: fxNode, fz: fzNode, my: 0 } },
-          { type: 'nodal' as const, data: { nodeId: elem.nodeJ, fx: fxNode, fz: fzNode, my: 0 } },
-        );
-      }
-    }
-  }
+  // Build solver loads array (shared with the multi-case combo path)
+  const solverLoads = buildSolverLoads2D(model, model.loads, includeSelfWeight);
 
   // Build solver input
   const input: SolverInput = {
@@ -804,6 +813,106 @@ export function solveCombinations2D(
   if (model.supports.size < 1) return t('svc.needSupport');
   if (combinations.length === 0) return t('svc.needCombination');
 
+  // The engine's multi-case 2D solver rebuilds each case WITHOUT constraints
+  // and connectors (load_cases.rs), and sliding joints expand into exactly
+  // those primitives — models using them keep the per-case path so their
+  // results stay correct. Names key the multi-case wire format, so duplicate
+  // case/combo names also route to the id-keyed per-case path.
+  const namesUnique =
+    new Set(loadCases.map(c => c.name)).size === loadCases.length &&
+    new Set(combinations.map(c => c.name)).size === combinations.length;
+  if (
+    !namesUnique ||
+    constraintsTo2D(model.constraints).length > 0 ||
+    (model.connectors?.size ?? 0) > 0 ||
+    modelHasSlidingJoints(model.elements.values())
+  ) {
+    return solveCombinations2DFallback(model, loadCases, combinations, includeSelfWeight);
+  }
+
+  // Build base solver input once (structural data without loads)
+  const baseInput = buildSolverInput2D({ ...model, loads: [] }, false);
+  if (!baseInput) return t('svc.emptyModel');
+
+  // Build per-case load arrays — reuse baseInput structure, only build loads per case
+  const mcLoadCases: Array<{ name: string; loads: SolverInput['loads'] }> = [];
+  const caseNameToId = new Map<string, number>();
+
+  for (const lc of loadCases) {
+    const caseLoads = model.loads.filter(l => (l.data.caseId ?? 1) === lc.id);
+    const loads = buildSolverLoads2D(model, caseLoads, includeSelfWeight && lc.type === 'D');
+    mcLoadCases.push({ name: lc.name, loads });
+    caseNameToId.set(lc.name, lc.id);
+  }
+
+  if (mcLoadCases.length === 0) return t('svc.noLoadsApplied');
+
+  // Build combination definitions (name-based factors for WASM multi-case)
+  const mcCombinations: Array<{ name: string; factors: Record<string, number> }> = [];
+  const comboNameToId = new Map<string, number>();
+
+  for (const combo of combinations) {
+    const factors: Record<string, number> = {};
+    for (const f of combo.factors) {
+      const lc = loadCases.find(c => c.id === f.caseId);
+      if (lc) factors[lc.name] = f.factor;
+    }
+    // The per-case path skips combos whose factors all reference missing cases
+    // (combineResults → null); the engine would instead emit a zeroed combo that
+    // also enters the envelope. Skip here to keep perCombo/envelope identical.
+    if (Object.keys(factors).length === 0) continue;
+    mcCombinations.push({ name: combo.name, factors });
+    comboNameToId.set(combo.name, combo.id);
+  }
+
+  // Single WASM call: solves all cases, combines, computes envelope
+  try {
+    const t0 = performance.now();
+    const mcResult = solveMultiCase2D({
+      solver: baseInput,
+      loadCases: mcLoadCases,
+      combinations: mcCombinations,
+    });
+    const tWasm = performance.now() - t0;
+
+    if (!mcResult || !mcResult.caseResults || !mcResult.combinationResults || !mcResult.envelope) {
+      return t('svc.envelopeError');
+    }
+
+    // Map results back to id-keyed Maps
+    const perCase = new Map<number, AnalysisResults>();
+    for (const cr of mcResult.caseResults) {
+      const id = caseNameToId.get(cr.name);
+      if (id != null) perCase.set(id, cr.results);
+    }
+
+    const perCombo = new Map<number, AnalysisResults>();
+    for (const cr of mcResult.combinationResults) {
+      const id = comboNameToId.get(cr.name);
+      if (id != null) perCombo.set(id, cr.results);
+    }
+
+    console.log(`[solveCombinations2D] WASM multi-case: ${tWasm.toFixed(0)} ms | Cases: ${perCase.size} | Combos: ${perCombo.size}`);
+
+    return { perCase, perCombo, envelope: mcResult.envelope };
+  } catch (err: any) {
+    // Fallback: if multi-case fails (e.g. an unsolvable case), the per-case
+    // path reproduces the precise validation/kinematics error message.
+    // (The engine throws plain strings, so don't rely on err.message.)
+    console.warn('Multi-case 2D failed, falling back to per-case solve:', err?.message ?? String(err));
+    return solveCombinations2DFallback(model, loadCases, combinations, includeSelfWeight);
+  }
+}
+
+/** Fallback: solve cases individually (used when the model needs per-case
+ *  features — constraints/connectors/sliding joints — or when the multi-case
+ *  WASM call fails). */
+function solveCombinations2DFallback(
+  model: ModelData,
+  loadCases: LoadCase[],
+  combinations: LoadCombination[],
+  includeSelfWeight: boolean,
+): { perCase: Map<number, AnalysisResults>; perCombo: Map<number, AnalysisResults>; envelope: FullEnvelope } | string | null {
   const perCase = new Map<number, AnalysisResults>();
 
   for (const lc of loadCases) {
@@ -1588,8 +1697,10 @@ export async function solveCombinations3DParallel(
   const baseInput = buildSolverInput3D({ ...model, loads: [] }, false, leftHand);
   if (!baseInput) return t('svc.emptyModel');
 
-  // Serialize the base structure (shared across all cases)
-  const baseJson = JSON.parse(serializeInput3D(baseInput));
+  // Plain-object wire form of the base structure (shared across all cases).
+  // Built straight from the Maps — the old JSON.parse(serializeInput3D(...))
+  // round trip only served to obtain this object.
+  const baseWire = input3DToWireObject(baseInput);
 
   // Build per-case inputs
   const caseInputs: Array<{ caseId: number; caseName: string; json: string }> = [];
@@ -1598,7 +1709,7 @@ export async function solveCombinations3DParallel(
     const caseLoads = model.loads.filter(l => (l.data.caseId ?? 1) === lc.id);
     const loads = buildSolverLoads3D(model, caseLoads, includeSelfWeight && lc.type === 'D', leftHand);
     // Create full solver input JSON with this case's loads
-    const fullInput = { ...baseJson, loads };
+    const fullInput = { ...baseWire, loads };
     caseInputs.push({ caseId: lc.id, caseName: lc.name, json: JSON.stringify(fullInput) });
   }
 
@@ -1633,6 +1744,11 @@ export async function solveCombinations3DParallel(
     if (perCase.size === 0) return t('svc.noLoadsApplied');
 
     // Combine results for each combination (fast, on main thread)
+    // TODO(perf): batch the combine+envelope into one WASM call. Not possible
+    // today without an engine change: combine_results_3d is per-combo (each
+    // call re-serializes the referenced per-case results) and
+    // solve_multi_case_3d would re-solve the cases the workers just solved.
+    // Needs an engine-side batch export (e.g. combine_multi_3d) first.
     const t1 = performance.now();
     const perCombo = new Map<number, AnalysisResults3D>();
     for (const combo of combinations) {

--- a/web/src/lib/engine/solver-service.ts
+++ b/web/src/lib/engine/solver-service.ts
@@ -228,22 +228,16 @@ function buildSolverLoads2D(model: ModelData, loads: Load[], includeSelfWeight: 
 }
 
 /**
- * Full 2D solve with all pre-solve validations.
- * Returns AnalysisResults on success, an error string, or null.
- * Also returns the KinematicResult via the optional `onKinematic` callback.
+ * Model-level rejections the 2D solver cannot honor: disconnected nodes,
+ * zero-length elements, and 3D-only features (support types / z-coords).
+ * Returns the exact legacy error string, or null when the model passes.
+ * Shared by `validateAndSolve2D` and the multi-case batch path in
+ * `solveCombinations2D`, which must reject the same models the per-case path
+ * refuses instead of solving them silently. Also returns the connectivity set
+ * (elements + connectors + constraints) that the graph-connectivity check
+ * reuses downstream.
  */
-export function validateAndSolve2D(
-  model: ModelData,
-  includeSelfWeight = false,
-  onKinematic?: (k: KinematicResult | null) => void,
-): AnalysisResults | string | null {
-  if (model.nodes.size < 2 || model.elements.size < 1) {
-    return t('svc.needNodesAndElements');
-  }
-  if (model.supports.size < 1) {
-    return t('svc.needSupport');
-  }
-
+function preflightModel2D(model: ModelData): { error: string | null; connectedNodes: Set<number> } {
   // Constraints are stored in 3D semantics; the 2D solver speaks [ux, uz, ry].
   // Remap ONCE and use the result for both the connectivity preflight and the
   // wire, so the preflight only credits constraints that actually reach the
@@ -270,7 +264,7 @@ export function validateAndSolve2D(
   addConstraintConnectivity(connectedNodes, constraints2D);
   for (const nodeId of model.nodes.keys()) {
     if (!connectedNodes.has(nodeId)) {
-      return t('svc.disconnectedNode').replace('{n}', String(nodeId));
+      return { error: t('svc.disconnectedNode').replace('{n}', String(nodeId)), connectedNodes };
     }
   }
 
@@ -283,9 +277,9 @@ export function validateAndSolve2D(
       if (L2d < 1e-6) {
         const dz = Math.abs((nj.z ?? 0) - (ni.z ?? 0));
         if (dz > 1e-6) {
-          return t('svc.zeroLength2dButZ').replace('{n}', String(elem.id)).replace('{dz}', dz.toFixed(3));
+          return { error: t('svc.zeroLength2dButZ').replace('{n}', String(elem.id)).replace('{dz}', dz.toFixed(3)), connectedNodes };
         }
-        return t('svc.zeroLengthElement').replace('{n}', String(elem.id)).replace('{ni}', String(elem.nodeI)).replace('{nj}', String(elem.nodeJ));
+        return { error: t('svc.zeroLengthElement').replace('{n}', String(elem.id)).replace('{ni}', String(elem.nodeI)).replace('{nj}', String(elem.nodeJ)), connectedNodes };
       }
     }
   }
@@ -295,13 +289,39 @@ export function validateAndSolve2D(
     const types3D = new Set(['fixed3d', 'pinned3d', 'spring3d', 'rollerXZ', 'rollerXY', 'rollerYZ']);
     const sup3D = [...model.supports.values()].find(s => types3D.has(s.type));
     if (sup3D) {
-      return t('svc.model3dSupport').replace('{n}', sup3D.type);
+      return { error: t('svc.model3dSupport').replace('{n}', sup3D.type), connectedNodes };
     }
     const hasZCoords = [...model.nodes.values()].some(n => n.z !== undefined && Math.abs(n.z) > 1e-10);
     if (hasZCoords) {
-      return t('svc.model3dZCoords');
+      return { error: t('svc.model3dZCoords'), connectedNodes };
     }
   }
+
+  return { error: null, connectedNodes };
+}
+
+/**
+ * Full 2D solve with all pre-solve validations.
+ * Returns AnalysisResults on success, an error string, or null.
+ * Also returns the KinematicResult via the optional `onKinematic` callback.
+ */
+export function validateAndSolve2D(
+  model: ModelData,
+  includeSelfWeight = false,
+  onKinematic?: (k: KinematicResult | null) => void,
+): AnalysisResults | string | null {
+  if (model.nodes.size < 2 || model.elements.size < 1) {
+    return t('svc.needNodesAndElements');
+  }
+  if (model.supports.size < 1) {
+    return t('svc.needSupport');
+  }
+
+  const { error: preflightError, connectedNodes } = preflightModel2D(model);
+  if (preflightError) return preflightError;
+
+  // Constraints are stored in 3D semantics; the 2D solver speaks [ux, uz, ry].
+  const constraints2D = constraintsTo2D(model.constraints);
 
   // Count support DOFs for basic stability check
   const hasFrames = [...model.elements.values()].some(e => e.type === 'frame');
@@ -813,6 +833,14 @@ export function solveCombinations2D(
   if (model.supports.size < 1) return t('svc.needSupport');
   if (combinations.length === 0) return t('svc.needCombination');
 
+  // Same model-level rejections as the per-case path (disconnected nodes,
+  // zero-length elements, 3D support types, 3D z-coords) — the engine accepts
+  // these silently (a fixed3d restrains nothing in 2D; z is projected), so
+  // without the gate the batch path would succeed where the legacy path
+  // correctly refused.
+  const preflightError = preflightModel2D(model).error;
+  if (preflightError) return preflightError;
+
   // The engine's multi-case 2D solver rebuilds each case WITHOUT constraints
   // and connectors (load_cases.rs), and sliding joints expand into exactly
   // those primitives — models using them keep the per-case path so their
@@ -855,7 +883,10 @@ export function solveCombinations2D(
     const factors: Record<string, number> = {};
     for (const f of combo.factors) {
       const lc = loadCases.find(c => c.id === f.caseId);
-      if (lc) factors[lc.name] = f.factor;
+      // Accumulate, don't overwrite: the per-case path passes the raw factors
+      // array to combineResults, which SUMS duplicate references to the same
+      // case. A Record keyed by name would silently keep only the last entry.
+      if (lc) factors[lc.name] = (factors[lc.name] ?? 0) + f.factor;
     }
     // The per-case path skips combos whose factors all reference missing cases
     // (combineResults → null); the engine would instead emit a zeroed combo that
@@ -1423,7 +1454,7 @@ export function validateAndSolve3D(model: ModelData, includeSelfWeight = false, 
   addConstraintConnectivity(connectedNodes, model.constraints);
   for (const nodeId of model.nodes.keys()) {
     if (!connectedNodes.has(nodeId)) {
-      return t('svc.disconnectedNode').replace('{n}', String(nodeId));
+      return { error: t('svc.disconnectedNode').replace('{n}', String(nodeId)), connectedNodes };
     }
   }
 

--- a/web/src/lib/engine/solver-worker.ts
+++ b/web/src/lib/engine/solver-worker.ts
@@ -3,7 +3,7 @@
  * Each worker loads its own WASM instance and solves independently.
  *
  * Messages:
- *   { type: 'init', wasmBytes: ArrayBuffer }  → initialize WASM module
+ *   { type: 'init', wasmModule: WebAssembly.Module }  → initialize WASM (pre-compiled module, structured-cloned)
  *   { type: 'solve3d', id: number, json: string } → solve and return results
  */
 
@@ -21,8 +21,7 @@ self.onmessage = async (e: MessageEvent) => {
       initSync = wasm.initSync;
       solve_3d = wasm.solve_3d;
 
-      const module = new WebAssembly.Module(msg.wasmBytes);
-      initSync(module);
+      initSync({ module: msg.wasmModule });
       ready = true;
       self.postMessage({ type: 'ready' });
     } catch (err: any) {

--- a/web/src/lib/engine/wasm-solver.ts
+++ b/web/src/lib/engine/wasm-solver.ts
@@ -135,6 +135,24 @@ let wasmCheckBoltGroups: ((json: string) => string) | null = null;
 let wasmCheckWeldGroups: ((json: string) => string) | null = null;
 let wasmCheckSpreadFootings: ((json: string) => string) | null = null;
 
+let wasmBytesPromise: Promise<ArrayBuffer> | null = null;
+
+/** Fetch the WASM binary once. Shared between the main-thread init and the
+ *  worker pool so the bytes cross the network a single time. A failed fetch
+ *  is not cached — the next call retries. */
+export function getWasmBytes(): Promise<ArrayBuffer> {
+  if (!wasmBytesPromise) {
+    const wasmUrl = new URL('../wasm/dedaliano_engine_bg.wasm', import.meta.url);
+    wasmBytesPromise = fetch(wasmUrl)
+      .then(resp => {
+        if (!resp.ok) throw new Error(`Failed to fetch WASM binary: HTTP ${resp.status}`);
+        return resp.arrayBuffer();
+      })
+      .catch(err => { wasmBytesPromise = null; throw err; });
+  }
+  return wasmBytesPromise;
+}
+
 /** Initialize the WASM module. Call once at app startup. */
 export async function initSolver(): Promise<void> {
   if (wasmReady) return;
@@ -151,7 +169,7 @@ export async function initSolver(): Promise<void> {
       const wasmBytes = readFileSync(fileURLToPath(wasmUrl));
       wasm.initSync({ module: wasmBytes });
     } else {
-      await wasm.default();
+      await wasm.default(await getWasmBytes());
     }
     wasmSolve2d = wasm.solve_2d;
     wasmSolve3d = wasm.solve_3d;
@@ -310,9 +328,10 @@ function serializeInput2D(input: SolverInput): string {
   });
 }
 
-/** Serialize SolverInput3D (with Maps) to JSON string for WASM. */
-export function serializeInput3D(input: SolverInput3D): string {
-  return JSON.stringify({
+/** Convert SolverInput3D (with Maps) to the plain JSON-ready wire object,
+ *  without a string round trip. */
+export function input3DToWireObject(input: SolverInput3D): Record<string, any> {
+  return {
     nodes: mapToObj(input.nodes),
     materials: mapToObj(input.materials),
     sections: mapToObj(input.sections),
@@ -325,7 +344,12 @@ export function serializeInput3D(input: SolverInput3D): string {
     constraints: input.constraints ?? [],
     connectors: input.connectors ? mapToObj(input.connectors) : {},
     leftHand: input.leftHand ?? false,
-  });
+  };
+}
+
+/** Serialize SolverInput3D (with Maps) to JSON string for WASM. */
+export function serializeInput3D(input: SolverInput3D): string {
+  return JSON.stringify(input3DToWireObject(input));
 }
 
 // ─── Solver functions ───────────────────────────────────────────


### PR DESCRIPTION
- solver-service: solveCombinations2D now makes one solveMultiCase2D call (cases + combos + envelope) instead of per-case validate+analyze+solve round trips plus per-combo full-results re-serialization. Load mapping is byte-identical to the per-case path (shared buildSolverLoads2D). Models with constraints/connectors/sliding joints or duplicate case names keep the legacy per-case path (engine multi-case ignores those), and any multi-case failure falls back to reproduce the exact legacy error string.
- 3D parallel path: drop the JSON.parse(serializeInput3D()) double round trip (new input3DToWireObject). Batch combine+envelope needs an engine export — left a TODO(perf) with the exact shape needed.
- Worker pool: fetch the wasm binary once (shared cached promise), compile once on the main thread, structured-clone the WebAssembly.Module to each worker (was: fetch twice + byte copy + compile per worker).
- wasm build: drop --no-opt so wasm-pack runs wasm-opt — binary 4.22MB ->
  3.20MB (-24%); full suite passes with the optimized binary.

Tests: new solver-service-combos-2d.test.ts (7 tests — superposition math, batch/per-case parity, constraint + duplicate-name guards, error strings). Full web suite 2675 passed / 7 skipped; production build green.