### PR TITLE
fix(web): 3D orphan preflight must return the string error, not the preflight object

### DIFF
--- a/web/src/lib/engine/__tests__/constraint-connectivity.test.ts
+++ b/web/src/lib/engine/__tests__/constraint-connectivity.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { validateAndSolve2D, validateAndSolve3D, type ModelData } from '../solver-service';
+import { validateAndSolve2D, validateAndSolve3D, validateAndSolve3DAsync, type ModelData } from '../solver-service';
 import type { Constraint3D } from '../types-3d';
 
 // Build a minimal 2D model: two valid nodes connected by one frame element,
@@ -199,6 +199,23 @@ describe('JS preflight validator: constraint-linked nodes are not orphans', () =
       const m = baseModel2D(99);
       // No constraint; node 99 is genuinely orphan.
       const result = validateAndSolve2D(m);
+      expect(typeof result).toBe('string');
+      expect(result as string).toMatch(ORPHAN_RX);
+    });
+
+    it('3D: orphan error is a STRING via the public contract (regression: PR #75 returned { error, connectedNodes })', () => {
+      const m = baseModel3D(99);
+      const result = validateAndSolve3D(m);
+      // Must be the orphan error string — not an { error, connectedNodes }
+      // object (which callers can't detect via typeof === 'string') and not a
+      // generic WASM parse error from feeding the object into the solver.
+      expect(typeof result).toBe('string');
+      expect(result as string).toMatch(ORPHAN_RX);
+    });
+
+    it('3D async: orphan error resolves to the same STRING (regression: object reached input3DToWireObject and threw)', async () => {
+      const m = baseModel3D(99);
+      const result = await validateAndSolve3DAsync(m);
       expect(typeof result).toBe('string');
       expect(result as string).toMatch(ORPHAN_RX);
     });

--- a/web/src/lib/engine/solver-service.ts
+++ b/web/src/lib/engine/solver-service.ts
@@ -1561,7 +1561,7 @@ function prepareSolve3D(model: ModelData, includeSelfWeight = false, leftHand = 
   addConstraintConnectivity(connectedNodes, model.constraints);
   for (const nodeId of model.nodes.keys()) {
     if (!connectedNodes.has(nodeId)) {
-      return { error: t('svc.disconnectedNode').replace('{n}', String(nodeId)), connectedNodes };
+      return t('svc.disconnectedNode').replace('{n}', String(nodeId));
     }
   }
 


### PR DESCRIPTION
Confirma el defecto reportado por QA sobre `origin/main` (introducido por 85a74c96, el fix de preflight-parity de PR #75):

## Defecto

La rama de nodo desconectado de `prepareSolve3D` (antes cuerpo inline de `validateAndSolve3D`) retornaba `{ error, connectedNodes }` — el shape del helper `preflightModel2D` (2D) — donde el contrato declarado es `SolverInput3D | string | null`.

```
src/lib/engine/solver-service.ts(1564,16): error TS2353: Object literal may only
specify known properties, and 'error' does not exist in type 'SolverInput3D'.
```

## Impacto en runtime

Los callers detectan falla con `typeof result === 'string'`, así que el objeto pasaba el guard:

- **Path sync**: el objeto se mandaba al solver WASM → error de parseo críptico en vez del mensaje de nodo desconectado.
- **Path async (PR #77)**: `input3DToWireObject(input)` crasheaba con `input.nodes === undefined` — TypeError en vez del string de error.

Escapó CI porque main no corre typecheck gate (el build de vite no typecheckea).

## Fix

La rama retorna el string plano, como todas sus hermanas. El shape `{ error, connectedNodes }` queda interno a `preflightModel2D` (2D), cuyo contrato es válido. Verificado: TS2353 eliminado de `tsc --noEmit`.

## Regresión

Dos tests nuevos en el control negativo de `constraint-connectivity.test.ts`: modelo 3D con nodo huérfano asserta el error **string** correcto tanto en `validateAndSolve3D` como en `validateAndSolve3DAsync` (esta última pre-fix tiraba TypeError).

Suite engine+store: 90 files, 2250 passed, 0 failed.