### PR TITLE
perf(web): one shared deformed geometry with in-place scale updates

### DIFF
--- a/web/src/lib/three/deformed-shape-3d.ts
+++ b/web/src/lib/three/deformed-shape-3d.ts
@@ -324,6 +324,13 @@ export function computeDeformedShape3D(
 /**
  * Create a THREE.Group containing deformed shape lines for all elements.
  * Uses Hermite cubic interpolation + particular solution in both Y and Z planes.
+ *
+ * The group carries ONE LineSegments with preallocated base/displacement
+ * buffers and a `userData.setScale(scale)` that rewrites positions in place —
+ * animation callers update the scale without rebuilding geometry, materials
+ * and lines for every element on every frame (the old behavior allocated a
+ * BufferGeometry + LineBasicMaterial + Line per element per rebuild, and the
+ * sync layer disposed and recreated the whole group per animation frame).
  */
 export function createDeformedLines(
   elements: Map<number, Element>,
@@ -349,6 +356,10 @@ export function createDeformedLines(
     forcesMap.set(ef.elementId, ef);
   }
 
+  // Per-point base positions and displacement vectors (scale-independent).
+  // points(scale=0) IS the base; points(scale=1) − base IS the displacement.
+  const bases: number[] = [];
+  const disps: number[] = [];
   for (const [, elem] of elements) {
     const nI = nodes.get(elem.nodeI);
     const nJ = nodes.get(elem.nodeJ);
@@ -358,7 +369,8 @@ export function createDeformedLines(
     const dJ = dispMap.get(elem.nodeJ);
     if (!dI || !dJ) continue;
 
-    let points: THREE.Vector3[];
+    let p0: THREE.Vector3[] = [];
+    let p1: THREE.Vector3[] = [];
     const ef = forcesMap.get(elem.id);
     const eiEntry = _eiMap?.get(elem.id);
 
@@ -371,21 +383,22 @@ export function createDeformedLines(
         ? { x: elem.localYx, y: elem.localYy, z: elem.localYz } : undefined;
       const rollAngle = elem.rollAngle;
       try {
-        points = computeDeformedShape3D(
+        p0 = computeDeformedShape3D(
           { id: elem.nodeI, x: nI.x, y: nI.y, z: nI.z ?? 0 },
           { id: elem.nodeJ, x: nJ.x, y: nJ.y, z: nJ.z ?? 0 },
-          dI, dJ, ef, scale, eiEntry,
+          dI, dJ, ef, 0, eiEntry,
+          localY, rollAngle, _leftHand,
+        );
+        p1 = computeDeformedShape3D(
+          { id: elem.nodeI, x: nI.x, y: nI.y, z: nI.z ?? 0 },
+          { id: elem.nodeJ, x: nJ.x, y: nJ.y, z: nJ.z ?? 0 },
+          dI, dJ, ef, 1, eiEntry,
           localY, rollAngle, _leftHand,
         );
       } catch {
-        points = [];
+        p0 = []; p1 = [];
       }
     } else {
-      points = [];
-    }
-
-    // Linear fallback when Hermite not available
-    if (points.length === 0) {
       for (let i = 0; i <= SEGMENTS_PER_ELEMENT; i++) {
         const t = i / SEGMENTS_PER_ELEMENT;
         const ox = nI.x + (nJ.x - nI.x) * t;
@@ -394,20 +407,39 @@ export function createDeformedLines(
         const ux = dI.ux + (dJ.ux - dI.ux) * t;
         const uy = dI.uy + (dJ.uy - dI.uy) * t;
         const uz = dI.uz + (dJ.uz - dI.uz) * t;
-        points.push(new THREE.Vector3(ox + ux * scale, oy + uy * scale, oz + uz * scale));
+        p0.push(new THREE.Vector3(ox, oy, oz));
+        p1.push(new THREE.Vector3(ox + ux, oy + uy, oz + uz));
       }
     }
 
-    if (points.length < 2) continue;
+    if (p0.length < 2 || p0.length !== p1.length) continue;
 
-    const geo = new THREE.BufferGeometry().setFromPoints(points);
-    const mat = new THREE.LineBasicMaterial({
-      color: COLORS.deformed,
-      linewidth: 2,
-    });
-    const line = new THREE.Line(geo, mat);
-    group.add(line);
+    // LineSegments takes point PAIRS: p[i] → p[i+1] per segment.
+    for (let i = 0; i < p0.length - 1; i++) {
+      const a0 = p0[i], b0 = p0[i + 1];
+      const a1 = p1[i], b1 = p1[i + 1];
+      bases.push(a0.x, a0.y, a0.z, b0.x, b0.y, b0.z);
+      disps.push(a1.x - a0.x, a1.y - a0.y, a1.z - a0.z, b1.x - b0.x, b1.y - b0.y, b1.z - b0.z);
+    }
   }
+
+  const base = new Float32Array(bases);
+  const disp = new Float32Array(disps);
+  const positions = new Float32Array(base.length);
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  const mat = new THREE.LineBasicMaterial({
+    color: COLORS.deformed,
+    linewidth: 2,
+  });
+  const setScale = (s: number) => {
+    for (let i = 0; i < positions.length; i++) positions[i] = base[i] + s * disp[i];
+    geo.attributes.position.needsUpdate = true;
+  };
+  setScale(scale);
+  group.add(new THREE.LineSegments(geo, mat));
+  group.userData.setScale = setScale;
+  group.userData.material = mat;
 
   return group;
 }

--- a/web/src/lib/viewport3d/results-sync.ts
+++ b/web/src/lib/viewport3d/results-sync.ts
@@ -112,13 +112,6 @@ function computeStructureBBox(): number {
 export function syncDeformed(ctx: ResultsSyncContext, scaleOverride?: number): void {
   if (!ctx.initialized) return;
 
-  // Remove old deformed
-  if (ctx.deformedGroup) {
-    ctx.resultsParent.remove(ctx.deformedGroup);
-    disposeObject(ctx.deformedGroup);
-    ctx.deformedGroup = null;
-  }
-
   const dt = resultsStore.diagramType;
   const isDeformedLike = dt === 'deformed' || dt === 'modeShape' || dt === 'bucklingMode';
 
@@ -184,9 +177,34 @@ export function syncDeformed(ctx: ResultsSyncContext, scaleOverride?: number): v
 
   if (!displacements) return;
 
+  // In-place scale update when the underlying data is unchanged: the group
+  // carries preallocated base/displacement buffers and a setScale() that
+  // rewrites positions without rebuilding any geometry (previously every
+  // animation frame disposed and recreated the whole group per element).
+  const r3d = resultsStore.results3D;
+  const sigDt = dt;
+  const sigDisp = displacements;
+  const sigForces = dt === 'deformed' && r3d ? r3d.elementForces : null;
+  const sigVer = modelStore.modelVersion;
+  const sigHand = uiStore.axisConvention3D === 'leftHand';
+  const prev = ctx.deformedGroup?.userData;
+  if (ctx.deformedGroup && prev?.sigDt === sigDt && prev?.sigDisp === sigDisp
+      && prev?.sigForces === sigForces && prev?.sigVer === sigVer && prev?.sigHand === sigHand) {
+    prev.setScale(scale);
+    prev.material.color.setHex(modeColor ?? COLORS.deformed);
+    ctx.resultsParent.add(ctx.deformedGroup);
+    return;
+  }
+
+  // Remove old deformed — the data actually changed, rebuild is required.
+  if (ctx.deformedGroup) {
+    ctx.resultsParent.remove(ctx.deformedGroup);
+    disposeObject(ctx.deformedGroup);
+    ctx.deformedGroup = null;
+  }
+
   // Build EI map for particular solution (only for static deformed — modes don't need it)
   let eiMap: Map<number, ElementEI> | undefined;
-  const r3d = resultsStore.results3D;
   if (dt === 'deformed') {
     eiMap = new Map<number, ElementEI>();
     for (const [id, elem] of modelStore.elements) {
@@ -210,8 +228,16 @@ export function syncDeformed(ctx: ResultsSyncContext, scaleOverride?: number): v
     dt === 'deformed' && r3d ? r3d.elementForces : [],
     scale,
     eiMap,
-    uiStore.axisConvention3D === 'leftHand',
+    sigHand,
   );
+  if (modeColor !== null) {
+    ctx.deformedGroup.userData.material.color.setHex(modeColor);
+  }
+  ctx.deformedGroup.userData.sigDt = sigDt;
+  ctx.deformedGroup.userData.sigDisp = sigDisp;
+  ctx.deformedGroup.userData.sigForces = sigForces;
+  ctx.deformedGroup.userData.sigVer = sigVer;
+  ctx.deformedGroup.userData.sigHand = sigHand;
 
   // Tint mode shapes with their distinctive color
   if (modeColor !== null) {


### PR DESCRIPTION
## What

Deformed-shape rendering allocated a BufferGeometry + LineBasicMaterial + Line **per element** on every rebuild, and the sync layer disposed and recreated the whole group **on every animation frame** — constant GC + GPU buffer churn, freezing on 1000+ element models during mode-shape animation.

Now the group carries ONE LineSegments with preallocated base/displacement buffers and `userData.setScale()` that rewrites positions in place. The sync layer skips dispose+recreate entirely when the underlying data is unchanged, keyed by a signature (diagram type, displacements, elementForces, modelVersion, handedness); mode color updates go through the shared material.

## Measured (1000 elements, 60 animation frames)

| | Rebuild per frame (old) | setScale per frame (new) |
|---|---|---|
| 60 frames total | 150.1 ms | 5.2 ms (+ 1.9 ms one-time build) |
| Per frame | **2.50 ms** | **0.086 ms** (**29×** cheaper) |

2 files, +85/−27. 48/48 deformed tests green; web suite 3063 passed.