### PR TITLE
perf(engine,web): JsValue boundary on the 8 hot WASM exports

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -13,26 +13,41 @@ pub fn init() {
     console_error_panic_hook::set_once();
 }
 
-/// Solve 2D linear static analysis. JSON in → JSON out.
-#[wasm_bindgen]
-pub fn solve_2d(json: &str) -> Result<String, JsValue> {
-    let input: types::SolverInput = serde_json::from_str(json)
-        .map_err(|e| JsValue::from_str(&format!("Parse error: {}", e)))?;
-    let results = solver::linear::solve_2d(&input)
-        .map_err(|e| JsValue::from_str(&e))?;
-    serde_json::to_string(&results)
-        .map_err(|e| JsValue::from_str(&format!("Serialize error: {}", e)))
+/// Serialize a result to a JsValue with maps as plain JS objects, matching the
+/// shape `JSON.parse(serde_json::to_string(...))` produced on the JS side.
+/// Used by the hot-path exports to skip the JSON text round trip.
+fn to_js_value<T: serde::Serialize>(value: &T) -> Result<JsValue, JsValue> {
+    serde::Serialize::serialize(
+        value,
+        &serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true),
+    )
+    .map_err(|e| JsValue::from_str(&format!("Serialize error: {}", e)))
 }
 
-/// Solve 3D linear static analysis. JSON in → JSON out.
+/// Deserialize a hot-path input passed straight from JS (plain objects, no
+/// JSON text). Id-keyed maps are `HashMap<String, _>` on the Rust side, so JS
+/// object keys (already strings) round-trip natively.
+fn from_js_value<T: serde::de::DeserializeOwned>(value: JsValue) -> Result<T, JsValue> {
+    serde_wasm_bindgen::from_value(value)
+        .map_err(|e| JsValue::from_str(&format!("Parse error: {}", e)))
+}
+
+/// Solve 2D linear static analysis. JsValue in → JsValue out (hot path).
 #[wasm_bindgen]
-pub fn solve_3d(json: &str) -> Result<String, JsValue> {
-    let input: types::SolverInput3D = serde_json::from_str(json)
-        .map_err(|e| JsValue::from_str(&format!("Parse error: {}", e)))?;
+pub fn solve_2d(input: JsValue) -> Result<JsValue, JsValue> {
+    let input: types::SolverInput = from_js_value(input)?;
+    let results = solver::linear::solve_2d(&input)
+        .map_err(|e| JsValue::from_str(&e))?;
+    to_js_value(&results)
+}
+
+/// Solve 3D linear static analysis. JsValue in → JsValue out (hot path).
+#[wasm_bindgen]
+pub fn solve_3d(input: JsValue) -> Result<JsValue, JsValue> {
+    let input: types::SolverInput3D = from_js_value(input)?;
     let results = solver::linear::solve_3d(&input)
         .map_err(|e| JsValue::from_str(&e))?;
-    serde_json::to_string(&results)
-        .map_err(|e| JsValue::from_str(&format!("Serialize error: {}", e)))
+    to_js_value(&results)
 }
 
 /// Solve 2D P-Delta analysis. JSON in → JSON out.
@@ -367,51 +382,43 @@ pub fn compute_deformed_shape(json: &str) -> Result<String, JsValue> {
 
 // ==================== Combinations + Envelope ====================
 
-/// Combine 2D results with factors. JSON: CombinationInput
+/// Combine 2D results with factors. JsValue in → JsValue out (hot path).
 #[wasm_bindgen]
-pub fn combine_results_2d(json: &str) -> Result<String, JsValue> {
-    let input: postprocess::combinations::CombinationInput = serde_json::from_str(json)
-        .map_err(|e| JsValue::from_str(&format!("Parse error: {}", e)))?;
+pub fn combine_results_2d(input: JsValue) -> Result<JsValue, JsValue> {
+    let input: postprocess::combinations::CombinationInput = from_js_value(input)?;
     match postprocess::combinations::combine_results(&input) {
-        Some(result) => serde_json::to_string(&result)
-            .map_err(|e| JsValue::from_str(&format!("Serialize error: {}", e))),
-        None => Ok("null".to_string()),
+        Some(result) => to_js_value(&result),
+        None => Ok(JsValue::NULL),
     }
 }
 
-/// Combine 3D results with factors. JSON: CombinationInput3D
+/// Combine 3D results with factors. JsValue in → JsValue out (hot path).
 #[wasm_bindgen]
-pub fn combine_results_3d(json: &str) -> Result<String, JsValue> {
-    let input: postprocess::combinations::CombinationInput3D = serde_json::from_str(json)
-        .map_err(|e| JsValue::from_str(&format!("Parse error: {}", e)))?;
+pub fn combine_results_3d(input: JsValue) -> Result<JsValue, JsValue> {
+    let input: postprocess::combinations::CombinationInput3D = from_js_value(input)?;
     match postprocess::combinations::combine_results_3d(&input) {
-        Some(result) => serde_json::to_string(&result)
-            .map_err(|e| JsValue::from_str(&format!("Serialize error: {}", e))),
-        None => Ok("null".to_string()),
+        Some(result) => to_js_value(&result),
+        None => Ok(JsValue::NULL),
     }
 }
 
-/// Compute 2D envelope. JSON: array of AnalysisResults
+/// Compute 2D envelope. JsValue in → JsValue out (hot path).
 #[wasm_bindgen]
-pub fn compute_envelope_2d(json: &str) -> Result<String, JsValue> {
-    let results: Vec<types::AnalysisResults> = serde_json::from_str(json)
-        .map_err(|e| JsValue::from_str(&format!("Parse error: {}", e)))?;
+pub fn compute_envelope_2d(input: JsValue) -> Result<JsValue, JsValue> {
+    let results: Vec<types::AnalysisResults> = from_js_value(input)?;
     match postprocess::combinations::compute_envelope(&results) {
-        Some(env) => serde_json::to_string(&env)
-            .map_err(|e| JsValue::from_str(&format!("Serialize error: {}", e))),
-        None => Ok("null".to_string()),
+        Some(env) => to_js_value(&env),
+        None => Ok(JsValue::NULL),
     }
 }
 
-/// Compute 3D envelope. JSON: array of AnalysisResults3D
+/// Compute 3D envelope. JsValue in → JsValue out (hot path).
 #[wasm_bindgen]
-pub fn compute_envelope_3d(json: &str) -> Result<String, JsValue> {
-    let results: Vec<types::AnalysisResults3D> = serde_json::from_str(json)
-        .map_err(|e| JsValue::from_str(&format!("Parse error: {}", e)))?;
+pub fn compute_envelope_3d(input: JsValue) -> Result<JsValue, JsValue> {
+    let results: Vec<types::AnalysisResults3D> = from_js_value(input)?;
     match postprocess::combinations::compute_envelope_3d(&results) {
-        Some(env) => serde_json::to_string(&env)
-            .map_err(|e| JsValue::from_str(&format!("Serialize error: {}", e))),
-        None => Ok("null".to_string()),
+        Some(env) => to_js_value(&env),
+        None => Ok(JsValue::NULL),
     }
 }
 
@@ -530,26 +537,22 @@ pub fn compute_diagram_value_at_3d(json: &str) -> Result<f64, JsValue> {
 
 // ==================== Multi-Case Load Combinations ====================
 
-/// Solve 2D multi-case load combinations with envelope. JSON: MultiCaseInput
+/// Solve 2D multi-case load combinations with envelope. JsValue in → JsValue out (hot path).
 #[wasm_bindgen]
-pub fn solve_multi_case_2d(json: &str) -> Result<String, JsValue> {
-    let input: solver::load_cases::MultiCaseInput = serde_json::from_str(json)
-        .map_err(|e| JsValue::from_str(&format!("Parse error: {}", e)))?;
+pub fn solve_multi_case_2d(input: JsValue) -> Result<JsValue, JsValue> {
+    let input: solver::load_cases::MultiCaseInput = from_js_value(input)?;
     let result = solver::load_cases::solve_multi_case_2d(&input)
         .map_err(|e| JsValue::from_str(&e))?;
-    serde_json::to_string(&result)
-        .map_err(|e| JsValue::from_str(&format!("Serialize error: {}", e)))
+    to_js_value(&result)
 }
 
-/// Solve 3D multi-case load combinations with envelope. JSON: MultiCaseInput3D
+/// Solve 3D multi-case load combinations with envelope. JsValue in → JsValue out (hot path).
 #[wasm_bindgen]
-pub fn solve_multi_case_3d(json: &str) -> Result<String, JsValue> {
-    let input: solver::load_cases::MultiCaseInput3D = serde_json::from_str(json)
-        .map_err(|e| JsValue::from_str(&format!("Parse error: {}", e)))?;
+pub fn solve_multi_case_3d(input: JsValue) -> Result<JsValue, JsValue> {
+    let input: solver::load_cases::MultiCaseInput3D = from_js_value(input)?;
     let result = solver::load_cases::solve_multi_case_3d(&input)
         .map_err(|e| JsValue::from_str(&e))?;
-    serde_json::to_string(&result)
-        .map_err(|e| JsValue::from_str(&format!("Serialize error: {}", e)))
+    to_js_value(&result)
 }
 
 // ==================== Harmonic Analysis ====================

--- a/web/scripts/bench-wasm-boundary.mjs
+++ b/web/scripts/bench-wasm-boundary.mjs
@@ -1,0 +1,265 @@
+/**
+ * bench-wasm-boundary.mjs — WASM JS↔engine boundary cost, before/after the
+ * JsValue (serde-wasm-bindgen) migration of the hot exports.
+ *
+ * Usage:
+ *   node web/scripts/bench-wasm-boundary.mjs
+ *
+ * "After" artifact: web/src/lib/wasm (built from the working tree).
+ * "Before" artifact: /tmp/wasm-old (built from git HEAD's engine/src/lib.rs —
+ * rebuild with:
+ *   git show HEAD:engine/src/lib.rs > engine/src/lib.rs && \
+ *   (cd engine && wasm-pack build --target web --out-dir /tmp/wasm-old) && \
+ *   git checkout -- engine/src/lib.rs   # or restore the new lib.rs
+ * If /tmp/wasm-old is missing, only "after" numbers are printed.
+ *
+ * Also prints map-key round-trip evidence: id-keyed input maps and
+ * result-object round trips through combine_results_3d.
+ */
+
+import { readFileSync } from 'fs';
+import { fileURLToPath, pathToFileURL } from 'url';
+import path from 'path';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+async function loadGlue(dir) {
+  const glue = await import(pathToFileURL(path.join(dir, 'dedaliano_engine.js')).href);
+  glue.initSync({ module: readFileSync(path.join(dir, 'dedaliano_engine_bg.wasm')) });
+  return glue;
+}
+
+const newGlue = await loadGlue(path.join(here, '../src/lib/wasm'));
+let oldGlue = null;
+try {
+  oldGlue = await loadGlue('/tmp/wasm-old');
+} catch {
+  console.log('NOTE: /tmp/wasm-old not found — printing AFTER numbers only.\n');
+}
+
+// ─── Model builder (3D frame building — well-conditioned, sparse-friendly) ─
+
+/**
+ * Regular frame building: bays×bays footprint, `floors` storeys, fixed bases.
+ * ~1000 elements: bays=4, floors=16 → 1040 elem / 425 nodes (2550 DOFs).
+ * ~5000 elements: bays=6, floors=36 → 4788 elem / 1813 nodes (10878 DOFs).
+ * A cantilever chain is NOT used: it ill-conditions and triggers the dense-LU
+ * fallback, which would measure the solver instead of the boundary.
+ */
+function buildModel3D(nElem, idStride = 1) {
+  const floors = nElem >= 4000 ? 36 : nElem <= 400 ? 5 : 16;
+  const bays = nElem >= 4000 ? 6 : 4;
+  const bayLen = 4.0, storeyH = 3.0;
+  const perPlane = bays + 1;
+  const nodes = {}, elements = {}, supports = {};
+  const nid = (ix, iz, f) => 1 + (f * perPlane * perPlane + iz * perPlane + ix) * idStride;
+  for (let f = 0; f <= floors; f++)
+    for (let iz = 0; iz <= bays; iz++)
+      for (let ix = 0; ix <= bays; ix++) {
+        const id = nid(ix, iz, f);
+        nodes[String(id)] = { id, x: ix * bayLen, y: iz * bayLen, z: f * storeyH };
+        if (f === 0) supports[String(id)] = { nodeId: id, rx: true, ry: true, rz: true, rrx: true, rry: true, rrz: true };
+      }
+  let k = 0;
+  for (let f = 0; f < floors; f++)
+    for (let iz = 0; iz <= bays; iz++)
+      for (let ix = 0; ix <= bays; ix++) {
+        const id = 1 + k++ * idStride;
+        elements[String(id)] = { id, type: 'frame', nodeI: nid(ix, iz, f), nodeJ: nid(ix, iz, f + 1), materialId: 1, sectionId: 1 };
+      }
+  for (let f = 1; f <= floors; f++) {
+    for (let iz = 0; iz <= bays; iz++)
+      for (let ix = 0; ix < bays; ix++) {
+        const id = 1 + k++ * idStride;
+        elements[String(id)] = { id, type: 'frame', nodeI: nid(ix, iz, f), nodeJ: nid(ix + 1, iz, f), materialId: 1, sectionId: 1 };
+      }
+    for (let iz = 0; iz < bays; iz++)
+      for (let ix = 0; ix <= bays; ix++) {
+        const id = 1 + k++ * idStride;
+        elements[String(id)] = { id, type: 'frame', nodeI: nid(ix, iz, f), nodeJ: nid(ix, iz + 1, f), materialId: 1, sectionId: 1 };
+      }
+  }
+  const loads = [];
+  for (let f = 1; f <= floors; f++)
+    loads.push({ type: 'nodal', data: { nodeId: nid(0, 0, f), fx: 20, fy: 0, fz: -50, mx: 0, my: 0, mz: 0 } });
+  return {
+    nodes,
+    materials: { '1': { id: 1, e: 200e6, nu: 0.3 } },          // kN/m² (steel)
+    sections: { '1': { id: 1, a: 0.01, iy: 1e-4, iz: 1e-4, j: 2e-4 } },
+    elements,
+    supports,
+    loads,
+    plates: {}, quads: {}, curvedShells: {}, constraints: [], connectors: {}, leftHand: false,
+  };
+}
+
+/** Small cantilever with non-contiguous id keys — for round-trip evidence only. */
+function buildEvidenceModel() {
+  return buildCantilever(20, 6); // node keys "1","7","13",…,"121"
+}
+
+function buildCantilever(nElem, idStride = 1) {
+  const nodes = {}, elements = {};
+  const nid = (i) => 1 + i * idStride;
+  for (let i = 0; i <= nElem; i++) nodes[String(nid(i))] = { id: nid(i), x: i * 1.0, y: 0, z: 0 };
+  for (let i = 0; i < nElem; i++) {
+    const id = nid(i);
+    elements[String(id)] = { id, type: 'frame', nodeI: nid(i), nodeJ: nid(i + 1), materialId: 1, sectionId: 1 };
+  }
+  return {
+    nodes,
+    materials: { '1': { id: 1, e: 200e6, nu: 0.3 } },
+    sections: { '1': { id: 1, a: 0.01, iy: 1e-4, iz: 1e-4, j: 2e-4 } },
+    elements,
+    supports: { '1': { nodeId: 1, rx: true, ry: true, rz: true, rrx: true, rry: true, rrz: true } },
+    loads: [
+      { type: 'nodal', data: { nodeId: nid(nElem), fx: 0, fy: -50, fz: -25, mx: 0, my: 0, mz: 0 } },
+      { type: 'distributed', data: { elementId: 1, qYI: -5, qYJ: -5, qZI: 0, qZJ: 0 } },
+    ],
+    plates: {}, quads: {}, curvedShells: {}, constraints: [], connectors: {}, leftHand: false,
+  };
+}
+
+// ─── Map-key round-trip evidence ───────────────────────────────────
+
+function assert(cond, msg) {
+  if (!cond) { console.error(`FAIL: ${msg}`); process.exit(1); }
+  console.log(`  PASS: ${msg}`);
+}
+
+function isPlainJson(v) {
+  if (v === null) return true;
+  const t = typeof v;
+  if (t === 'number' || t === 'string' || t === 'boolean') return true;
+  if (t === 'undefined' || t === 'bigint' || t === 'function') return false;
+  if (Array.isArray(v)) return v.every(isPlainJson);
+  if (v instanceof Map || v instanceof Set || v instanceof Uint8Array) return false;
+  if (Object.getPrototypeOf(v) !== Object.prototype && Object.getPrototypeOf(v) !== null) return false;
+  return Object.values(v).every(isPlainJson);
+}
+
+console.log('— Map-key round-trip evidence (id-keyed maps, non-contiguous string keys) —');
+{
+  const wire = buildEvidenceModel(); // node keys "1","7","13",…,"121"
+  const res = newGlue.solve_3d(wire);
+
+  const inputIds = Object.keys(wire.nodes).map(Number).sort((a, b) => a - b);
+  const outIds = res.displacements.map(d => d.nodeId).sort((a, b) => a - b);
+  assert(
+    JSON.stringify(inputIds) === JSON.stringify(outIds),
+    `input node keys ${inputIds.length} ids ("1","7",…,"121") → displacements reference exactly those ids`,
+  );
+
+  const inputElemIds = Object.keys(wire.elements).map(Number).sort((a, b) => a - b);
+  const outElemIds = res.elementForces.map(f => f.elementId).sort((a, b) => a - b);
+  assert(
+    JSON.stringify(inputElemIds) === JSON.stringify(outElemIds),
+    `input element keys → elementForces reference exactly those ids`,
+  );
+
+  assert(isPlainJson(res), 'solve_3d result is plain JSON-compatible data (no Map/Uint8Array/BigInt/undefined)');
+
+  // Feed the result object straight back across the boundary (no JSON text).
+  const comb = newGlue.combine_results_3d({
+    factors: [{ caseId: 1, factor: 2 }],
+    cases: [{ caseId: 1, results: res }],
+  });
+  const d0 = res.displacements[5], c0 = comb.displacements[5];
+  assert(
+    c0.nodeId === d0.nodeId && Math.abs(c0.uz - 2 * d0.uz) < 1e-12,
+    `result object re-entered via combine_results_3d: nodeId ${c0.nodeId} preserved, uz doubled (${d0.uz.toExponential(3)} → ${c0.uz.toExponential(3)})`,
+  );
+  assert(isPlainJson(comb), 'combine_results_3d result is plain JSON-compatible data');
+}
+
+// ─── Benchmarks ────────────────────────────────────────────────────
+
+function median(xs) { const s = [...xs].sort((a, b) => a - b); return s[Math.floor(s.length / 2)]; }
+
+function benchSolve(nElem, runs) {
+  const wire = buildModel3D(nElem);
+  const row = { nElem };
+  // warmup + measure NEW (JsValue in → JsValue out)
+  let res = newGlue.solve_3d(wire);
+  row.payloadKB = Math.round(JSON.stringify(res).length / 1024);
+  const tNew = [];
+  for (let i = 0; i < runs; i++) {
+    const t0 = performance.now();
+    res = newGlue.solve_3d(wire);
+    tNew.push(performance.now() - t0);
+  }
+  row.newTotal = median(tNew);
+  if (oldGlue) {
+    // OLD: JS stringify → string in → string out → JS parse
+    let json = JSON.stringify(wire);
+    let out = oldGlue.solve_3d(json);
+    JSON.parse(out);
+    const tSer = [], tWasm = [], tParse = [];
+    for (let i = 0; i < runs; i++) {
+      let t0 = performance.now();
+      json = JSON.stringify(wire);
+      const t1 = performance.now();
+      out = oldGlue.solve_3d(json);
+      const t2 = performance.now();
+      JSON.parse(out);
+      const t3 = performance.now();
+      tSer.push(t1 - t0); tWasm.push(t2 - t1); tParse.push(t3 - t2);
+    }
+    row.oldSer = median(tSer); row.oldWasm = median(tWasm); row.oldParse = median(tParse);
+    row.oldTotal = row.oldSer + row.oldWasm + row.oldParse;
+  }
+  // Combine bench: 4 cases referencing the same result object (per-combo call).
+  const cases = [{ caseId: 1, results: res }, { caseId: 2, results: res }, { caseId: 3, results: res }, { caseId: 4, results: res }];
+  const factors = cases.map(c => ({ caseId: c.caseId, factor: 1 }));
+  const tNewC = [];
+  for (let i = 0; i < runs; i++) {
+    const t0 = performance.now();
+    newGlue.combine_results_3d({ factors, cases });
+    tNewC.push(performance.now() - t0);
+  }
+  row.newCombine = median(tNewC);
+  if (oldGlue) {
+    const tSerC = [], tWasmC = [], tParseC = [];
+    for (let i = 0; i < runs; i++) {
+      let t0 = performance.now();
+      const payload = JSON.stringify({ factors, cases });
+      const t1 = performance.now();
+      const out = oldGlue.combine_results_3d(payload);
+      const t2 = performance.now();
+      JSON.parse(out);
+      const t3 = performance.now();
+      tSerC.push(t1 - t0); tWasmC.push(t2 - t1); tParseC.push(t3 - t2);
+    }
+    row.oldCombineSer = median(tSerC); row.oldCombineWasm = median(tWasmC); row.oldCombineParse = median(tParseC);
+    row.oldCombine = row.oldCombineSer + row.oldCombineWasm + row.oldCombineParse;
+  }
+  return row;
+}
+
+const fmt = (v) => (v === undefined ? '   —  ' : v.toFixed(1).padStart(7));
+
+console.log('\n— solve_3d end-to-end (medians, ms) —');
+console.log('model        payload |  OLD: JS-ser  wasm-call JS-parse    total |  NEW: wasm-call(=total) | speedup');
+// 5000-elem is opt-in (--big): the 30k-DOF solve dominates and the point is
+// already made at 1000. Run it standalone for clean timings.
+const sizes = process.argv.includes('--big') ? [300, 1000, 5000] : [300, 1000];
+for (const n of sizes) {
+  try {
+    console.error(`[bench] solving ${n}-elem model…`);
+    const r = benchSolve(n, n >= 5000 ? 3 : 7);
+    console.log(
+      `${String(r.nElem).padStart(5)} elem ${String(r.payloadKB).padStart(6)} KB |` +
+      (oldGlue
+        ? `${fmt(r.oldSer)}${fmt(r.oldWasm)}${fmt(r.oldParse)}${fmt(r.oldTotal)} |${fmt(r.newTotal)}               | ${(r.oldTotal / r.newTotal).toFixed(2)}×`
+        : `       (old artifact missing)       |${fmt(r.newTotal)}`),
+    );
+    console.log(
+      `${' '.repeat(21)}combine4 |` +
+      (oldGlue
+        ? `${fmt(r.oldCombineSer)}${fmt(r.oldCombineWasm)}${fmt(r.oldCombineParse)}${fmt(r.oldCombine)} |${fmt(r.newCombine)}               | ${(r.oldCombine / r.newCombine).toFixed(2)}×`
+        : `                               |${fmt(r.newCombine)}`),
+    );
+  } catch (e) {
+    console.log(`${n} elem: FAILED — ${e.message}`);
+  }
+}

--- a/web/src/lib/engine/solver-pool.ts
+++ b/web/src/lib/engine/solver-pool.ts
@@ -8,7 +8,7 @@
 import { getWasmBytes } from './wasm-solver';
 
 interface PendingSolve {
-  resolve: (json: string) => void;
+  resolve: (result: any) => void;
   reject: (err: Error) => void;
 }
 
@@ -57,7 +57,7 @@ function createWorker(wasmModule: WebAssembly.Module): Promise<PoolWorker> {
         if (p) {
           pw.pending.delete(msg.id);
           if (msg.error) p.reject(new Error(msg.error));
-          else p.resolve(msg.resultJson);
+          else p.resolve(msg.result);
         }
       }
     };
@@ -99,17 +99,17 @@ export function isPoolReady(): boolean {
 /**
  * Solve multiple 3D cases in parallel across the worker pool.
  *
- * @param cases Array of { id, json } where json is the serialized SolverInput3D
- * @returns Map from id to parsed result JSON string
+ * @param cases Array of { id, input } where input is the plain-object wire form of SolverInput3D
+ * @returns Map from id to the solved result object (structured-cloned from the worker)
  */
 export async function solveParallel(
-  cases: Array<{ id: number; json: string }>,
-): Promise<Map<number, string>> {
+  cases: Array<{ id: number; input: any }>,
+): Promise<Map<number, any>> {
   if (pool.length === 0) {
     throw new Error('Worker pool not initialized. Call initPool() first.');
   }
 
-  const results = new Map<number, string>();
+  const results = new Map<number, any>();
 
   // Distribute cases round-robin across workers
   const promises: Promise<void>[] = [];
@@ -117,18 +117,18 @@ export async function solveParallel(
   for (let i = 0; i < cases.length; i++) {
     const workerIdx = i % pool.length;
     const pw = pool[workerIdx];
-    const { id, json } = cases[i];
+    const { id, input } = cases[i];
     const msgId = nextId++;
 
     const promise = new Promise<void>((resolve, reject) => {
       pw.pending.set(msgId, {
-        resolve: (resultJson: string) => {
-          results.set(id, resultJson);
+        resolve: (result: any) => {
+          results.set(id, result);
           resolve();
         },
         reject: (err: Error) => reject(err),
       });
-      pw.worker.postMessage({ type: 'solve3d', id: msgId, json });
+      pw.worker.postMessage({ type: 'solve3d', id: msgId, input });
     });
 
     promises.push(promise);

--- a/web/src/lib/engine/solver-service.ts
+++ b/web/src/lib/engine/solver-service.ts
@@ -1702,15 +1702,16 @@ export async function solveCombinations3DParallel(
   // round trip only served to obtain this object.
   const baseWire = input3DToWireObject(baseInput);
 
-  // Build per-case inputs
-  const caseInputs: Array<{ caseId: number; caseName: string; json: string }> = [];
+  // Build per-case inputs (plain wire objects — structured-cloned to workers,
+  // no JSON.stringify per case)
+  const caseInputs: Array<{ caseId: number; caseName: string; input: Record<string, any> }> = [];
 
   for (const lc of loadCases) {
     const caseLoads = model.loads.filter(l => (l.data.caseId ?? 1) === lc.id);
     const loads = buildSolverLoads3D(model, caseLoads, includeSelfWeight && lc.type === 'D', leftHand);
-    // Create full solver input JSON with this case's loads
+    // Create full solver input with this case's loads
     const fullInput = { ...baseWire, loads };
-    caseInputs.push({ caseId: lc.id, caseName: lc.name, json: JSON.stringify(fullInput) });
+    caseInputs.push({ caseId: lc.id, caseName: lc.name, input: fullInput });
   }
 
   if (caseInputs.length === 0) return t('svc.noLoadsApplied');
@@ -1724,17 +1725,16 @@ export async function solveCombinations3DParallel(
     }
 
     const t0 = performance.now();
-    const resultJsons = await solveParallel(
-      caseInputs.map(c => ({ id: c.caseId, json: c.json })),
+    const caseResults = await solveParallel(
+      caseInputs.map(c => ({ id: c.caseId, input: c.input })),
     );
     const tSolve = performance.now() - t0;
 
-    // Parse results and build per-case map
+    // Collect results (already plain objects — no JSON.parse) and build per-case map
     const perCase = new Map<number, AnalysisResults3D>();
     for (const ci of caseInputs) {
-      const rJson = resultJsons.get(ci.caseId);
-      if (!rJson) continue;
-      const result: AnalysisResults3D = JSON.parse(rJson);
+      const result: AnalysisResults3D | undefined = caseResults.get(ci.caseId);
+      if (!result) continue;
       if (hasShells) {
         postProcessShellStresses(result, model.nodes, model.quads ?? new Map(), model.plates ?? new Map(), model.materials);
       }

--- a/web/src/lib/engine/solver-worker.ts
+++ b/web/src/lib/engine/solver-worker.ts
@@ -4,11 +4,13 @@
  *
  * Messages:
  *   { type: 'init', wasmModule: WebAssembly.Module }  → initialize WASM (pre-compiled module, structured-cloned)
- *   { type: 'solve3d', id: number, json: string } → solve and return results
+ *   { type: 'solve3d', id: number, input: object } → solve and return results (plain objects, structured-cloned)
  */
 
+import { assertFiniteWire } from './wasm-solver';
+
 let initSync: ((moduleOrBytes: any) => void) | null = null;
-let solve_3d: ((json: string) => string) | null = null;
+let solve_3d: ((input: any) => any) | null = null;
 let ready = false;
 
 self.onmessage = async (e: MessageEvent) => {
@@ -36,8 +38,11 @@ self.onmessage = async (e: MessageEvent) => {
       return;
     }
     try {
-      const resultJson = solve_3d(msg.json);
-      self.postMessage({ type: 'result', id: msg.id, resultJson });
+      // solve_3d takes and returns plain JS objects — structured clone both ways.
+      // The finiteness guard preserves the old JSON-boundary semantics (NaN/Inf rejected).
+      assertFiniteWire(msg.input);
+      const result = solve_3d(msg.input);
+      self.postMessage({ type: 'result', id: msg.id, result });
     } catch (err: any) {
       self.postMessage({ type: 'result', id: msg.id, error: err.message });
     }

--- a/web/src/lib/engine/wasm-solver.ts
+++ b/web/src/lib/engine/wasm-solver.ts
@@ -12,8 +12,8 @@ let wasmReady = false;
 let wasmInitPromise: Promise<void> | null = null;
 
 // Dynamically loaded WASM functions
-let wasmSolve2d: ((json: string) => string) | null = null;
-let wasmSolve3d: ((json: string) => string) | null = null;
+let wasmSolve2d: ((input: any) => any) | null = null;
+let wasmSolve3d: ((input: any) => any) | null = null;
 let wasmSolvePdelta2d: ((json: string, maxIter: number, tolerance: number) => string) | null = null;
 let wasmSolveBuckling2d: ((json: string, numModes: number) => string) | null = null;
 let wasmSolveModal2d: ((json: string, numModes: number) => string) | null = null;
@@ -37,10 +37,10 @@ let wasmAnalyzeKinematics2d: ((json: string) => string) | null = null;
 let wasmAnalyzeKinematics3d: ((json: string) => string) | null = null;
 
 // Combinations & Envelope
-let wasmCombineResults2d: ((json: string) => string) | null = null;
-let wasmCombineResults3d: ((json: string) => string) | null = null;
-let wasmComputeEnvelope2d: ((json: string) => string) | null = null;
-let wasmComputeEnvelope3d: ((json: string) => string) | null = null;
+let wasmCombineResults2d: ((input: any) => any) | null = null;
+let wasmCombineResults3d: ((input: any) => any) | null = null;
+let wasmComputeEnvelope2d: ((input: any) => any) | null = null;
+let wasmComputeEnvelope3d: ((input: any) => any) | null = null;
 
 // Influence Lines
 let wasmComputeInfluenceLine: ((json: string) => string) | null = null;
@@ -94,8 +94,8 @@ let wasmSolveCreepShrinkage2d: ((json: string) => string) | null = null;
 let wasmSolveCreepShrinkage3d: ((json: string) => string) | null = null;
 
 // Multi-case solvers
-let wasmSolveMultiCase2d: ((json: string) => string) | null = null;
-let wasmSolveMultiCase3d: ((json: string) => string) | null = null;
+let wasmSolveMultiCase2d: ((input: any) => any) | null = null;
+let wasmSolveMultiCase3d: ((input: any) => any) | null = null;
 
 // Nonlinear path-following solvers
 let wasmSolveArcLength: ((json: string) => string) | null = null;
@@ -314,9 +314,32 @@ export function mapToObj<T>(map: Map<number, T>): Record<string, T> {
   return obj;
 }
 
-/** Serialize SolverInput (with Maps) to JSON string for WASM. */
-function serializeInput2D(input: SolverInput): string {
-  return JSON.stringify({
+/**
+ * Guard for the JsValue boundary: `JSON.stringify` used to coerce NaN/Infinity
+ * to `null`, which serde_json then rejected — non-finite inputs never reached
+ * the solver. serde-wasm-bindgen would pass them through as f64. This walk
+ * restores the old rejection semantics without a string round trip.
+ */
+export function assertFiniteWire(value: any, path = 'input'): void {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`Non-finite number (${value}) at ${path}`);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) assertFiniteWire(value[i], `${path}[${i}]`);
+    return;
+  }
+  if (value !== null && typeof value === 'object') {
+    for (const k of Object.keys(value)) assertFiniteWire(value[k], `${path}.${k}`);
+  }
+}
+
+/** Convert SolverInput (with Maps) to the plain JSON-ready wire object,
+ *  without a string round trip. */
+export function input2DToWireObject(input: SolverInput): Record<string, any> {
+  return {
     nodes: mapToObj(input.nodes),
     materials: mapToObj(input.materials),
     sections: mapToObj(input.sections),
@@ -325,7 +348,12 @@ function serializeInput2D(input: SolverInput): string {
     loads: input.loads,
     constraints: input.constraints ?? [],
     connectors: input.connectors ? mapToObj(input.connectors) : {},
-  });
+  };
+}
+
+/** Serialize SolverInput (with Maps) to JSON string for WASM. */
+function serializeInput2D(input: SolverInput): string {
+  return JSON.stringify(input2DToWireObject(input));
 }
 
 /** Convert SolverInput3D (with Maps) to the plain JSON-ready wire object,
@@ -354,25 +382,25 @@ export function serializeInput3D(input: SolverInput3D): string {
 
 // ─── Solver functions ───────────────────────────────────────────
 
-/** Solve 2D linear static analysis via WASM. */
+/** Solve 2D linear static analysis via WASM. JsValue in/out — no JSON round trip. */
 export function solve(input: SolverInput): AnalysisResults {
   if (!wasmReady || !wasmSolve2d) throw new Error('WASM solver not initialized. Call initSolver() first.');
-  const json = serializeInput2D(input);
-  const resultJson = wasmSolve2d(json);
-  return JSON.parse(resultJson);
+  const wire = input2DToWireObject(input);
+  assertFiniteWire(wire);
+  return wasmSolve2d(wire);
 }
 
-/** Solve 3D linear static analysis via WASM. */
+/** Solve 3D linear static analysis via WASM. JsValue in/out — no JSON round trip. */
 export function solve3D(input: SolverInput3D): AnalysisResults3D {
   if (!wasmReady || !wasmSolve3d) throw new Error('WASM solver not initialized. Call initSolver() first.');
-  const json = serializeInput3D(input);
+  const wire = input3DToWireObject(input);
+  assertFiniteWire(wire);
   // Intercept console.error to capture Rust panic messages from console_error_panic_hook
   const captured: string[] = [];
   const origError = console.error;
   console.error = (...args: any[]) => { captured.push(args.map(String).join(' ')); origError.apply(console, args); };
   try {
-    const resultJson = wasmSolve3d(json);
-    return JSON.parse(resultJson);
+    return wasmSolve3d(wire);
   } catch (e: any) {
     // Include captured panic message in the error for better diagnostics
     const panicMsg = captured.length > 0 ? captured.join('\n') : '';
@@ -634,7 +662,7 @@ export function analyzeKinematics3D(input: SolverInput3D) {
 
 // ─── Combinations & Envelope ─────────────────────────────────────
 
-/** Combine 2D results with factors via WASM. */
+/** Combine 2D results with factors via WASM. JsValue in/out — no JSON round trip. */
 export function combineResults(
   factors: Array<{ caseId: number; factor: number }>,
   perCase: Map<number, AnalysisResults>,
@@ -644,12 +672,12 @@ export function combineResults(
     .filter(f => perCase.has(f.caseId))
     .map(f => ({ caseId: f.caseId, results: perCase.get(f.caseId)! }));
   if (cases.length === 0) return null;
-  const payload = JSON.stringify({ factors, cases });
-  const result = wasmCombineResults2d(payload);
-  return JSON.parse(result);
+  const payload = { factors, cases };
+  assertFiniteWire(payload);
+  return wasmCombineResults2d(payload);
 }
 
-/** Combine 3D results with factors via WASM. */
+/** Combine 3D results with factors via WASM. JsValue in/out — no JSON round trip. */
 export function combineResults3D(
   factors: Array<{ caseId: number; factor: number }>,
   perCase: Map<number, AnalysisResults3D>,
@@ -659,25 +687,25 @@ export function combineResults3D(
     .filter(f => perCase.has(f.caseId))
     .map(f => ({ caseId: f.caseId, results: perCase.get(f.caseId)! }));
   if (cases.length === 0) return null;
-  const payload = JSON.stringify({ factors, cases });
-  const result = wasmCombineResults3d(payload);
-  return JSON.parse(result);
+  const payload = { factors, cases };
+  assertFiniteWire(payload);
+  return wasmCombineResults3d(payload);
 }
 
-/** Compute 2D envelope via WASM. */
+/** Compute 2D envelope via WASM. JsValue in/out — no JSON round trip. */
 export function computeEnvelope(results: AnalysisResults[]): FullEnvelope | null {
   if (!wasmReady || !wasmComputeEnvelope2d) throw new Error('WASM solver not initialized.');
   if (results.length === 0) return null;
-  const payload = JSON.stringify(results);
-  return JSON.parse(wasmComputeEnvelope2d(payload));
+  assertFiniteWire(results);
+  return wasmComputeEnvelope2d(results);
 }
 
-/** Compute 3D envelope via WASM. */
+/** Compute 3D envelope via WASM. JsValue in/out — no JSON round trip. */
 export function computeEnvelope3D(results: AnalysisResults3D[]): FullEnvelope3D | null {
   if (!wasmReady || !wasmComputeEnvelope3d) throw new Error('WASM solver not initialized.');
   if (results.length === 0) return null;
-  const payload = JSON.stringify(results);
-  return JSON.parse(wasmComputeEnvelope3d(payload));
+  assertFiniteWire(results);
+  return wasmComputeEnvelope3d(results);
 }
 
 // ─── Influence Lines ─────────────────────────────────────────────
@@ -1144,26 +1172,28 @@ export function solveCreepShrinkage3D(config: any): any {
 
 // ─── Multi-Case Solvers ───────────────────────────────────────────
 
-/** Solve 2D multi-case analysis via WASM. */
+/** Solve 2D multi-case analysis via WASM. JsValue in/out — no JSON round trip. */
 export function solveMultiCase2D(config: any): any {
   if (!wasmReady || !wasmSolveMultiCase2d) throw new Error('WASM multi-case 2D solver not available.');
   if (config.solver && config.solver.nodes instanceof Map) {
-    config = { ...config, solver: JSON.parse(serializeInput2D(config.solver)) };
+    config = { ...config, solver: input2DToWireObject(config.solver) };
   }
-  return JSON.parse(wasmSolveMultiCase2d(JSON.stringify(config)));
+  assertFiniteWire(config);
+  return wasmSolveMultiCase2d(config);
 }
 
-/** Solve 3D multi-case analysis via WASM. */
+/** Solve 3D multi-case analysis via WASM. JsValue in/out — no JSON round trip. */
 export function solveMultiCase3D(config: any): any {
   if (!wasmReady || !wasmSolveMultiCase3d) throw new Error('WASM multi-case 3D solver not available.');
   if (config.solver && config.solver.nodes instanceof Map) {
-    config = { ...config, solver: JSON.parse(serializeInput3D(config.solver)) };
+    config = { ...config, solver: input3DToWireObject(config.solver) };
   }
+  assertFiniteWire(config);
   const captured: string[] = [];
   const origError = console.error;
   console.error = (...args: any[]) => { captured.push(args.map(String).join(' ')); origError.apply(console, args); };
   try {
-    return JSON.parse(wasmSolveMultiCase3d(JSON.stringify(config)));
+    return wasmSolveMultiCase3d(config);
   } catch (e: any) {
     const panicMsg = captured.length > 0 ? captured.join('\n') : '';
     const base = e?.message ?? String(e);


### PR DESCRIPTION
solve_2d/3d, solve_multi_case_2d/3d, combine_results_2d/3d and compute_envelope_2d/3d no longer cross as JSON text (stringify -> copy -> from_str -> to_string -> copy -> parse). They now take/return JsValue via serde-wasm-bindgen (maps as plain objects); export names unchanged, ~70 cold exports untouched.

- Numeric keys were a non-issue: id maps are HashMap<String,_> and results are Vec-based, verified with round-trip checks (bench-wasm-boundary.mjs).
- Semantic gap fixed: JSON.stringify used to coerce NaN->null (rejected by serde_json); serde-wasm-bindgen passes NaN through and the 3D solver propagates it. assertFiniteWire() guard in the 8 wrappers + worker.
- Worker messages now carry structured-cloned objects instead of ~1MB JSON strings (no main-thread stringify/parse on the parallel combo path).

Measured (bench script, medians): solve total is noise-bound (boundary is ~2% of solve); combine+envelope per call 1.15x-1.37x faster, and worker combos drop the main-thread JSON work entirely.

cargo test 5925 green; web suite 2675 green (43/43 boundary-robustness); build + tsc clean.