### PR TITLE
perf(engine): index lookups instead of per-element linear scans

### DIFF
--- a/engine/src/postprocess/diagrams.rs
+++ b/engine/src/postprocess/diagrams.rs
@@ -250,12 +250,16 @@ pub fn compute_diagrams_2d(
     let mut shear = Vec::new();
     let mut axial = Vec::new();
 
+    // O(1) lookups once — the per-element .values().find() scans made this
+    // O(E·(E+N)) per call on big models.
+    let elem_by_id: std::collections::HashMap<usize, &crate::types::SolverElement> =
+        input.elements.values().map(|e| (e.id, e)).collect();
+    let node_by_id: std::collections::HashMap<usize, &crate::types::SolverNode> =
+        input.nodes.values().map(|n| (n.id, n)).collect();
+
     for ef in &results.element_forces {
-        let elem = input.elements.values().find(|e| e.id == ef.element_id);
-        let (node_ix, node_iy, node_jx, node_jy) = if let Some(elem) = elem {
-            let ni = input.nodes.values().find(|n| n.id == elem.node_i);
-            let nj = input.nodes.values().find(|n| n.id == elem.node_j);
-            match (ni, nj) {
+        let (node_ix, node_iy, node_jx, node_jy) = if let Some(elem) = elem_by_id.get(&ef.element_id) {
+            match (node_by_id.get(&elem.node_i), node_by_id.get(&elem.node_j)) {
                 (Some(ni), Some(nj)) => (ni.x, ni.z, nj.x, nj.z),
                 _ => (0.0, 0.0, ef.length, 0.0),
             }

--- a/engine/src/solver/assembly.rs
+++ b/engine/src/solver/assembly.rs
@@ -2631,6 +2631,12 @@ pub fn assemble_load_vector_3d_sparse(
         input.plates.values().map(|p| (p.id, p)).collect();
     let quad_map: std::collections::HashMap<usize, &SolverQuadElement> =
         input.quads.values().map(|q| (q.id, q)).collect();
+    let quad9_map: std::collections::HashMap<usize, &crate::types::SolverQuad9Element> =
+        input.quad9s.values().map(|q| (q.id, q)).collect();
+    let solid_shell_map: std::collections::HashMap<usize, &crate::types::SolverSolidShellElement> =
+        input.solid_shells.values().map(|s| (s.id, s)).collect();
+    let curved_shell_map: std::collections::HashMap<usize, &crate::types::SolverCurvedShellElement> =
+        input.curved_shells.values().map(|s| (s.id, s)).collect();
 
     // Frame/truss element loads (FEF + thermal)
     assemble_frame_loads_3d(input, loads, dof_num, &mut f_global);
@@ -2739,7 +2745,7 @@ pub fn assemble_load_vector_3d_sparse(
         }
         // Quad9 (MITC9) load dispatch — sparse path
         if let SolverLoad3D::Quad9Pressure(pl) = load {
-            if let Some(q9) = input.quad9s.values().find(|q| q.id == pl.element_id) {
+            if let Some(q9) = quad9_map.get(&pl.element_id) {
                 let coords = quad9_coords(&node_map, q9);
                 let f_p = crate::element::quad9::quad9_pressure_load(&coords, pl.pressure);
                 let dofs = dof_num.quad9_element_dofs(&q9.nodes);
@@ -2749,7 +2755,7 @@ pub fn assemble_load_vector_3d_sparse(
             }
         }
         if let SolverLoad3D::Quad9Thermal(tl) = load {
-            if let Some(q9) = input.quad9s.values().find(|q| q.id == tl.element_id) {
+            if let Some(q9) = quad9_map.get(&tl.element_id) {
                 let mat = mat_map[&q9.material_id];
                 let e = mat.e * 1000.0;
                 let nu = mat.nu;
@@ -2765,7 +2771,7 @@ pub fn assemble_load_vector_3d_sparse(
             }
         }
         if let SolverLoad3D::Quad9SelfWeight(sw) = load {
-            if let Some(q9) = input.quad9s.values().find(|q| q.id == sw.element_id) {
+            if let Some(q9) = quad9_map.get(&sw.element_id) {
                 let coords = quad9_coords(&node_map, q9);
                 let f_sw_local = crate::element::quad9::quad9_self_weight_load(
                     &coords, sw.density, q9.thickness, sw.gx, sw.gy, sw.gz,
@@ -2779,7 +2785,7 @@ pub fn assemble_load_vector_3d_sparse(
             }
         }
         if let SolverLoad3D::Quad9Edge(el) = load {
-            if let Some(q9) = input.quad9s.values().find(|q| q.id == el.element_id) {
+            if let Some(q9) = quad9_map.get(&el.element_id) {
                 let coords = quad9_coords(&node_map, q9);
                 let f_edge = crate::element::quad9::quad9_edge_load(&coords, el.edge, el.qn, el.qt);
                 let dofs = dof_num.quad9_element_dofs(&q9.nodes);
@@ -2790,7 +2796,7 @@ pub fn assemble_load_vector_3d_sparse(
         }
         // Solid-shell load dispatch — sparse path
         if let SolverLoad3D::SolidShellPressure(pl) = load {
-            if let Some(ss) = input.solid_shells.values().find(|s| s.id == pl.element_id) {
+            if let Some(ss) = solid_shell_map.get(&pl.element_id) {
                 let coords = solid_shell_coords(&node_map, ss);
                 let f_p = crate::element::solid_shell::solid_shell_pressure_load(&coords, pl.pressure);
                 let dofs = dof_num.solid_shell_element_dofs(&ss.nodes);
@@ -2800,7 +2806,7 @@ pub fn assemble_load_vector_3d_sparse(
             }
         }
         if let SolverLoad3D::SolidShellSelfWeight(sw) = load {
-            if let Some(ss) = input.solid_shells.values().find(|s| s.id == sw.element_id) {
+            if let Some(ss) = solid_shell_map.get(&sw.element_id) {
                 let coords = solid_shell_coords(&node_map, ss);
                 let f_sw = crate::element::solid_shell::solid_shell_self_weight_load(
                     &coords, sw.density, sw.gx, sw.gy, sw.gz,
@@ -2813,7 +2819,7 @@ pub fn assemble_load_vector_3d_sparse(
         }
         // Curved shell loads (sparse path)
         if let SolverLoad3D::CurvedShellPressure(pl) = load {
-            if let Some(cs) = input.curved_shells.values().find(|s| s.id == pl.element_id) {
+            if let Some(cs) = curved_shell_map.get(&pl.element_id) {
                 let coords = curved_shell_coords(&node_map, cs);
                 let dirs = cs.normals.unwrap_or_else(|| crate::element::curved_shell::compute_element_directors(&coords));
                 let f_p = crate::element::curved_shell::curved_shell_pressure_load(&coords, &dirs, cs.thickness, pl.pressure);
@@ -2824,7 +2830,7 @@ pub fn assemble_load_vector_3d_sparse(
             }
         }
         if let SolverLoad3D::CurvedShellThermal(tl) = load {
-            if let Some(cs) = input.curved_shells.values().find(|s| s.id == tl.element_id) {
+            if let Some(cs) = curved_shell_map.get(&tl.element_id) {
                 let mat = mat_map[&cs.material_id];
                 let e = mat.e * 1000.0;
                 let nu = mat.nu;
@@ -2841,7 +2847,7 @@ pub fn assemble_load_vector_3d_sparse(
             }
         }
         if let SolverLoad3D::CurvedShellSelfWeight(sw) = load {
-            if let Some(cs) = input.curved_shells.values().find(|s| s.id == sw.element_id) {
+            if let Some(cs) = curved_shell_map.get(&sw.element_id) {
                 let coords = curved_shell_coords(&node_map, cs);
                 let dirs = cs.normals.unwrap_or_else(|| crate::element::curved_shell::compute_element_directors(&coords));
                 let f_sw = crate::element::curved_shell::curved_shell_self_weight_load(
@@ -2854,7 +2860,7 @@ pub fn assemble_load_vector_3d_sparse(
             }
         }
         if let SolverLoad3D::CurvedShellEdge(el) = load {
-            if let Some(cs) = input.curved_shells.values().find(|s| s.id == el.element_id) {
+            if let Some(cs) = curved_shell_map.get(&el.element_id) {
                 let coords = curved_shell_coords(&node_map, cs);
                 let dirs = cs.normals.unwrap_or_else(|| crate::element::curved_shell::compute_element_directors(&coords));
                 let f_e = crate::element::curved_shell::curved_shell_edge_load(

--- a/engine/src/solver/linear.rs
+++ b/engine/src/solver/linear.rs
@@ -3049,6 +3049,21 @@ pub(crate) fn compute_internal_forces_2d_with_loads(
     let sec_map: std::collections::HashMap<usize, &SolverSection> =
         input.sections.values().map(|s| (s.id, s)).collect();
 
+    // Index loads per element once — the per-element `for load in loads` rescans
+    // below made this O(E·L) per call, O(modes·E·L) in spectral solves.
+    let empty_loads: Vec<&SolverLoad> = Vec::new();
+    let mut loads_by_elem: std::collections::HashMap<usize, Vec<&SolverLoad>> =
+        std::collections::HashMap::new();
+    for load in loads {
+        let eid = match load {
+            SolverLoad::Distributed(l) => l.element_id,
+            SolverLoad::PointOnElement(l) => l.element_id,
+            SolverLoad::Thermal(l) => l.element_id,
+            SolverLoad::Nodal(_) => continue,
+        };
+        loads_by_elem.entry(eid).or_default().push(load);
+    }
+
     for elem in input.elements.values() {
         let node_i = node_map[&elem.node_i];
         let node_j = node_map[&elem.node_j];
@@ -3076,7 +3091,7 @@ pub(crate) fn compute_internal_forces_2d_with_loads(
             let mut n_axial = e * sec.a / l * delta;
 
             // Subtract thermal FEF for truss: f = K*u - FEF (matches 3D truss path)
-            for load in loads {
+            for load in loads_by_elem.get(&elem.id).unwrap_or(&empty_loads) {
                 if let SolverLoad::Thermal(tl) = load {
                     if tl.element_id == elem.id {
                         let alpha = 12e-6;
@@ -3132,7 +3147,7 @@ pub(crate) fn compute_internal_forces_2d_with_loads(
             let mut point_loads_info = Vec::new();
             let mut dist_loads_info = Vec::new();
 
-            for load in loads {
+            for load in loads_by_elem.get(&elem.id).unwrap_or(&empty_loads) {
                 match load {
                     SolverLoad::Distributed(dl) if dl.element_id == elem.id => {
                         let a = dl.a.unwrap_or(0.0);
@@ -3242,6 +3257,21 @@ pub(crate) fn compute_internal_forces_3d_with_loads(
     let sec_map: std::collections::HashMap<usize, &SolverSection3D> =
         input.sections.values().map(|s| (s.id, s)).collect();
 
+    // Index loads per element once — the per-element `for load in loads` rescans
+    // below made this O(E·L) per call, O(modes·E·L) in spectral solves.
+    let empty_loads: Vec<&SolverLoad3D> = Vec::new();
+    let mut loads_by_elem: std::collections::HashMap<usize, Vec<&SolverLoad3D>> =
+        std::collections::HashMap::new();
+    for load in loads {
+        let eid = match load {
+            SolverLoad3D::Distributed(l) => l.element_id,
+            SolverLoad3D::PointOnElement(l) => l.element_id,
+            SolverLoad3D::Thermal(l) => l.element_id,
+            _ => continue, // nodal / shell-surface loads don't apply to frame/truss elements
+        };
+        loads_by_elem.entry(eid).or_default().push(load);
+    }
+
     for elem in input.elements.values() {
         let node_i = node_map[&elem.node_i];
         let node_j = node_map[&elem.node_j];
@@ -3271,7 +3301,7 @@ pub(crate) fn compute_internal_forces_3d_with_loads(
             // f_local_axial = EA/L * delta - (-EAαΔT) = EA/L * delta + EAαΔT
             // n = -f_local_axial (sign convention) → n = -(EA/L * delta + EAαΔT)
             // Equivalently: subtract EAαΔT from n_axial before the sign convention is applied
-            for load in loads {
+            for load in loads_by_elem.get(&elem.id).unwrap_or(&empty_loads) {
                 if let SolverLoad3D::Thermal(tl) = load {
                     if tl.element_id == elem.id {
                         let alpha = 12e-6;
@@ -3395,7 +3425,7 @@ pub(crate) fn compute_internal_forces_3d_with_loads(
         let mut pt_loads_y = Vec::new();
         let mut pt_loads_z = Vec::new();
 
-        for load in loads {
+        for load in loads_by_elem.get(&elem.id).unwrap_or(&empty_loads) {
             match load {
                 SolverLoad3D::Distributed(dl) if dl.element_id == elem.id => {
                     let a_param = dl.a.unwrap_or(0.0);


### PR DESCRIPTION
Three hot-path sites did O(E·(E+N)) or O(E·L) per call by rescanning maps for every element:

- `postprocess/diagrams.rs` `compute_diagrams_2d`: three `HashMap::values().find()` per element (element + two nodes) → id-maps built once before the loop.
- `linear.rs` `compute_internal_forces_2d/3d_with_loads`: full `for load in loads` rescan per element — O(E·L) per call, O(modes·E·L) in spectral solves → loads indexed per element id once.
- `assembly.rs` `assemble_load_vector_3d_sparse`: 10 `.values().find()` over quad9/solid/curved-shell maps — O(loads × shells) → quad9/solid-shell/curved-shell id-maps added next to the existing plate/quad maps.

3 files, +59/−19. 4625 engine tests green (core + validation + gates).