### PR TITLE
docs: stamp the test inventory with its measurement point + make test-inventory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: dev dev-backend dev-web wasm build build-backend build-web \
-       test test-engine test-backend test-web \
+       test test-engine test-backend test-web test-inventory \
        docker-build docker-up docker-down \
        clean fmt check
 
@@ -42,6 +42,31 @@ test-backend:
 
 test-web:
 	cd web && npm install && npx vitest run
+
+## Measure the engine test inventory published in docs/BENCHMARKS.md.
+## Engine-coupled = every target except `reference`, whose tests recompute
+## textbook/code formulas inline and never call the engine (see
+## engine/tests/reference/main.rs). Single pass: attributes each `test result`
+## line to the target announced by the preceding `Running` line.
+test-inventory:
+	@cd engine && cargo test 2>&1 | awk -v sha="$$(git rev-parse --short HEAD)" -v day="$$(date +%Y-%m-%d)" ' \
+		/^[[:space:]]*Running / { target = $$2 } \
+		/^[[:space:]]*Doc-tests / { target = "doc-tests" } \
+		/^test result:/ { \
+			if ($$5 != "passed;") next; \
+			if (target ~ /reference/) ref += $$4; else eng += $$4; \
+			failed += $$6; seen++; \
+		} \
+		END { \
+			if (seen < 20 || ref == 0) { \
+				printf "INCOMPLETE RUN (%d target(s) reported, reference=%d) — do not publish these numbers.\n", seen, ref; \
+				exit 1; \
+			} \
+			printf "measured at %s on %s\n", sha, day; \
+			printf "engine-coupled: %d passing, %d failures\n", eng, failed; \
+			printf "reference-formula self-checks: %d passing\n", ref; \
+			printf "total registered: %d\n", eng + ref; \
+		}'
 
 # ── Docker ───────────────────────────────────────────────────
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -23,9 +23,12 @@ It should not be the main roadmap or the historical archive.
 
 The benchmark ledger below is curated. It is narrower than the full automated test inventory, because many validation, unit, integration, and regression tests are support checks rather than one benchmark row per test.
 
-Current measured inventory:
+Measured inventory — **measured at `6c3369d6` on 2026-08-01**. These are point-in-time
+counts, not live numbers: every merged PR moves them. Re-measure with `make test-inventory`
+(runs the full engine suite, ~10 min) and update the stamp above in the same commit. A
+number here without a stamp it was measured at is a number nobody can check.
 
-- Engine-coupled tests (call the solver / its public functions): `5590` passing, `0` failures.
+- Engine-coupled tests (call the solver / its public functions): `5655` passing, `0` failures.
 - Reference-formula self-checks (`engine/tests/reference/`, textbook/code formulas recomputed
   inline — NOT engine verification): `1192` passing. Counted separately by design.
 - `25` integration test files (`186` integration test functions)


### PR DESCRIPTION
## Why

PR #81 published honest test counts, separating engine-coupled tests from reference-formula self-checks. Those counts then drifted the moment later PRs merged: `docs/BENCHMARKS.md` still claims `5590` engine-coupled tests, while the real number at `6c3369d6` is **5655** (measured; `1192` reference-formula, `6847` total, 0 failures).

A bare count in a doc is unfalsifiable — a reader can't tell whether it's current, and nothing signals when it goes stale. That's a poor property for the document whose job is honest measurement.

## What

- **`docs/BENCHMARKS.md`**: counts corrected and stamped with the commit and date they were measured at, stated plainly as point-in-time, with the command to re-measure.
- **`make test-inventory`**: single pass over `cargo test`, attributing each `test result` line to the target announced by the preceding `Running` line, so the engine-coupled / reference split stays exactly the one BENCHMARKS.md reports. ~10 min (the `validation` target alone is 4724 tests / ~7 min).
- The target **refuses to print totals** if fewer than 20 targets reported or the reference target is missing. This is not hypothetical: while developing it, truncated runs printed `726` and `2107` — plausible-looking numbers that could easily have been published. It now fails loudly instead.

## Verification

```
$ make test-inventory
measured at 6c3369d6 on 2026-08-01
engine-coupled: 5655 passing, 0 failures
reference-formula self-checks: 1192 passing
total registered: 6847
```

Docs-only + one Makefile target; no code, no test, no CI change.

## Follow-up (not in this PR)

`scripts/sync_solver_docs.py` is dead: it targets `BENCHMARKS.md` at the repo root (the file now lives in `docs/`) and matches `engine/tests/validation_*.rs`, a layout that no longer exists. It fails loudly rather than corrupting anything, and its launchd plist isn't installed — but it should be repaired or removed so it doesn't read as the maintained path for these numbers.