### PR TITLE
perf(engine,web): user-impact batch — combine guard, dense-LU cache, sparse 2D dynamic, deformed geometry

### DIFF
--- a/engine/src/solver/harmonic.rs
+++ b/engine/src/solver/harmonic.rs
@@ -93,7 +93,27 @@ pub fn solve_harmonic_2d(input: &HarmonicInput) -> Result<HarmonicResult, String
         return Err("Target DOF is restrained".into());
     }
 
-    // Assemble K, M, F
+    // Assemble K, M, F — sparse first for large unconstrained models (dense K
+    // and M are O(n²) memory and assembly time; the sparse modal path exists
+    // and was unused here).
+    let cs = FreeConstraintSystem::build_2d(&input.solver.constraints, &dof_num, &input.solver.nodes);
+
+    if cs.is_none() && nf >= super::linear::SPARSE_THRESHOLD {
+        let sasm = super::sparse_assembly::assemble_stiffness_sparse_2d(&input.solver, &dof_num);
+        let f_full = crate::solver::assembly::assemble_load_vector_2d(
+            &input.solver, &input.solver.loads, &dof_num, &sasm.inclined_transforms_2d,
+        );
+        let f_ff: Vec<f64> = f_full[..nf].to_vec();
+        let m_csc = assemble_mass_matrix_2d_sparse(&input.solver, &dof_num, &input.densities);
+        if let Some((response_points, peak_frequency, peak_amplitude)) =
+            solve_harmonic_modal_sparse(&sasm.k_ff, &m_csc, &f_ff, &input.frequencies, input.damping_ratio, target_dof)
+        {
+            return Ok(HarmonicResult { response_points, peak_frequency, peak_amplitude });
+        }
+        // Sparse modal found no usable modes (or Lanczos failed) — fall through
+        // to the dense modal/direct paths below.
+    }
+
     let asm = assemble_2d(&input.solver, &dof_num);
     let m_full = assemble_mass_matrix_2d(&input.solver, &dof_num, &input.densities);
 
@@ -103,7 +123,6 @@ pub fn solve_harmonic_2d(input: &HarmonicInput) -> Result<HarmonicResult, String
     let f_ff: Vec<f64> = asm.f[..nf].to_vec();
 
     // Apply constraint reduction if constraints present
-    let cs = FreeConstraintSystem::build_2d(&input.solver.constraints, &dof_num, &input.solver.nodes);
     let ns = cs.as_ref().map_or(nf, |c| c.n_free_indep);
 
     let (k_s, m_s, f_s) = if let Some(ref cs) = cs {

--- a/engine/src/solver/linear.rs
+++ b/engine/src/solver/linear.rs
@@ -1219,6 +1219,11 @@ struct SparsePrepared3D {
     conditioning_us: u64,
     symbolic_us: u64,
     numeric_us: u64,
+    /// Lazily-factored dense LU of the (unshifted) K_ff, built only if a case's
+    /// sparse solve fails the residual check and shared across load cases.
+    /// `None` (inside) = K_ff is singular. The OLD fallback re-assembled the
+    /// full dense K and re-factored it PER CASE.
+    dense_lu: std::cell::OnceCell<Option<(Vec<f64>, Vec<usize>)>>,
 }
 
 struct SparseDenseLuPrepared3D {
@@ -1432,6 +1437,7 @@ pub fn prepare_static_3d(input: &SolverInput3D) -> Result<PreparedStatic3D, Stri
                         conditioning_us,
                         symbolic_us,
                         numeric_us,
+                        dense_lu: std::cell::OnceCell::new(),
                     }),
                 })
             }
@@ -1813,23 +1819,22 @@ impl PreparedStatic3D {
         Ok(results)
     }
 
-    /// Dense LU fallback (per case): dense K_ff factor + dense load vector.
-    /// Used when the sparse Cholesky solve gives a bad residual.
-    fn dense_lu_fallback_3d(&self, loads: &[SolverLoad3D]) -> Result<Vec<f64>, String> {
-        let input = &self.input;
-        let dof_num = &self.dof_num;
-        let (n, nf, nr) = (self.n, self.nf, self.nr);
-        let stiff_d = assemble_stiffness_3d(input, dof_num);
-        let f_d = assemble_load_vector_3d_dense(input, loads, dof_num, &stiff_d.inclined_transforms);
-        let free_idx: Vec<usize> = (0..nf).collect();
-        let rest_idx: Vec<usize> = (nf..n).collect();
-        let k_fr = extract_submatrix(&stiff_d.k, n, &free_idx, &rest_idx);
-        let kfr_ur_d = mat_vec_rect(&k_fr, &self.u_r, nf, nr);
-        let mut f_work: Vec<f64> = f_d[..nf].to_vec();
-        for i in 0..nf { f_work[i] -= kfr_ur_d[i]; }
-        let mut k_ff_d = extract_submatrix(&stiff_d.k, n, &free_idx, &free_idx);
-        lu_solve(&mut k_ff_d, &mut f_work, nf)
-            .ok_or_else(|| "Singular stiffness matrix — structure is a mechanism".to_string())
+    /// Dense LU fallback (per case): triangular solve against the dense LU of K_ff,
+    /// factored ONCE from the already-assembled sparse CSC (unshifted) and cached in
+    /// the prepared struct. The OLD version re-assembled the full dense K and
+    /// re-factored it per load case. `f_f` is the case's free load vector, already
+    /// corrected for prescribed displacements (same input the sparse solve used).
+    fn dense_lu_fallback_3d(&self, p: &SparsePrepared3D, f_f: &[f64]) -> Result<Vec<f64>, String> {
+        let nf = self.nf;
+        let lu = p.dense_lu.get_or_init(|| {
+            let mut k_ff_d = p.k_ff.to_dense_symmetric();
+            lu_factor(&mut k_ff_d, nf).map(|piv| (k_ff_d, piv))
+        });
+        match lu {
+            Some((a, piv)) => lu_apply(a, piv, f_f, nf)
+                .ok_or_else(|| "Singular stiffness matrix — structure is a mechanism".to_string()),
+            None => Err("Singular stiffness matrix — structure is a mechanism".to_string()),
+        }
     }
 
     fn solve_loads_sparse(
@@ -1911,7 +1916,7 @@ impl PreparedStatic3D {
             });
             used_residual_fallback = true;
             let t0 = now_micros();
-            let u_fb = self.dense_lu_fallback_3d(loads)?;
+            let u_fb = self.dense_lu_fallback_3d(p, &f_f)?;
             dense_fb_us = now_micros().saturating_sub(t0);
             (u_fb, s_us, r_us)
         };

--- a/engine/src/solver/modal.rs
+++ b/engine/src/solver/modal.rs
@@ -70,38 +70,47 @@ pub fn solve_modal_2d(
         return Err("No mass assigned — set material densities".into());
     }
 
-    // Assemble M (dense); K is assembled sparse for large models, dense otherwise
-    let m_full = assemble_mass_matrix_2d(input, &dof_num, densities);
-
-    let free_idx: Vec<usize> = (0..nf).collect();
-    let m_ff = extract_submatrix(&m_full, n, &free_idx, &free_idx);
-
+    // Assemble M (dense); K is assembled sparse for large models, dense otherwise.
+    // SKIPPED in the sparse-unconstrained branch below, which assembles the mass
+    // as CSC directly — a dense mass is O(n²) memory and assembly time.
     // Apply constraint transform if present
     let cs = FreeConstraintSystem::build_2d(&input.constraints, &dof_num, &input.nodes);
+    let need_dense_mass = nf < SPARSE_THRESHOLD || cs.is_some();
+    let m_full = if need_dense_mass {
+        Some(assemble_mass_matrix_2d(input, &dof_num, densities))
+    } else {
+        None
+    };
+
+    let free_idx: Vec<usize> = (0..nf).collect();
+    let m_ff = m_full.as_ref().map(|m| extract_submatrix(m, n, &free_idx, &free_idx));
 
     // Solve K·φ = λ·M·φ where λ = ω²
     // Large unconstrained models: triplet sparse assembly + sparse shift-invert
     // Lanczos (mirrors the 3D modal wiring); constraints still reduce dense K.
+    // The mass is assembled as CSC directly in the sparse-unconstrained branch —
+    // a dense mass costs O(n²) memory and assembly time for nothing there.
+    let mut m_csc_opt: Option<crate::linalg::CscMatrix> = None;
     let (result, ns, m_solve) = if nf >= SPARSE_THRESHOLD {
         let sasm = super::sparse_assembly::assemble_stiffness_sparse_2d(input, &dof_num);
         if let Some(ref cs) = cs {
             let k_ff = sasm.k_ff.to_dense_symmetric();
             let k_solve = cs.reduce_matrix(&k_ff);
-            let m_solve = cs.reduce_matrix(&m_ff);
+            let m_solve = cs.reduce_matrix(m_ff.as_ref().unwrap());
             let result = lanczos_generalized_eigen(&k_solve, &m_solve, cs.n_free_indep, num_modes, 0.0)
                 .ok_or_else(|| "Eigenvalue decomposition failed".to_string())?;
             (result, cs.n_free_indep, m_solve)
         } else {
-            // Sparse shift-invert op takes the mass as CSC (PR #73 signature);
-            // convert the dense free block at the call site (same values).
-            let m_csc = crate::linalg::CscMatrix::from_dense_symmetric(&m_ff, nf);
+            let m_csc = super::mass_matrix::assemble_mass_matrix_2d_sparse(input, &dof_num, densities);
             let result = lanczos_generalized_eigen_sparse(&sasm.k_ff, &m_csc, num_modes, 0.0)
                 .ok_or_else(|| "Eigenvalue decomposition failed".to_string())?;
-            (result, nf, m_ff)
+            m_csc_opt = Some(m_csc);
+            (result, nf, Vec::new())
         }
     } else {
         let asm = assemble_2d(input, &dof_num);
         let k_ff = extract_submatrix(&asm.k, n, &free_idx, &free_idx);
+        let m_ff = m_ff.unwrap();
         let (k_solve, m_solve, ns) = if let Some(ref cs) = cs {
             (cs.reduce_matrix(&k_ff), cs.reduce_matrix(&m_ff), cs.n_free_indep)
         } else {
@@ -149,8 +158,12 @@ pub fn solve_modal_2d(
         // Extract eigenvector in solve space (ns-dimensional)
         let phi_s: Vec<f64> = (0..ns).map(|i| result.vectors[i * n_converged + idx]).collect();
 
-        // Compute φᵀ·M·φ in solve space
-        let m_phi = mat_vec_sub(&m_solve, &phi_s, ns);
+        // Compute φᵀ·M·φ in solve space — sparse CSC matvec when the mass was
+        // assembled sparse (large unconstrained models), dense otherwise.
+        let m_phi = match &m_csc_opt {
+            Some(m_csc) => m_csc.sym_mat_vec(&phi_s),
+            None => mat_vec_sub(&m_solve, &phi_s, ns),
+        };
         let phi_m_phi: f64 = phi_s.iter().zip(m_phi.iter()).map(|(a, b)| a * b).sum();
 
         // Participation factors in solve space

--- a/web/src/lib/engine/wasm-solver.ts
+++ b/web/src/lib/engine/wasm-solver.ts
@@ -672,9 +672,11 @@ export function combineResults(
     .filter(f => perCase.has(f.caseId))
     .map(f => ({ caseId: f.caseId, results: perCase.get(f.caseId)! }));
   if (cases.length === 0) return null;
-  const payload = { factors, cases };
-  assertFiniteWire(payload);
-  return wasmCombineResults2d(payload);
+  // Guard the FACTORS only (user data, cheap). The per-case results are solver
+  // output — produced after the input-side guard already rejected non-finite
+  // model data — so re-walking multi-MB result trees per combo was pure cost.
+  assertFiniteWire(factors);
+  return wasmCombineResults2d({ factors, cases });
 }
 
 /** Combine 3D results with factors via WASM. JsValue in/out — no JSON round trip. */
@@ -687,16 +689,16 @@ export function combineResults3D(
     .filter(f => perCase.has(f.caseId))
     .map(f => ({ caseId: f.caseId, results: perCase.get(f.caseId)! }));
   if (cases.length === 0) return null;
-  const payload = { factors, cases };
-  assertFiniteWire(payload);
-  return wasmCombineResults3d(payload);
+  // Same rationale as combineResults: guard factors (cheap), trust solver output.
+  assertFiniteWire(factors);
+  return wasmCombineResults3d({ factors, cases });
 }
 
 /** Compute 2D envelope via WASM. JsValue in/out — no JSON round trip. */
 export function computeEnvelope(results: AnalysisResults[]): FullEnvelope | null {
   if (!wasmReady || !wasmComputeEnvelope2d) throw new Error('WASM solver not initialized.');
   if (results.length === 0) return null;
-  assertFiniteWire(results);
+  // Solver output — no guard (see combineResults).
   return wasmComputeEnvelope2d(results);
 }
 
@@ -704,7 +706,7 @@ export function computeEnvelope(results: AnalysisResults[]): FullEnvelope | null
 export function computeEnvelope3D(results: AnalysisResults3D[]): FullEnvelope3D | null {
   if (!wasmReady || !wasmComputeEnvelope3d) throw new Error('WASM solver not initialized.');
   if (results.length === 0) return null;
-  assertFiniteWire(results);
+  // Solver output — no guard (see combineResults).
   return wasmComputeEnvelope3d(results);
 }
 

--- a/web/src/lib/three/deformed-shape-3d.ts
+++ b/web/src/lib/three/deformed-shape-3d.ts
@@ -324,6 +324,13 @@ export function computeDeformedShape3D(
 /**
  * Create a THREE.Group containing deformed shape lines for all elements.
  * Uses Hermite cubic interpolation + particular solution in both Y and Z planes.
+ *
+ * The group carries ONE LineSegments with preallocated base/displacement
+ * buffers and a `userData.setScale(scale)` that rewrites positions in place —
+ * animation callers update the scale without rebuilding geometry, materials
+ * and lines for every element on every frame (the old behavior allocated a
+ * BufferGeometry + LineBasicMaterial + Line per element per rebuild, and the
+ * sync layer disposed and recreated the whole group per animation frame).
  */
 export function createDeformedLines(
   elements: Map<number, Element>,
@@ -349,6 +356,10 @@ export function createDeformedLines(
     forcesMap.set(ef.elementId, ef);
   }
 
+  // Per-point base positions and displacement vectors (scale-independent).
+  // points(scale=0) IS the base; points(scale=1) − base IS the displacement.
+  const bases: number[] = [];
+  const disps: number[] = [];
   for (const [, elem] of elements) {
     const nI = nodes.get(elem.nodeI);
     const nJ = nodes.get(elem.nodeJ);
@@ -358,7 +369,8 @@ export function createDeformedLines(
     const dJ = dispMap.get(elem.nodeJ);
     if (!dI || !dJ) continue;
 
-    let points: THREE.Vector3[];
+    let p0: THREE.Vector3[] = [];
+    let p1: THREE.Vector3[] = [];
     const ef = forcesMap.get(elem.id);
     const eiEntry = _eiMap?.get(elem.id);
 
@@ -371,21 +383,22 @@ export function createDeformedLines(
         ? { x: elem.localYx, y: elem.localYy, z: elem.localYz } : undefined;
       const rollAngle = elem.rollAngle;
       try {
-        points = computeDeformedShape3D(
+        p0 = computeDeformedShape3D(
           { id: elem.nodeI, x: nI.x, y: nI.y, z: nI.z ?? 0 },
           { id: elem.nodeJ, x: nJ.x, y: nJ.y, z: nJ.z ?? 0 },
-          dI, dJ, ef, scale, eiEntry,
+          dI, dJ, ef, 0, eiEntry,
+          localY, rollAngle, _leftHand,
+        );
+        p1 = computeDeformedShape3D(
+          { id: elem.nodeI, x: nI.x, y: nI.y, z: nI.z ?? 0 },
+          { id: elem.nodeJ, x: nJ.x, y: nJ.y, z: nJ.z ?? 0 },
+          dI, dJ, ef, 1, eiEntry,
           localY, rollAngle, _leftHand,
         );
       } catch {
-        points = [];
+        p0 = []; p1 = [];
       }
     } else {
-      points = [];
-    }
-
-    // Linear fallback when Hermite not available
-    if (points.length === 0) {
       for (let i = 0; i <= SEGMENTS_PER_ELEMENT; i++) {
         const t = i / SEGMENTS_PER_ELEMENT;
         const ox = nI.x + (nJ.x - nI.x) * t;
@@ -394,20 +407,39 @@ export function createDeformedLines(
         const ux = dI.ux + (dJ.ux - dI.ux) * t;
         const uy = dI.uy + (dJ.uy - dI.uy) * t;
         const uz = dI.uz + (dJ.uz - dI.uz) * t;
-        points.push(new THREE.Vector3(ox + ux * scale, oy + uy * scale, oz + uz * scale));
+        p0.push(new THREE.Vector3(ox, oy, oz));
+        p1.push(new THREE.Vector3(ox + ux, oy + uy, oz + uz));
       }
     }
 
-    if (points.length < 2) continue;
+    if (p0.length < 2 || p0.length !== p1.length) continue;
 
-    const geo = new THREE.BufferGeometry().setFromPoints(points);
-    const mat = new THREE.LineBasicMaterial({
-      color: COLORS.deformed,
-      linewidth: 2,
-    });
-    const line = new THREE.Line(geo, mat);
-    group.add(line);
+    // LineSegments takes point PAIRS: p[i] → p[i+1] per segment.
+    for (let i = 0; i < p0.length - 1; i++) {
+      const a0 = p0[i], b0 = p0[i + 1];
+      const a1 = p1[i], b1 = p1[i + 1];
+      bases.push(a0.x, a0.y, a0.z, b0.x, b0.y, b0.z);
+      disps.push(a1.x - a0.x, a1.y - a0.y, a1.z - a0.z, b1.x - b0.x, b1.y - b0.y, b1.z - b0.z);
+    }
   }
+
+  const base = new Float32Array(bases);
+  const disp = new Float32Array(disps);
+  const positions = new Float32Array(base.length);
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  const mat = new THREE.LineBasicMaterial({
+    color: COLORS.deformed,
+    linewidth: 2,
+  });
+  const setScale = (s: number) => {
+    for (let i = 0; i < positions.length; i++) positions[i] = base[i] + s * disp[i];
+    geo.attributes.position.needsUpdate = true;
+  };
+  setScale(scale);
+  group.add(new THREE.LineSegments(geo, mat));
+  group.userData.setScale = setScale;
+  group.userData.material = mat;
 
   return group;
 }

--- a/web/src/lib/viewport3d/results-sync.ts
+++ b/web/src/lib/viewport3d/results-sync.ts
@@ -112,13 +112,6 @@ function computeStructureBBox(): number {
 export function syncDeformed(ctx: ResultsSyncContext, scaleOverride?: number): void {
   if (!ctx.initialized) return;
 
-  // Remove old deformed
-  if (ctx.deformedGroup) {
-    ctx.resultsParent.remove(ctx.deformedGroup);
-    disposeObject(ctx.deformedGroup);
-    ctx.deformedGroup = null;
-  }
-
   const dt = resultsStore.diagramType;
   const isDeformedLike = dt === 'deformed' || dt === 'modeShape' || dt === 'bucklingMode';
 
@@ -184,9 +177,34 @@ export function syncDeformed(ctx: ResultsSyncContext, scaleOverride?: number): v
 
   if (!displacements) return;
 
+  // In-place scale update when the underlying data is unchanged: the group
+  // carries preallocated base/displacement buffers and a setScale() that
+  // rewrites positions without rebuilding any geometry (previously every
+  // animation frame disposed and recreated the whole group per element).
+  const r3d = resultsStore.results3D;
+  const sigDt = dt;
+  const sigDisp = displacements;
+  const sigForces = dt === 'deformed' && r3d ? r3d.elementForces : null;
+  const sigVer = modelStore.modelVersion;
+  const sigHand = uiStore.axisConvention3D === 'leftHand';
+  const prev = ctx.deformedGroup?.userData;
+  if (ctx.deformedGroup && prev?.sigDt === sigDt && prev?.sigDisp === sigDisp
+      && prev?.sigForces === sigForces && prev?.sigVer === sigVer && prev?.sigHand === sigHand) {
+    prev.setScale(scale);
+    prev.material.color.setHex(modeColor ?? COLORS.deformed);
+    ctx.resultsParent.add(ctx.deformedGroup);
+    return;
+  }
+
+  // Remove old deformed — the data actually changed, rebuild is required.
+  if (ctx.deformedGroup) {
+    ctx.resultsParent.remove(ctx.deformedGroup);
+    disposeObject(ctx.deformedGroup);
+    ctx.deformedGroup = null;
+  }
+
   // Build EI map for particular solution (only for static deformed — modes don't need it)
   let eiMap: Map<number, ElementEI> | undefined;
-  const r3d = resultsStore.results3D;
   if (dt === 'deformed') {
     eiMap = new Map<number, ElementEI>();
     for (const [id, elem] of modelStore.elements) {
@@ -210,8 +228,16 @@ export function syncDeformed(ctx: ResultsSyncContext, scaleOverride?: number): v
     dt === 'deformed' && r3d ? r3d.elementForces : [],
     scale,
     eiMap,
-    uiStore.axisConvention3D === 'leftHand',
+    sigHand,
   );
+  if (modeColor !== null) {
+    ctx.deformedGroup.userData.material.color.setHex(modeColor);
+  }
+  ctx.deformedGroup.userData.sigDt = sigDt;
+  ctx.deformedGroup.userData.sigDisp = sigDisp;
+  ctx.deformedGroup.userData.sigForces = sigForces;
+  ctx.deformedGroup.userData.sigVer = sigVer;
+  ctx.deformedGroup.userData.sigHand = sigHand;
 
   // Tint mode shapes with their distinctive color
   if (modeColor !== null) {


### PR DESCRIPTION
Del análisis de performance del proyecto (solo ítems con impacto en usuario):

1. **Combine/envelope sin walk de result trees**: `assertFiniteWire` ahora solo sobre los factors (barato). Los resultados por caso son output del solver — el guard recursivo escalaba con combos × casos × tamaño del resultado.
2. **Dense-LU fallback con cache**: el fallback por residual del sparse Cholesky 3D ya no re-ensambla K denso ni re-factoriza por load case. K_ff se construye una vez desde el CSC y la LU queda cacheada en el prepared struct.
3. **Modal/harmonic 2D sparse**: modelos grandes sin constraints ya no ensamblan K y M densos (la función sparse de masa existía sin callers). 163/163 tests modal-harmonic-spectral con valores idénticos.
4. **Deformed geometry compartida**: una sola LineSegments con buffers prealocados + setScale() in-place firmado por (tipo, desplazamientos, fuerzas, modelVersion, handedness). Los frames de animación actualizan el atributo en vez de recrear geometría+materiales por elemento por frame.

**Diferido**: staged construction densa por stage (staged.rs) — rewrite mayor de mayor riesgo (consumidores compartidos de AssemblyResult), merece PR propio.

Verificación: engine 6828 + 19 gates, web 3063 — todo verde.