### PR TITLE
perf(web): combine/envelope guard only on factors, not on solver output

### DIFF
--- a/web/src/lib/engine/wasm-solver.ts
+++ b/web/src/lib/engine/wasm-solver.ts
@@ -672,9 +672,11 @@ export function combineResults(
     .filter(f => perCase.has(f.caseId))
     .map(f => ({ caseId: f.caseId, results: perCase.get(f.caseId)! }));
   if (cases.length === 0) return null;
-  const payload = { factors, cases };
-  assertFiniteWire(payload);
-  return wasmCombineResults2d(payload);
+  // Guard the FACTORS only (user data, cheap). The per-case results are solver
+  // output — produced after the input-side guard already rejected non-finite
+  // model data — so re-walking multi-MB result trees per combo was pure cost.
+  assertFiniteWire(factors);
+  return wasmCombineResults2d({ factors, cases });
 }
 
 /** Combine 3D results with factors via WASM. JsValue in/out — no JSON round trip. */
@@ -687,16 +689,16 @@ export function combineResults3D(
     .filter(f => perCase.has(f.caseId))
     .map(f => ({ caseId: f.caseId, results: perCase.get(f.caseId)! }));
   if (cases.length === 0) return null;
-  const payload = { factors, cases };
-  assertFiniteWire(payload);
-  return wasmCombineResults3d(payload);
+  // Same rationale as combineResults: guard factors (cheap), trust solver output.
+  assertFiniteWire(factors);
+  return wasmCombineResults3d({ factors, cases });
 }
 
 /** Compute 2D envelope via WASM. JsValue in/out — no JSON round trip. */
 export function computeEnvelope(results: AnalysisResults[]): FullEnvelope | null {
   if (!wasmReady || !wasmComputeEnvelope2d) throw new Error('WASM solver not initialized.');
   if (results.length === 0) return null;
-  assertFiniteWire(results);
+  // Solver output — no guard (see combineResults).
   return wasmComputeEnvelope2d(results);
 }
 
@@ -704,7 +706,7 @@ export function computeEnvelope(results: AnalysisResults[]): FullEnvelope | null
 export function computeEnvelope3D(results: AnalysisResults3D[]): FullEnvelope3D | null {
   if (!wasmReady || !wasmComputeEnvelope3d) throw new Error('WASM solver not initialized.');
   if (results.length === 0) return null;
-  assertFiniteWire(results);
+  // Solver output — no guard (see combineResults).
   return wasmComputeEnvelope3d(results);
 }
 


### PR DESCRIPTION
## What

`assertFiniteWire` recursively walked the **full payload** on every combine/envelope call — multi-MB per-case result trees, per combination. The results are solver output (produced after the input-side guard already rejected non-finite model data), so the walk was pure cost. It now guards only the factors (user data, cheap). The full input guard on solve inputs is unchanged.

## Measured (1000-element 3D model, 4 cases per combine)

| Payload | Guard walk | Combine call | Guard share | Saved per 10-combo batch |
|---|---|---|---|---|
| 1000 elem / 3.2 MB | 3.44 ms | 14.18 ms | **24%** | ~34 ms |
| 5000 elem / 14.8 MB | 19.9 ms | 69.2 ms | **29%** | ~199 ms |

1 file, +10/−8. Web suite: 3063 passed, 0 failed.