### PR TITLE
fix(web): PR #76 review follow-ups — worker error propagation, guard/boundary tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ It should capture what changed, not what should be built next.
 
 ## Unreleased
 
+### Performance
+
+#### JsValue boundary on the 8 hot WASM exports (2026-07-24)
+
+- `solve_2d`/`solve_3d`, `combine_results_2d`/`3d`, `compute_envelope_2d`/`3d`, and `solve_multi_case_2d`/`3d` now cross the JS↔WASM boundary as `JsValue` (serde-wasm-bindgen, maps as plain objects) instead of JSON text — no `stringify`/`parse` round trip on the hot path. Export names unchanged; ~70 cold exports untouched.
+- Worker pool messages carry structured-cloned plain objects instead of ~1MB JSON strings, removing main-thread JSON work from the parallel 3D combinations path.
+- `assertFiniteWire` guard preserves the old boundary semantics: NaN/Infinity inputs are rejected before reaching the solver (JSON.stringify used to coerce them to `null`, which serde_json rejected).
+- New `web/scripts/bench-wasm-boundary.mjs` benchmark (`npm run bench:wasm-boundary`): combine+envelope per call 1.15–2.1× faster; single-solve total is noise-bound (boundary is ~2% of solve).
+
 ### Fixed
 
 #### Hinge/release correctness cleanup (2026-04-26)

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "wasm": "cd ../engine && wasm-pack build --target web --out-dir ../web/src/lib/wasm --no-opt",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "bench:wasm-boundary": "node scripts/bench-wasm-boundary.mjs"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^5.0.3",

--- a/web/src/lib/engine/__tests__/assert-finite-wire.test.ts
+++ b/web/src/lib/engine/__tests__/assert-finite-wire.test.ts
@@ -1,0 +1,69 @@
+/**
+ * assertFiniteWire unit tests — the JsValue boundary guard.
+ *
+ * The 8 hot WASM exports used to receive JSON text: JSON.stringify coerced
+ * NaN/Infinity to null and serde_json rejected them. serde-wasm-bindgen would
+ * pass non-finite numbers straight through as f64. This guard restores the
+ * old rejection semantics without a string round trip.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { assertFiniteWire } from '../wasm-solver';
+
+describe('assertFiniteWire', () => {
+  describe('accepts finite values', () => {
+    it('scalars and empty containers', () => {
+      expect(() => assertFiniteWire(null)).not.toThrow();
+      expect(() => assertFiniteWire(0)).not.toThrow();
+      expect(() => assertFiniteWire(-0)).not.toThrow();
+      expect(() => assertFiniteWire(1e300)).not.toThrow();
+      expect(() => assertFiniteWire(-1e300)).not.toThrow();
+      expect(() => assertFiniteWire('NaN')).not.toThrow(); // strings are not numbers
+      expect(() => assertFiniteWire(true)).not.toThrow();
+      expect(() => assertFiniteWire(undefined)).not.toThrow();
+      expect(() => assertFiniteWire([])).not.toThrow();
+      expect(() => assertFiniteWire({})).not.toThrow();
+    });
+
+    it('nested plain structures (wire-object shape)', () => {
+      const wire = {
+        nodes: { '1': { id: 1, x: 0, y: 0, z: 0 }, '7': { id: 7, x: 5, y: 0, z: 0 } },
+        materials: { '1': { id: 1, e: 200e6, nu: 0.3 } },
+        loads: [{ type: 'nodal', data: { nodeId: 7, fx: 0, fy: 0, fz: -10 } }],
+        constraints: [],
+        leftHand: false,
+      };
+      expect(() => assertFiniteWire(wire)).not.toThrow();
+    });
+  });
+
+  describe('rejects non-finite numbers', () => {
+    it('NaN at top level', () => {
+      expect(() => assertFiniteWire(NaN)).toThrow(/Non-finite number \(NaN\) at input$/);
+    });
+
+    it('Infinity / -Infinity at top level', () => {
+      expect(() => assertFiniteWire(Infinity)).toThrow(/Non-finite number \(Infinity\) at input$/);
+      expect(() => assertFiniteWire(-Infinity)).toThrow(/Non-finite number \(-Infinity\) at input$/);
+    });
+
+    it('NaN nested in an object reports the key path', () => {
+      expect(() => assertFiniteWire({ nodes: { '1': { x: NaN } } }))
+        .toThrow(/Non-finite number \(NaN\) at input\.nodes\.1\.x$/);
+    });
+
+    it('Infinity nested in an array reports the index path', () => {
+      expect(() => assertFiniteWire({ loads: [{ data: { fz: -10 } }, { data: { fz: Infinity } }] }))
+        .toThrow(/Non-finite number \(Infinity\) at input\.loads\[1\]\.data\.fz$/);
+    });
+
+    it('respects a custom root path', () => {
+      expect(() => assertFiniteWire({ a: NaN }, 'payload'))
+        .toThrow(/Non-finite number \(NaN\) at payload\.a$/);
+    });
+
+    it('fails fast on the first non-finite value', () => {
+      expect(() => assertFiniteWire([NaN, Infinity])).toThrow(/at input\[0\]$/);
+    });
+  });
+});

--- a/web/src/lib/engine/__tests__/solver-worker-roundtrip.test.ts
+++ b/web/src/lib/engine/__tests__/solver-worker-roundtrip.test.ts
@@ -1,0 +1,102 @@
+/**
+ * solver-worker message round-trip — smoke test for the structured-clone
+ * boundary introduced by the JsValue migration.
+ *
+ * The worker now receives plain objects (no JSON text), runs the finiteness
+ * guard, and returns plain objects. This wires the real worker module to a
+ * stubbed `self`, initializes it with the real WASM build, and checks the
+ * init → solve3d → result flow plus the NaN rejection path.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+interface PostedMessage {
+  type: string;
+  id?: number;
+  result?: any;
+  error?: string;
+  message?: string;
+}
+
+function cantileverWire(): Record<string, any> {
+  return {
+    nodes: { '1': { id: 1, x: 0, y: 0, z: 0 }, '2': { id: 2, x: 5, y: 0, z: 0 } },
+    materials: { '1': { id: 1, e: 200e6, nu: 0.3 } },
+    sections: { '1': { id: 1, a: 0.01, iy: 1e-4, iz: 1e-4, j: 2e-4 } },
+    elements: { '1': { id: 1, type: 'frame', nodeI: 1, nodeJ: 2, materialId: 1, sectionId: 1 } },
+    supports: { '1': { nodeId: 1, rx: true, ry: true, rz: true, rrx: true, rry: true, rrz: true } },
+    loads: [{ type: 'nodal', data: { nodeId: 2, fx: 0, fy: 0, fz: -10, mx: 0, my: 0, mz: 0 } }],
+    plates: {}, quads: {}, curvedShells: {}, constraints: [], connectors: {}, leftHand: false,
+  };
+}
+
+describe('solver-worker message round-trip', () => {
+  let posted: PostedMessage[];
+  let dispatch: (msg: any) => Promise<void>;
+
+  beforeAll(async () => {
+    posted = [];
+    const fakeSelf: Record<string, any> = {
+      postMessage: (msg: PostedMessage) => { posted.push(msg); },
+    };
+    vi.stubGlobal('self', fakeSelf);
+    // Importing the module assigns fakeSelf.onmessage.
+    await import('../solver-worker');
+    dispatch = (msg) => fakeSelf.onmessage({ data: msg });
+
+    const wasmPath = fileURLToPath(new URL('../../wasm/dedaliano_engine_bg.wasm', import.meta.url));
+    const wasmModule = await WebAssembly.compile(readFileSync(wasmPath));
+    await dispatch({ type: 'init', wasmModule });
+
+    const err = posted.find(m => m.type === 'error');
+    if (err) throw new Error(`Worker init failed: ${err.message}`);
+    expect(posted.some(m => m.type === 'ready')).toBe(true);
+  }, 30000);
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('solves a plain-object input and returns a plain-object result', async () => {
+    await dispatch({ type: 'solve3d', id: 1, input: cantileverWire() });
+
+    const res = posted.find(m => m.type === 'result' && m.id === 1);
+    expect(res).toBeDefined();
+    expect(res!.error).toBeUndefined();
+
+    const result = res!.result;
+    expect(result.displacements.length).toBe(2);
+    const tip = result.displacements.find((d: any) => d.nodeId === 2);
+    expect(tip).toBeDefined();
+    expect(typeof tip.uz).toBe('number');
+    expect(Number.isFinite(tip.uz)).toBe(true);
+    expect(tip.uz).toBeLessThan(0); // downward load → negative uz
+  });
+
+  it('rejects non-finite input on the worker side (assertFiniteWire)', async () => {
+    const bad = cantileverWire();
+    bad.nodes['2'] = { id: 2, x: NaN, y: 0, z: 0 };
+
+    await dispatch({ type: 'solve3d', id: 2, input: bad });
+
+    const res = posted.find(m => m.type === 'result' && m.id === 2);
+    expect(res).toBeDefined();
+    expect(res!.result).toBeUndefined();
+    expect(res!.error).toMatch(/Non-finite number \(NaN\) at input\.nodes\.2\.x/);
+  });
+
+  it('reports an error for structurally invalid input instead of hanging', async () => {
+    // Element references node 99, which does not exist.
+    const bad = cantileverWire();
+    bad.elements['1'] = { ...bad.elements['1'], nodeJ: 99 };
+
+    await dispatch({ type: 'solve3d', id: 3, input: bad });
+
+    const res = posted.find(m => m.type === 'result' && m.id === 3);
+    expect(res).toBeDefined();
+    expect(res!.result).toBeUndefined();
+    expect(res!.error).toBeTruthy();
+  });
+});

--- a/web/src/lib/engine/solver-worker.ts
+++ b/web/src/lib/engine/solver-worker.ts
@@ -44,7 +44,9 @@ self.onmessage = async (e: MessageEvent) => {
       const result = solve_3d(msg.input);
       self.postMessage({ type: 'result', id: msg.id, result });
     } catch (err: any) {
-      self.postMessage({ type: 'result', id: msg.id, error: err.message });
+      // Engine errors cross the boundary as plain strings (JsValue::from_str),
+      // which have no .message — fall back to String() so they are not lost.
+      self.postMessage({ type: 'result', id: msg.id, error: err?.message ?? String(err) });
     }
     return;
   }


### PR DESCRIPTION
Follow-ups from the PR #76 review (JsValue boundary):

- **solver-worker**: engine errors cross the JsValue boundary as plain strings (`JsValue::from_str`) with no `.message`; the worker posted `error: undefined` and the pool resolved with `undefined` instead of rejecting. Falls back to `String(err)`, matching the main-thread wrapper. (Pre-existing bug — exposed by the new round-trip test, matters more once PR #77 routes single solves through the worker.)
- **assert-finite-wire.test.ts** (8 tests): unit coverage for the NaN/Infinity guard — accepted shapes, exact key/index paths, fail-fast.
- **solver-worker-roundtrip.test.ts** (3 tests): worker init→solve round-trip with the real WASM build, worker-side NaN rejection, invalid-input error reporting.
- **package.json**: `bench:wasm-boundary` script for the PR #76 benchmark.
- **CHANGELOG**: Unreleased/Performance entry for the JsValue boundary.

54/54 targeted tests green on top of main (cdd43991); build clean.