### PR TITLE
fix(engine): Rc-wrap symbolic at the 2D sparse factorization (main co…

### DIFF
--- a/engine/src/solver/linear.rs
+++ b/engine/src/solver/linear.rs
@@ -342,7 +342,7 @@ fn prepare_static_2d_impl(input: &SolverInput, force_dense: bool) -> Result<Prep
         // the ORIGINAL K_ff below, which reports "Singular stiffness matrix"
         // for mechanisms exactly as before. (The 3D path keeps its shift
         // ladder — shell drilling DOFs need it.)
-        let sym = symbolic_cholesky(&stiff.k_ff);
+        let sym = std::rc::Rc::new(symbolic_cholesky(&stiff.k_ff));
         let num = numeric_cholesky(&sym, &stiff.k_ff)
             .map(|num| (num, false, 0.0));
 


### PR DESCRIPTION
…mpile break)

The sequential merges of #72 (2D sparse routing, calling numeric_cholesky with a plain SymbolicCholesky) and #74 (NumericCholesky now takes Rc<SymbolicCholesky>) were textually clean but left main not compiling at engine/src/solver/linear.rs:346. One-line Rc wrap. Full suite 6839/0.