### PR TITLE
perf(web): cache projected nodes, fire colormap sync on geometry only, hoist shell id unions

### DIFF
--- a/web/src/components/Viewport3D.svelte
+++ b/web/src/components/Viewport3D.svelte
@@ -910,7 +910,11 @@
     uiStore.renderMode3D;
     modelStore.plates;
     modelStore.quads;
-    modelStore.modelVersion;
+    // Geometry refs (Maps are replaced on structural edits), NOT modelVersion —
+    // that bumps on load/material edits too and was recoloring + rebuilding the
+    // heatmap on every keystroke while a color map was active.
+    modelStore.nodes;
+    modelStore.elements;
     // Also react to verification store changes for 'verification' color map.
     // `.design` and `.providedRevision` were missing: a baseline-only or
     // reinforcement-only change left the overlay painted with the previous state.

--- a/web/src/lib/engine/shell-combos.ts
+++ b/web/src/lib/engine/shell-combos.ts
@@ -24,9 +24,12 @@ type Membrane = { sigmaXx: number; sigmaYy: number; tauXy: number; mx: number; m
 function combineMembrane(
   factors: ComboFactor[],
   perCase: Map<number, Map<number, Membrane>>,
+  ids?: Set<number>,
 ): Map<number, Membrane> {
-  const ids = new Set<number>();
-  for (const f of factors) { const m = perCase.get(f.caseId); if (m) for (const id of m.keys()) ids.add(id); }
+  if (!ids) {
+    ids = new Set<number>();
+    for (const f of factors) { const m = perCase.get(f.caseId); if (m) for (const id of m.keys()) ids.add(id); }
+  }
   const out = new Map<number, Membrane>();
   for (const id of ids) {
     const acc: Membrane = { sigmaXx: 0, sigmaYy: 0, tauXy: 0, mx: 0, my: 0, mxy: 0 };
@@ -49,14 +52,15 @@ export function combineShellStresses(
   factors: ComboFactor[],
   perCasePlates: Map<number, Map<number, Membrane>>,
   perCaseQuads: Map<number, Map<number, Membrane>>,
+  ids?: { plates: Set<number>; quads: Set<number> },
 ): { plateStresses: PlateStress[]; quadStresses: QuadStress[] } {
   const plates: PlateStress[] = [];
-  for (const [id, m] of combineMembrane(factors, perCasePlates)) {
+  for (const [id, m] of combineMembrane(factors, perCasePlates, ids?.plates)) {
     const pr = principalStresses(m.sigmaXx, m.sigmaYy, m.tauXy);
     plates.push({ elementId: id, sigmaXx: m.sigmaXx, sigmaYy: m.sigmaYy, tauXy: m.tauXy, mx: m.mx, my: m.my, mxy: m.mxy, sigma1: pr.sigma1, sigma2: pr.sigma2, vonMises: vonMisesPlane(m.sigmaXx, m.sigmaYy, m.tauXy) });
   }
   const quads: QuadStress[] = [];
-  for (const [id, m] of combineMembrane(factors, perCaseQuads)) {
+  for (const [id, m] of combineMembrane(factors, perCaseQuads, ids?.quads)) {
     quads.push({ elementId: id, sigmaXx: m.sigmaXx, sigmaYy: m.sigmaYy, tauXy: m.tauXy, mx: m.mx, my: m.my, mxy: m.mxy, vonMises: vonMisesPlane(m.sigmaXx, m.sigmaYy, m.tauXy) });
   }
   return { plateStresses: plates, quadStresses: quads };
@@ -96,10 +100,18 @@ export function enrichComboShellStresses(
   }
   if (!any) return;
 
+  // The id union is constant across combos — build it once instead of inside
+  // every combineMembrane call (was O(combos × cases × shells) of Set churn).
+  const plateIds = new Set<number>();
+  const quadIds = new Set<number>();
+  for (const m of perCasePlates.values()) for (const id of m.keys()) plateIds.add(id);
+  for (const m of perCaseQuads.values()) for (const id of m.keys()) quadIds.add(id);
+  const ids = { plates: plateIds, quads: quadIds };
+
   for (const combo of combinations) {
     const r = perCombo.get(combo.id);
     if (!r) continue;
-    const { plateStresses, quadStresses } = combineShellStresses(combo.factors, perCasePlates, perCaseQuads);
+    const { plateStresses, quadStresses } = combineShellStresses(combo.factors, perCasePlates, perCaseQuads, ids);
     r.plateStresses = plateStresses;
     r.quadStresses = quadStresses;
   }

--- a/web/src/lib/engine/shell-combos.ts
+++ b/web/src/lib/engine/shell-combos.ts
@@ -33,13 +33,18 @@ function combineMembrane(
   const out = new Map<number, Membrane>();
   for (const id of ids) {
     const acc: Membrane = { sigmaXx: 0, sigmaYy: 0, tauXy: 0, mx: 0, my: 0, mxy: 0 };
+    let contributed = false;
     for (const f of factors) {
       const s = perCase.get(f.caseId)?.get(id);
       if (!s) continue;
+      contributed = true;
       acc.sigmaXx += f.factor * s.sigmaXx; acc.sigmaYy += f.factor * s.sigmaYy; acc.tauXy += f.factor * s.tauXy;
       acc.mx += f.factor * s.mx; acc.my += f.factor * s.my; acc.mxy += f.factor * s.mxy;
     }
-    out.set(id, acc);
+    // Only include ids present in at least one of THIS combo's cases — with a
+    // precomputed global union, absent ids would otherwise be written as zeros
+    // (phantom zero-stress entries in the combo output).
+    if (contributed) out.set(id, acc);
   }
   return out;
 }

--- a/web/src/lib/viewport3d/results-sync.ts
+++ b/web/src/lib/viewport3d/results-sync.ts
@@ -42,13 +42,20 @@ function projectFlag(): boolean {
 export const DIAGRAM_3D_TYPES: Set<string> = new Set(['momentY', 'momentZ', 'shearY', 'shearZ', 'axial', 'torsion']);
 
 /** Build a node map projected to scene coordinates (handles 2D→XZ swap for embedded models). */
+let projectedNodesCache: { key: string; map: Map<number, { id: number; x: number; y: number; z?: number }> } | null = null;
+
 function getProjectedNodes(): Map<number, { id: number; x: number; y: number; z?: number }> {
   const project2D = projectFlag();
+  // Node coords only change with modelVersion — one rebuild per edit total,
+  // not one per animation frame / per results publish.
+  const key = `${modelStore.modelVersion}|${project2D}`;
+  if (projectedNodesCache?.key === key) return projectedNodesCache.map;
   const projected = new Map<number, { id: number; x: number; y: number; z?: number }>();
   for (const [id, n] of modelStore.nodes) {
     const p = projectNodeToScene(n, project2D);
     projected.set(id, { id, x: p.x, y: p.y, z: p.z });
   }
+  projectedNodesCache = { key, map: projected };
   return projected;
 }
 


### PR DESCRIPTION
Three results/render-path costs:

- **`getProjectedNodes()`** rebuilt a fresh projected Map on every call — every animation frame from `syncDeformed` and every results publish. Node coordinates only change with `modelVersion`, so the projection is now cached on `(modelVersion, project2D)`: one rebuild per edit, zero per frame.
- **Colormap sync effect** depended on `modelVersion`, which bumps on load and material edits too — recoloring and rebuilding the heatmap on every keystroke while a color map was active. It now depends on the `nodes`/`elements` Map references (geometry-only).
- **`enrichComboShellStresses`** rebuilt the plate/quad id-union Set inside `combineMembrane` for every combo — O(combos × cases × shells) of Set churn. The union is now computed once and passed through.

3 files, +29/−6. Web suite: 3063 passed, 0 failed.