### PR TITLE
perf(engine): sparse K and M for large 2D modal/harmonic models

### DIFF
--- a/engine/src/solver/harmonic.rs
+++ b/engine/src/solver/harmonic.rs
@@ -93,7 +93,27 @@ pub fn solve_harmonic_2d(input: &HarmonicInput) -> Result<HarmonicResult, String
         return Err("Target DOF is restrained".into());
     }
 
-    // Assemble K, M, F
+    // Assemble K, M, F — sparse first for large unconstrained models (dense K
+    // and M are O(n²) memory and assembly time; the sparse modal path exists
+    // and was unused here).
+    let cs = FreeConstraintSystem::build_2d(&input.solver.constraints, &dof_num, &input.solver.nodes);
+
+    if cs.is_none() && nf >= super::linear::SPARSE_THRESHOLD {
+        let sasm = super::sparse_assembly::assemble_stiffness_sparse_2d(&input.solver, &dof_num);
+        let f_full = crate::solver::assembly::assemble_load_vector_2d(
+            &input.solver, &input.solver.loads, &dof_num, &sasm.inclined_transforms_2d,
+        );
+        let f_ff: Vec<f64> = f_full[..nf].to_vec();
+        let m_csc = assemble_mass_matrix_2d_sparse(&input.solver, &dof_num, &input.densities);
+        if let Some((response_points, peak_frequency, peak_amplitude)) =
+            solve_harmonic_modal_sparse(&sasm.k_ff, &m_csc, &f_ff, &input.frequencies, input.damping_ratio, target_dof)
+        {
+            return Ok(HarmonicResult { response_points, peak_frequency, peak_amplitude });
+        }
+        // Sparse modal found no usable modes (or Lanczos failed) — fall through
+        // to the dense modal/direct paths below.
+    }
+
     let asm = assemble_2d(&input.solver, &dof_num);
     let m_full = assemble_mass_matrix_2d(&input.solver, &dof_num, &input.densities);
 
@@ -103,7 +123,6 @@ pub fn solve_harmonic_2d(input: &HarmonicInput) -> Result<HarmonicResult, String
     let f_ff: Vec<f64> = asm.f[..nf].to_vec();
 
     // Apply constraint reduction if constraints present
-    let cs = FreeConstraintSystem::build_2d(&input.solver.constraints, &dof_num, &input.solver.nodes);
     let ns = cs.as_ref().map_or(nf, |c| c.n_free_indep);
 
     let (k_s, m_s, f_s) = if let Some(ref cs) = cs {

--- a/engine/src/solver/modal.rs
+++ b/engine/src/solver/modal.rs
@@ -70,38 +70,47 @@ pub fn solve_modal_2d(
         return Err("No mass assigned — set material densities".into());
     }
 
-    // Assemble M (dense); K is assembled sparse for large models, dense otherwise
-    let m_full = assemble_mass_matrix_2d(input, &dof_num, densities);
-
-    let free_idx: Vec<usize> = (0..nf).collect();
-    let m_ff = extract_submatrix(&m_full, n, &free_idx, &free_idx);
-
+    // Assemble M (dense); K is assembled sparse for large models, dense otherwise.
+    // SKIPPED in the sparse-unconstrained branch below, which assembles the mass
+    // as CSC directly — a dense mass is O(n²) memory and assembly time.
     // Apply constraint transform if present
     let cs = FreeConstraintSystem::build_2d(&input.constraints, &dof_num, &input.nodes);
+    let need_dense_mass = nf < SPARSE_THRESHOLD || cs.is_some();
+    let m_full = if need_dense_mass {
+        Some(assemble_mass_matrix_2d(input, &dof_num, densities))
+    } else {
+        None
+    };
+
+    let free_idx: Vec<usize> = (0..nf).collect();
+    let m_ff = m_full.as_ref().map(|m| extract_submatrix(m, n, &free_idx, &free_idx));
 
     // Solve K·φ = λ·M·φ where λ = ω²
     // Large unconstrained models: triplet sparse assembly + sparse shift-invert
     // Lanczos (mirrors the 3D modal wiring); constraints still reduce dense K.
+    // The mass is assembled as CSC directly in the sparse-unconstrained branch —
+    // a dense mass costs O(n²) memory and assembly time for nothing there.
+    let mut m_csc_opt: Option<crate::linalg::CscMatrix> = None;
     let (result, ns, m_solve) = if nf >= SPARSE_THRESHOLD {
         let sasm = super::sparse_assembly::assemble_stiffness_sparse_2d(input, &dof_num);
         if let Some(ref cs) = cs {
             let k_ff = sasm.k_ff.to_dense_symmetric();
             let k_solve = cs.reduce_matrix(&k_ff);
-            let m_solve = cs.reduce_matrix(&m_ff);
+            let m_solve = cs.reduce_matrix(m_ff.as_ref().unwrap());
             let result = lanczos_generalized_eigen(&k_solve, &m_solve, cs.n_free_indep, num_modes, 0.0)
                 .ok_or_else(|| "Eigenvalue decomposition failed".to_string())?;
             (result, cs.n_free_indep, m_solve)
         } else {
-            // Sparse shift-invert op takes the mass as CSC (PR #73 signature);
-            // convert the dense free block at the call site (same values).
-            let m_csc = crate::linalg::CscMatrix::from_dense_symmetric(&m_ff, nf);
+            let m_csc = super::mass_matrix::assemble_mass_matrix_2d_sparse(input, &dof_num, densities);
             let result = lanczos_generalized_eigen_sparse(&sasm.k_ff, &m_csc, num_modes, 0.0)
                 .ok_or_else(|| "Eigenvalue decomposition failed".to_string())?;
-            (result, nf, m_ff)
+            m_csc_opt = Some(m_csc);
+            (result, nf, Vec::new())
         }
     } else {
         let asm = assemble_2d(input, &dof_num);
         let k_ff = extract_submatrix(&asm.k, n, &free_idx, &free_idx);
+        let m_ff = m_ff.unwrap();
         let (k_solve, m_solve, ns) = if let Some(ref cs) = cs {
             (cs.reduce_matrix(&k_ff), cs.reduce_matrix(&m_ff), cs.n_free_indep)
         } else {
@@ -149,8 +158,12 @@ pub fn solve_modal_2d(
         // Extract eigenvector in solve space (ns-dimensional)
         let phi_s: Vec<f64> = (0..ns).map(|i| result.vectors[i * n_converged + idx]).collect();
 
-        // Compute φᵀ·M·φ in solve space
-        let m_phi = mat_vec_sub(&m_solve, &phi_s, ns);
+        // Compute φᵀ·M·φ in solve space — sparse CSC matvec when the mass was
+        // assembled sparse (large unconstrained models), dense otherwise.
+        let m_phi = match &m_csc_opt {
+            Some(m_csc) => m_csc.sym_mat_vec(&phi_s),
+            None => mat_vec_sub(&m_solve, &phi_s, ns),
+        };
         let phi_m_phi: f64 = phi_s.iter().zip(m_phi.iter()).map(|(a, b)| a * b).sum();
 
         // Participation factors in solve space


### PR DESCRIPTION
## What

2D modal and harmonic analysis always assembled **dense** K and M — O(n²) memory and assembly time — while the sparse paths existed unused (`assemble_mass_matrix_2d_sparse` had zero callers; `solve_harmonic_modal_sparse` was 3D-only).

- **Modal** (nf ≥ threshold, unconstrained): mass assembled as CSC directly, sparse shift-invert Lanczos, CSC matvec for per-mode mass weighting. The dense mass assembly is skipped entirely in this branch.
- **Harmonic** (same branch): mirrors the 3D wiring — sparse stiffness + sparse mass + `solve_harmonic_modal_sparse`, with the dense modal/direct paths kept as fallback for constraints or modal failure.

## Measured (2440-element 2D frame, ~3.7k free DOFs, debug build)

| | Dense (main) | Sparse (this PR) |
|---|---|---|
| modal 2D, 6 modes | 6.85–6.97 s | 6.73–6.83 s |
| First eigenfrequency | 0.510 Hz | **0.510 Hz** (identical) |

Honest reading: at this size the Lanczos solve dominates so completely that the wall-time delta is ~2%. **The real win is memory**: the dense mass at 3.7k DOFs is ~110 MB (dense K another ~110 MB); at 10k DOFs that is ~800 MB per matrix and the dense path stops being an option. The sparse branch keeps memory O(nnz).

163/163 modal-harmonic-spectral tests green with identical values. 2 files, +47/−15.