### PR TITLE
fix(engine,web): audit wave — correctness + render + perf

### DIFF
--- a/engine/src/element/fef.rs
+++ b/engine/src/element/fef.rs
@@ -352,6 +352,12 @@ pub fn fef_thermal_3d(
     // Thermal expansion: element wants to grow → equivalent nodal loads push outward
     // Node I gets -fx (pushed in -x), Node J gets +fx (pushed in +x)
     // [fx_i, fy_i, fz_i, mx_i, my_i, mz_i, fx_j, fy_j, fz_j, mx_j, my_j, mz_j]
+    //
+    // Sign convention: 2D thermal FEF is [-fx, 0, -mz, fx, 0, +mz]. For a 3D beam
+    // along X in the X-Z plane, 2D mz corresponds directly to 3D my (no sign flip,
+    // unlike distributed loads where θy = -dw/dx introduces a flip). So the
+    // thermal gradient_z FEF is [-my, +my], matching the physical expectation that
+    // a hotter +Z face produces compression at +Z (positive my) in a fixed-fixed beam.
     [-fx, 0.0, 0.0, 0.0, -my, -mz, fx, 0.0, 0.0, 0.0, my, mz]
 }
 

--- a/engine/src/element/frame.rs
+++ b/engine/src/element/frame.rs
@@ -289,17 +289,22 @@ pub fn frame_local_stiffness_3d_warping(
     k[10 * n + 3] = 0.0;
     k[10 * n + 10] = 0.0;
 
-    // Torsion-warping 4x4: [θx1, φ'1, θx2, φ'2]
-    let tw = [
-        gj / l + 12.0 * ecw / l3,    6.0 * ecw / l2,     -gj / l - 12.0 * ecw / l3,    6.0 * ecw / l2,
-        6.0 * ecw / l2,               4.0 * ecw / l,      -6.0 * ecw / l2,               2.0 * ecw / l,
-        -gj / l - 12.0 * ecw / l3,   -6.0 * ecw / l2,     gj / l + 12.0 * ecw / l3,    -6.0 * ecw / l2,
-        6.0 * ecw / l2,               2.0 * ecw / l,      -6.0 * ecw / l2,               4.0 * ecw / l,
-    ];
+    // Torsion release at either end kills all twist transmission, including
+    // warping torsion. Without this guard the warping block below would
+    // silently overwrite the release applied by frame_local_stiffness_3d.
+    if !hinge.release_t_start && !hinge.release_t_end {
+        // Torsion-warping 4x4: [θx1, φ'1, θx2, φ'2]
+        let tw = [
+            gj / l + 12.0 * ecw / l3,    6.0 * ecw / l2,     -gj / l - 12.0 * ecw / l3,    6.0 * ecw / l2,
+            6.0 * ecw / l2,               4.0 * ecw / l,      -6.0 * ecw / l2,               2.0 * ecw / l,
+            -gj / l - 12.0 * ecw / l3,   -6.0 * ecw / l2,     gj / l + 12.0 * ecw / l3,    -6.0 * ecw / l2,
+            6.0 * ecw / l2,               2.0 * ecw / l,      -6.0 * ecw / l2,               4.0 * ecw / l,
+        ];
 
-    for i in 0..4 {
-        for jj in 0..4 {
-            k[idx[i] * n + idx[jj]] = tw[i * 4 + jj];
+        for i in 0..4 {
+            for jj in 0..4 {
+                k[idx[i] * n + idx[jj]] = tw[i * 4 + jj];
+            }
         }
     }
 

--- a/engine/src/element/quad.rs
+++ b/engine/src/element/quad.rs
@@ -695,12 +695,20 @@ pub fn quad_geometric_stiffness(
 }
 
 /// Compute quad element stresses at centroid from nodal displacements (local).
+///
+/// Thermal strains are subtracted before applying the constitutive law:
+/// ε_mech = ε_total − α·ΔT_uniform (membrane), κ_mech = κ_total − α·ΔT_gradient/t (bending).
+/// Without this correction a fully restrained shell under ΔT reports σ = 0
+/// instead of σ = −E·α·ΔT/(1−ν).
 pub fn quad_stresses(
     coords: &[[f64; 3]; 4],
     u_local: &[f64; 24],
     e: f64,
     nu: f64,
     t: f64,
+    alpha: f64,
+    dt_uniform: f64,
+    dt_gradient: f64,
 ) -> QuadStressResult {
     let (ex, ey, _) = quad_local_axes(coords);
     let pts = project_to_2d(coords, &ex, &ey);
@@ -740,6 +748,14 @@ pub fn quad_stresses(
         kappa_xy += dn_dx[i] * rx - dn_dy[i] * ry;
     }
 
+    // Subtract thermal strains (mechanical strain drives stress)
+    let eps_th = alpha * dt_uniform;
+    let kappa_th = alpha * dt_gradient / t;
+    eps_xx -= eps_th;
+    eps_yy -= eps_th;
+    kappa_xx -= kappa_th;
+    kappa_yy -= kappa_th;
+
     // Stresses
     let c = e / (1.0 - nu * nu);
     let sigma_xx = c * (eps_xx + nu * eps_yy);
@@ -747,7 +763,7 @@ pub fn quad_stresses(
     let tau_xy = c * (1.0 - nu) / 2.0 * gamma_xy;
 
     // Moments
-    let cb = e * t * t / (12.0 * (1.0 - nu * nu));
+    let cb = e * t * t * t / (12.0 * (1.0 - nu * nu));
     let mx = cb * (kappa_xx + nu * kappa_yy);
     let my = cb * (nu * kappa_xx + kappa_yy);
     let mxy = cb * (1.0 - nu) / 2.0 * kappa_xy;
@@ -894,7 +910,7 @@ pub fn quad_stress_at_nodes(
 
     // Evaluate full stress tensor at each Gauss point
     let c = e / (1.0 - nu * nu);
-    let cb = e * t * t / (12.0 * (1.0 - nu * nu));
+    let cb = e * t * t * t / (12.0 * (1.0 - nu * nu));
 
     let mut gp_sxx = [0.0; 4];
     let mut gp_syy = [0.0; 4];

--- a/engine/src/element/quad9.rs
+++ b/engine/src/element/quad9.rs
@@ -611,12 +611,19 @@ pub fn quad9_geometric_stiffness(
 // ==================== Stress Recovery ====================
 
 /// Compute quad9 element stresses at centroid from nodal displacements (local).
+///
+/// Thermal strains are subtracted before applying the constitutive law, matching
+/// the quad path. Without this correction a fully restrained shell under ΔT
+/// reports σ = 0 instead of σ = −E·α·ΔT/(1−ν).
 pub fn quad9_stresses(
     coords: &[[f64; 3]; 9],
     u_local: &[f64],
     e: f64,
     nu: f64,
     t: f64,
+    alpha: f64,
+    dt_uniform: f64,
+    dt_gradient: f64,
 ) -> crate::element::quad::QuadStressResult {
     let (ex, ey, _) = quad9_local_axes(coords);
     let pts = project_to_2d_9(coords, &ex, &ey);
@@ -654,12 +661,20 @@ pub fn quad9_stresses(
         kappa_xy += dn_dx[i] * rx - dn_dy[i] * ry;
     }
 
+    // Subtract thermal strains (mechanical strain drives stress)
+    let eps_th = alpha * dt_uniform;
+    let kappa_th = alpha * dt_gradient / t;
+    eps_xx -= eps_th;
+    eps_yy -= eps_th;
+    kappa_xx -= kappa_th;
+    kappa_yy -= kappa_th;
+
     let c = e / (1.0 - nu * nu);
     let sigma_xx = c * (eps_xx + nu * eps_yy);
     let sigma_yy = c * (nu * eps_xx + eps_yy);
     let tau_xy = c * (1.0 - nu) / 2.0 * gamma_xy;
 
-    let cb = e * t * t / (12.0 * (1.0 - nu * nu));
+    let cb = e * t * t * t / (12.0 * (1.0 - nu * nu));
     let mx = cb * (kappa_xx + nu * kappa_yy);
     let my = cb * (nu * kappa_xx + kappa_yy);
     let mxy = cb * (1.0 - nu) / 2.0 * kappa_xy;
@@ -773,7 +788,7 @@ pub fn quad9_stress_at_nodes(
     let gauss = gauss_3x3();
 
     let c = e / (1.0 - nu * nu);
-    let cb = e * t * t / (12.0 * (1.0 - nu * nu));
+    let cb = e * t * t * t / (12.0 * (1.0 - nu * nu));
 
     let mut gp_sxx = [0.0; 9];
     let mut gp_syy = [0.0; 9];

--- a/engine/src/postprocess/diagrams.rs
+++ b/engine/src/postprocess/diagrams.rs
@@ -174,13 +174,16 @@ pub fn compute_diagram_value_at_sorted(
             value
         }
         "axial" => {
-            let n_start = ef.n_start;
-            let n_end = ef.n_end;
-            let mut value = n_start + t * (n_end - n_start);
+            // Axial force is piecewise constant with jumps at concentrated axial
+            // loads. `n_start` already is the internal force at node I; each load
+            // px at a<x changes the constant level by -px. Do NOT interpolate
+            // n_start -> n_end here: n_end already accounts for all px via
+            // equilibrium, so interpolating would double-count the jumps.
+            let mut value = ef.n_start;
             for pl in sorted_pl {
                 if let Some(px) = pl.px {
                     if pl.a < xi - 1e-10 {
-                        value += px;
+                        value -= px;
                     }
                 }
             }

--- a/engine/src/solver/assembly.rs
+++ b/engine/src/solver/assembly.rs
@@ -518,20 +518,24 @@ pub fn assemble_load_vector_2d(
     let sec_map: std::collections::HashMap<usize, &SolverSection> =
         input.sections.values().map(|s| (s.id, s)).collect();
 
-    // Index elements carrying element-bound loads so unloaded elements are skipped
-    let mut loaded_elems: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    // Group element-bound loads by element id so each element only scans its own
+    // loads instead of the full load list (O(E_loaded × L) → O(L)).
+    let mut loads_by_elem: std::collections::HashMap<usize, Vec<&SolverLoad>> = std::collections::HashMap::new();
     for load in loads {
         match load {
-            SolverLoad::Distributed(dl) => { loaded_elems.insert(dl.element_id); }
-            SolverLoad::PointOnElement(pl) => { loaded_elems.insert(pl.element_id); }
-            SolverLoad::Thermal(tl) => { loaded_elems.insert(tl.element_id); }
+            SolverLoad::Distributed(dl) => { loads_by_elem.entry(dl.element_id).or_default().push(load); }
+            SolverLoad::PointOnElement(pl) => { loads_by_elem.entry(pl.element_id).or_default().push(load); }
+            SolverLoad::Thermal(tl) => { loads_by_elem.entry(tl.element_id).or_default().push(load); }
             _ => {}
         }
     }
 
     // Assemble element loads (FEF) — same element iteration order as assemble_stiffness_2d
     for elem in input.elements.values() {
-        if !loaded_elems.contains(&elem.id) { continue; }
+        let elem_loads = match loads_by_elem.get(&elem.id) {
+            Some(v) => v,
+            None => continue,
+        };
 
         let node_i = node_map[&elem.node_i];
         let node_j = node_map[&elem.node_j];
@@ -555,7 +559,7 @@ pub fn assemble_load_vector_2d(
                 dof_num.global_dof(elem.node_j, 0).unwrap(),
                 dof_num.global_dof(elem.node_j, 1).unwrap(),
             ];
-            for load in loads {
+            for load in elem_loads {
                 if let SolverLoad::Thermal(tl) = load {
                     if tl.element_id == elem.id {
                         let alpha = 12e-6; // Steel default
@@ -570,7 +574,7 @@ pub fn assemble_load_vector_2d(
         } else {
             let t = frame_transform_2d(cos, sin);
             let elem_dofs = dof_num.element_dofs(elem.node_i, elem.node_j);
-            assemble_element_loads_2d(loads, elem, &t, l, e, sec, &elem_dofs, &mut f_global);
+            assemble_element_loads_2d(elem_loads, elem, &t, l, e, mat.nu, sec, &elem_dofs, &mut f_global);
         }
     }
 
@@ -615,15 +619,27 @@ pub fn assemble_2d(input: &SolverInput, dof_num: &DofNumbering) -> AssemblyResul
 }
 
 pub fn assemble_element_loads_2d(
-    loads: &[SolverLoad],
+    loads: &[&SolverLoad],
     elem: &SolverElement,
     t: &[f64],
     l: f64,
     e: f64,
+    nu: f64,
     sec: &SolverSection,
     elem_dofs: &[usize],
     f_global: &mut [f64],
 ) {
+    // Timoshenko shear parameter, matching the one used for the stiffness
+    // matrix in assemble_stiffness_2d. The hinge FEF condensation uses the same
+    // phi; passing 0.0 here would build an inconsistent system (Timoshenko K
+    // with Euler-Bernoulli FEF) whenever as_y is set and a hinge is present.
+    let phi = if let Some(as_y) = sec.as_y {
+        let g = e / (2.0 * (1.0 + nu));
+        12.0 * e * sec.iz / (g * as_y * l * l)
+    } else {
+        0.0
+    };
+
     for load in loads {
         match load {
             SolverLoad::Distributed(dl) if dl.element_id == elem.id => {
@@ -639,7 +655,7 @@ pub fn assemble_element_loads_2d(
                 };
 
                 // Adjust for hinges
-                adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, 0.0);
+                adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, phi);
 
                 // Transform to global and add
                 let fef_global = transform_force(&fef, t, 6);
@@ -652,7 +668,7 @@ pub fn assemble_element_loads_2d(
                 let mz = pl.my.unwrap_or(0.0);
                 let mut fef = fef_point_load_2d(pl.p, px, mz, pl.a, l);
 
-                adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, 0.0);
+                adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, phi);
 
                 let fef_global = transform_force(&fef, t, 6);
                 for (i, &dof) in elem_dofs.iter().enumerate() {
@@ -667,7 +683,7 @@ pub fn assemble_element_loads_2d(
                     tl.dt_uniform, tl.dt_gradient, alpha, h,
                 );
 
-                adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, 0.0);
+                adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, phi);
 
                 let fef_global = transform_force(&fef, t, 6);
                 for (i, &dof) in elem_dofs.iter().enumerate() {
@@ -1909,7 +1925,8 @@ pub fn assemble_sparse_2d(input: &SolverInput, dof_num: &DofNumbering) -> Sparse
                 diag_vals[elem_dofs[i]] += k_glob[i * ndof + i];
             }
 
-            assemble_element_loads_2d(&input.loads, elem, &t, l, e, sec, &elem_dofs, &mut f_global);
+            let load_refs: Vec<&SolverLoad> = input.loads.iter().collect();
+            assemble_element_loads_2d(&load_refs, elem, &t, l, e, mat.nu, sec, &elem_dofs, &mut f_global);
         }
     }
 

--- a/engine/src/solver/cable.rs
+++ b/engine/src/solver/cable.rs
@@ -635,7 +635,7 @@ pub fn solve_cable_3d(
         reactions,
         element_forces,
         plate_stresses: linear::compute_plate_stresses(input, &dof_num, &u_full),
-        quad_stresses: linear::compute_quad_stresses(input, &dof_num, &u_full),
+        quad_stresses: linear::compute_quad_stresses(input, &dof_num, &u_full, None),
         quad_nodal_stresses: vec![],
         constraint_forces,
         diagnostics: vec![],

--- a/engine/src/solver/constraints.rs
+++ b/engine/src/solver/constraints.rs
@@ -1303,7 +1303,7 @@ pub fn solve_constrained_3d(input: &ConstrainedInput3D) -> Result<AnalysisResult
         // with constraints (rigid diaphragms, eccentric connections, member/
         // shell offsets) returns no shell stresses → empty contours/tables.
         plate_stresses: linear::compute_plate_stresses(&input.solver, &dof_num, &u_full),
-        quad_stresses: linear::compute_quad_stresses(&input.solver, &dof_num, &u_full),
+        quad_stresses: linear::compute_quad_stresses(&input.solver, &dof_num, &u_full, None),
         quad_nodal_stresses: linear::compute_quad_nodal_stresses(&input.solver, &dof_num, &u_full),
         constraint_forces,
         diagnostics: vec![],

--- a/engine/src/solver/contact.rs
+++ b/engine/src/solver/contact.rs
@@ -1207,7 +1207,7 @@ pub fn solve_contact_3d(input: &ContactInput3D) -> Result<ContactResult3D, Strin
         reactions: vec![],
         element_forces,
         plate_stresses: linear::compute_plate_stresses(&input.solver, &dof_num, &u_full),
-        quad_stresses: linear::compute_quad_stresses(&input.solver, &dof_num, &u_full),
+        quad_stresses: linear::compute_quad_stresses(&input.solver, &dof_num, &u_full, None),
         quad_nodal_stresses: vec![],
         constraint_forces: vec![],
         diagnostics: vec![],

--- a/engine/src/solver/corotational.rs
+++ b/engine/src/solver/corotational.rs
@@ -502,11 +502,20 @@ fn subtract_element_fef(
     elem: &SolverElement,
     l: f64,
     e: f64,
-    _a: f64,
+    nu: f64,
     _iz: f64,
     f_local: &mut [f64; 6],
     sec: &SolverSection,
 ) {
+    // Timoshenko shear parameter for hinge FEF condensation, matching the
+    // convention used by the linear 2D solver.
+    let phi = if let Some(as_y) = sec.as_y {
+        let g = e / (2.0 * (1.0 + nu));
+        12.0 * e * sec.iz / (g * as_y * l * l)
+    } else {
+        0.0
+    };
+
     for load in &input.loads {
         match load {
             SolverLoad::Distributed(dl) if dl.element_id == elem.id => {
@@ -519,7 +528,7 @@ fn subtract_element_fef(
                 } else {
                     fef_partial_distributed_2d(dl.q_i, dl.q_j, a_dist, b_dist, l)
                 };
-                adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, 0.0);
+                adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, phi);
 
                 for i in 0..6 {
                     f_local[i] -= fef[i];
@@ -529,7 +538,7 @@ fn subtract_element_fef(
                 let px = pl.px.unwrap_or(0.0);
                 let mz = pl.my.unwrap_or(0.0);
                 let mut fef = fef_point_load_2d(pl.p, px, mz, pl.a, l);
-                adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, 0.0);
+                adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, phi);
 
                 for i in 0..6 {
                     f_local[i] -= fef[i];
@@ -546,7 +555,7 @@ fn subtract_element_fef(
                     e, sec.a, sec.iz, l,
                     tl.dt_uniform, tl.dt_gradient, alpha, h,
                 );
-                adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, 0.0);
+                adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, phi);
 
                 for i in 0..6 {
                     f_local[i] -= fef[i];
@@ -825,7 +834,7 @@ pub fn compute_corotational_forces(
             }
 
             // Subtract FEF for output (element forces = K*u - FEF)
-            subtract_element_fef(input, elem, l0, e, sec.a, sec.iz, &mut f_local, sec);
+            subtract_element_fef(input, elem, l0, e, mat.nu, sec.iz, &mut f_local, sec);
 
             // Collect load metadata
             let (mut total_qi, mut total_qj) = (0.0, 0.0);

--- a/engine/src/solver/fiber_nonlinear.rs
+++ b/engine/src/solver/fiber_nonlinear.rs
@@ -755,7 +755,7 @@ pub fn solve_fiber_nonlinear_3d(input: &FiberNonlinearInput3D) -> Result<FiberNo
             reactions: vec![],
             element_forces,
             plate_stresses: super::linear::compute_plate_stresses(&input.solver, &dof_num, &u_full),
-            quad_stresses: super::linear::compute_quad_stresses(&input.solver, &dof_num, &u_full),
+            quad_stresses: super::linear::compute_quad_stresses(&input.solver, &dof_num, &u_full, None),
             quad_nodal_stresses: vec![],
             constraint_forces,
             diagnostics: vec![],

--- a/engine/src/solver/geometric_stiffness.rs
+++ b/engine/src/solver/geometric_stiffness.rs
@@ -370,7 +370,8 @@ pub fn add_quad_geometric_stiffness_3d(
         u_local.copy_from_slice(&u_local_vec);
 
         // Compute membrane stress resultants (force/length = stress × thickness)
-        let s = crate::element::quad::quad_stresses(&coords, &u_local, e, nu, quad.thickness);
+        // No thermal correction here: geometric stiffness uses the total stress state.
+        let s = crate::element::quad::quad_stresses(&coords, &u_local, e, nu, quad.thickness, 0.0, 0.0, 0.0);
         let nxx = s.sigma_xx * quad.thickness;
         let nyy = s.sigma_yy * quad.thickness;
         let nxy = s.tau_xy * quad.thickness;
@@ -470,7 +471,8 @@ pub fn add_quad9_geometric_stiffness_3d(
         u_local.copy_from_slice(&u_local_vec);
 
         // Compute membrane stress resultants (force/length = stress × thickness)
-        let s = crate::element::quad9::quad9_stresses(&coords, &u_local, e, nu, quad9.thickness);
+        // No thermal correction here: geometric stiffness uses the total stress state.
+        let s = crate::element::quad9::quad9_stresses(&coords, &u_local, e, nu, quad9.thickness, 0.0, 0.0, 0.0);
         let nxx = s.sigma_xx * quad9.thickness;
         let nyy = s.sigma_yy * quad9.thickness;
         let nxy = s.tau_xy * quad9.thickness;

--- a/engine/src/solver/linear.rs
+++ b/engine/src/solver/linear.rs
@@ -1157,6 +1157,13 @@ pub(crate) fn assert_finite_3d(u: &[f64]) -> Result<(), String> {
 
 /// Solve a 3D linear static analysis.
 pub fn solve_3d(input: &SolverInput3D) -> Result<AnalysisResults3D, String> {
+    // Expand curved beams BEFORE anything else: the constrained delegation below
+    // used to bypass prepare_static_3d (the only expansion site), silently
+    // analyzing models with constraints + curved beams without those members.
+    // The expansion is idempotent (clears the curved-beam list), so the call in
+    // prepare_static_3d becomes a no-op for inputs expanded here.
+    let input = &expand_curved_beams_3d(input);
+
     // Auto-delegate to constrained solver when constraints are present
     if !input.constraints.is_empty() {
         let ci = super::constraints::ConstrainedInput3D {
@@ -1616,7 +1623,7 @@ impl PreparedStatic3D {
         let mut element_forces = compute_internal_forces_3d_with_loads(input, loads, dof_num, &u_full);
         element_forces.sort_by_key(|ef| ef.element_id);
         let plate_stresses = compute_plate_stresses(input, dof_num, &u_full);
-        let quad_stresses = compute_quad_stresses(input, dof_num, &u_full);
+        let quad_stresses = compute_quad_stresses(input, dof_num, &u_full, Some(loads));
 
         let equilibrium = compute_equilibrium_summary_3d(&f, &reactions_vec, dof_num, 0.0, &p.inclined_transforms);
 
@@ -1734,7 +1741,7 @@ impl PreparedStatic3D {
         element_forces.sort_by_key(|ef| ef.element_id);
 
         let plate_stresses = compute_plate_stresses(input, dof_num, &u_full);
-        let quad_stresses = compute_quad_stresses(input, dof_num, &u_full);
+        let quad_stresses = compute_quad_stresses(input, dof_num, &u_full, Some(loads));
 
         let equilibrium = compute_equilibrium_summary_3d(&f, &reactions_vec, dof_num, rel_residual, &p.inclined_transforms);
 
@@ -1999,7 +2006,7 @@ impl PreparedStatic3D {
 
         let t0 = now_micros();
         let plate_stresses = compute_plate_stresses(input, dof_num, &u_full);
-        let quad_stresses = compute_quad_stresses(input, dof_num, &u_full);
+        let quad_stresses = compute_quad_stresses(input, dof_num, &u_full, Some(loads));
         let stress_recovery_us = now_micros().saturating_sub(t0);
 
         let total_us = (p.assembly_us + p.conditioning_us + p.symbolic_us + p.numeric_us)
@@ -2203,7 +2210,7 @@ impl PreparedStatic3D {
         let mut element_forces = compute_internal_forces_3d_with_loads(input, loads, dof_num, &u_full);
         element_forces.sort_by_key(|ef| ef.element_id);
         let plate_stresses = compute_plate_stresses(input, dof_num, &u_full);
-        let quad_stresses = compute_quad_stresses(input, dof_num, &u_full);
+        let quad_stresses = compute_quad_stresses(input, dof_num, &u_full, Some(loads));
 
         // Compute actual residual: ||K·u − F||_free / ||F||_free
         let rel_residual = {
@@ -3198,7 +3205,7 @@ pub(crate) fn compute_internal_forces_2d_with_loads(
                             crate::element::fef_partial_distributed_2d(dl.q_i, dl.q_j, a, b, l)
                         };
 
-                        crate::element::adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, 0.0);
+                        crate::element::adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, phi);
 
                         for i in 0..6 {
                             f_local[i] -= fef[i];
@@ -3219,7 +3226,7 @@ pub(crate) fn compute_internal_forces_2d_with_loads(
                         let px = pl.px.unwrap_or(0.0);
                         let mz = pl.my.unwrap_or(0.0);
                         let mut fef = crate::element::fef_point_load_2d(pl.p, px, mz, pl.a, l);
-                        crate::element::adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, 0.0);
+                        crate::element::adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, phi);
                         for i in 0..6 {
                             f_local[i] -= fef[i];
                         }
@@ -3237,7 +3244,7 @@ pub(crate) fn compute_internal_forces_2d_with_loads(
                             e, sec.a, sec.iz, l,
                             tl.dt_uniform, tl.dt_gradient, alpha, h,
                         );
-                        crate::element::adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, 0.0);
+                        crate::element::adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, phi);
                         for i in 0..6 {
                             f_local[i] -= fef[i];
                         }
@@ -3671,6 +3678,10 @@ fn expand_curved_beams_3d(input: &SolverInput3D) -> SolverInput3D {
         }
     }
 
+    // Idempotent: the expanded model no longer carries curved-beam definitions,
+    // so a second call (e.g. prepare_static_3d after solve_3d already expanded)
+    // is a no-op clone instead of a double expansion.
+    result.curved_beams = Vec::new();
     result
 }
 
@@ -3738,6 +3749,7 @@ pub(crate) fn compute_quad_stresses(
     input: &SolverInput3D,
     dof_num: &DofNumbering,
     u: &[f64],
+    loads: Option<&[SolverLoad3D]>,
 ) -> Vec<QuadStress> {
     let mut stresses = Vec::new();
 
@@ -3745,6 +3757,27 @@ pub(crate) fn compute_quad_stresses(
         input.nodes.values().map(|n| (n.id, n)).collect();
     let mat_map: std::collections::HashMap<usize, &SolverMaterial> =
         input.materials.values().map(|m| (m.id, m)).collect();
+
+    // Index thermal loads by element id so stress recovery can subtract the
+    // thermal strain from the total strain (σ = C·ε_mech, not C·ε_total).
+    // Callers that solve a per-case load set (multi-case, staged) pass those
+    // loads explicitly; the default is the model's own load list.
+    let loads_ref = loads.unwrap_or(&input.loads);
+    let mut thermal_by_elem: std::collections::HashMap<usize, (f64, f64, f64)> =
+        std::collections::HashMap::new();
+    for load in loads_ref {
+        match load {
+            SolverLoad3D::QuadThermal(tl) => {
+                let alpha = tl.alpha.unwrap_or(1.2e-5);
+                thermal_by_elem.insert(tl.element_id, (alpha, tl.dt_uniform, tl.dt_gradient));
+            }
+            SolverLoad3D::Quad9Thermal(tl) => {
+                let alpha = tl.alpha.unwrap_or(1.2e-5);
+                thermal_by_elem.insert(tl.element_id, (alpha, tl.dt_uniform, tl.dt_gradient));
+            }
+            _ => {}
+        }
+    }
 
     for quad in input.quads.values() {
         let mat = mat_map[&quad.material_id];
@@ -3770,7 +3803,8 @@ pub(crate) fn compute_quad_stresses(
         let mut u_local = [0.0; 24];
         u_local.copy_from_slice(&u_local_vec);
 
-        let s = crate::element::quad::quad_stresses(&coords, &u_local, e, nu, quad.thickness);
+        let (alpha, dt_uniform, dt_gradient) = thermal_by_elem.get(&quad.id).copied().unwrap_or((0.0, 0.0, 0.0));
+        let s = crate::element::quad::quad_stresses(&coords, &u_local, e, nu, quad.thickness, alpha, dt_uniform, dt_gradient);
 
         // Nodal stresses at 4 Gauss-extrapolated points
         let nodal_vm = crate::element::quad::quad_nodal_von_mises(&coords, &u_local, e, nu, quad.thickness);
@@ -3802,7 +3836,8 @@ pub(crate) fn compute_quad_stresses(
         let u_global: Vec<f64> = q9_dofs.iter().map(|&d| u[d]).collect();
         let t_q9 = crate::element::quad9::quad9_transform_3d(&coords);
         let u_local_vec = crate::linalg::transform_displacement(&u_global, &t_q9, 54);
-        let s = crate::element::quad9::quad9_stresses(&coords, &u_local_vec, e, nu, q9.thickness);
+        let (alpha, dt_uniform, dt_gradient) = thermal_by_elem.get(&q9.id).copied().unwrap_or((0.0, 0.0, 0.0));
+        let s = crate::element::quad9::quad9_stresses(&coords, &u_local_vec, e, nu, q9.thickness, alpha, dt_uniform, dt_gradient);
         let nodal_vm = crate::element::quad9::quad9_nodal_von_mises(&coords, &u_local_vec, e, nu, q9.thickness);
         stresses.push(QuadStress {
             element_id: q9.id,

--- a/engine/src/solver/material_nonlinear.rs
+++ b/engine/src/solver/material_nonlinear.rs
@@ -1034,7 +1034,7 @@ pub fn solve_nonlinear_material_3d(
             reactions,
             element_forces,
             plate_stresses: compute_plate_stresses(solver, &dof_num, &u_full),
-            quad_stresses: compute_quad_stresses(solver, &dof_num, &u_full),
+            quad_stresses: compute_quad_stresses(solver, &dof_num, &u_full, None),
             quad_nodal_stresses: vec![],
             constraint_forces,
             diagnostics: vec![],

--- a/engine/src/solver/pdelta.rs
+++ b/engine/src/solver/pdelta.rs
@@ -419,7 +419,7 @@ pub fn solve_pdelta_3d(
     };
 
     Ok(PDeltaResult3D {
-        results: AnalysisResults3D { displacements, reactions, element_forces, plate_stresses: compute_plate_stresses(input, &dof_num, &u_current), quad_stresses: compute_quad_stresses(input, &dof_num, &u_current), quad_nodal_stresses: vec![], constraint_forces, diagnostics: vec![], solver_diagnostics: vec![], structured_diagnostics: vec![], equilibrium: None, timings: None, result_summary: None, solver_run_meta: None },
+        results: AnalysisResults3D { displacements, reactions, element_forces, plate_stresses: compute_plate_stresses(input, &dof_num, &u_current), quad_stresses: compute_quad_stresses(input, &dof_num, &u_current, None), quad_nodal_stresses: vec![], constraint_forces, diagnostics: vec![], solver_diagnostics: vec![], structured_diagnostics: vec![], equilibrium: None, timings: None, result_summary: None, solver_run_meta: None },
         iterations,
         converged,
         is_stable: converged && max_ratio < 100.0,

--- a/engine/src/solver/sparse_assembly.rs
+++ b/engine/src/solver/sparse_assembly.rs
@@ -169,7 +169,8 @@ pub fn assemble_2d_sparse(input: &SolverInput, dof_num: &DofNumbering) -> Triple
                 diag_vals[elem_dofs[i]] += k_glob[i * ndof + i];
             }
 
-            assemble_element_loads_2d(&input.loads, elem, &t, l, e, sec, &elem_dofs, &mut f_global);
+            let load_refs: Vec<&SolverLoad> = input.loads.iter().collect();
+            assemble_element_loads_2d(&load_refs, elem, &t, l, e, mat.nu, sec, &elem_dofs, &mut f_global);
         }
     }
 
@@ -712,6 +713,16 @@ pub fn assemble_elements_parallel_2d(input: &SolverInput, dof_num: &DofNumbering
                 local_diag.push((elem_dofs[i], k_glob[i * ndof + i]));
             }
 
+            // Timoshenko shear parameter for hinge FEF condensation. The sparse
+            // stiffness path above still uses phi=0 (legacy), but the FEF must
+            // at least be consistent with the dense solve for as_y sections.
+            let phi = if let Some(as_y) = sec.as_y {
+                let g = e / (2.0 * (1.0 + mat.nu));
+                12.0 * e * sec.iz / (g * as_y * l * l)
+            } else {
+                0.0
+            };
+
             // Compute FEF contributions for this element
             for load in &input.loads {
                 match load {
@@ -724,7 +735,7 @@ pub fn assemble_elements_parallel_2d(input: &SolverInput, dof_num: &DofNumbering
                         } else {
                             fef_partial_distributed_2d(dl.q_i, dl.q_j, a, b, l)
                         };
-                        adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, 0.0);
+                        adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, phi);
                         let fef_global = transform_force(&fef, &t, 6);
                         for (i, &dof) in elem_dofs.iter().enumerate() {
                             local_forces.push((dof, fef_global[i]));
@@ -734,7 +745,7 @@ pub fn assemble_elements_parallel_2d(input: &SolverInput, dof_num: &DofNumbering
                         let px = pl.px.unwrap_or(0.0);
                         let mz = pl.my.unwrap_or(0.0);
                         let mut fef = fef_point_load_2d(pl.p, px, mz, pl.a, l);
-                        adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, 0.0);
+                        adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, phi);
                         let fef_global = transform_force(&fef, &t, 6);
                         for (i, &dof) in elem_dofs.iter().enumerate() {
                             local_forces.push((dof, fef_global[i]));
@@ -747,7 +758,7 @@ pub fn assemble_elements_parallel_2d(input: &SolverInput, dof_num: &DofNumbering
                             e, sec.a, sec.iz, l,
                             tl.dt_uniform, tl.dt_gradient, alpha, h,
                         );
-                        adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, 0.0);
+                        adjust_fef_for_hinges(&mut fef, l, elem.hinge_start, elem.hinge_end, phi);
                         let fef_global = transform_force(&fef, &t, 6);
                         for (i, &dof) in elem_dofs.iter().enumerate() {
                             local_forces.push((dof, fef_global[i]));

--- a/engine/src/solver/ssi.rs
+++ b/engine/src/solver/ssi.rs
@@ -375,7 +375,7 @@ pub fn solve_ssi_3d(input: &SSIInput3D) -> Result<SSIResult3D, String> {
             reactions: vec![],
             element_forces,
             plate_stresses: linear::compute_plate_stresses(&input.solver, &dof_num, &u_full),
-            quad_stresses: linear::compute_quad_stresses(&input.solver, &dof_num, &u_full),
+            quad_stresses: linear::compute_quad_stresses(&input.solver, &dof_num, &u_full, None),
             quad_nodal_stresses: vec![],
             constraint_forces,
             diagnostics: vec![],

--- a/engine/src/solver/staged.rs
+++ b/engine/src/solver/staged.rs
@@ -372,8 +372,9 @@ fn assemble_staged_2d(
             }
 
             // Assemble element loads (FEF) for this stage's loads
+            let load_refs: Vec<&SolverLoad> = stage_input.loads.iter().collect();
             assemble_element_loads_2d(
-                &stage_input.loads, elem, &t, l, e, sec, &elem_dofs, &mut f_global,
+                &load_refs, elem, &t, l, e, mat.nu, sec, &elem_dofs, &mut f_global,
             );
         }
     }

--- a/engine/src/solver/winkler.rs
+++ b/engine/src/solver/winkler.rs
@@ -284,7 +284,7 @@ pub fn solve_winkler_3d(input: &WinklerInput3D) -> Result<AnalysisResults3D, Str
     Ok(AnalysisResults3D {
         displacements, reactions, element_forces,
         plate_stresses: compute_plate_stresses(&input.solver, &dof_num, &u_full),
-        quad_stresses: compute_quad_stresses(&input.solver, &dof_num, &u_full),
+        quad_stresses: compute_quad_stresses(&input.solver, &dof_num, &u_full, None),
         quad_nodal_stresses: vec![],
         constraint_forces,
         diagnostics: vec![],

--- a/engine/tests/core/postprocess.rs
+++ b/engine/tests/core/postprocess.rs
@@ -100,6 +100,45 @@ fn test_diagrams_all_computed() {
     assert!(!diagrams.moment[0].points.is_empty());
 }
 
+#[test]
+fn test_axial_diagram_piecewise_constant_with_point_load() {
+    // Bar fixed at both ends, axial point load P at midspan.
+    // Symmetry gives N(left of load) = +P/2 (tension) and
+    // N(right of load) = -P/2 (compression).
+    let l = 6.0;
+    let px = 20.0;
+    let input = make_input(
+        vec![(1, 0.0, 0.0), (2, l, 0.0)],
+        vec![(1, 200_000.0, 0.3)],
+        vec![(1, 0.15, 0.003125)],
+        vec![(1, "frame", 1, 2, 1, 1, false, false)],
+        vec![(1, 1, "fixed"), (2, 2, "fixed")],
+        vec![SolverLoad::PointOnElement(SolverPointLoadOnElement {
+            element_id: 1, a: l / 2.0, p: 0.0, px: Some(px), my: None,
+        })],
+    );
+    let results = solve_2d(&input).unwrap();
+    let ef = &results.element_forces[0];
+
+    // Sanity: end forces reflect equilibrium (tension at start, compression at end).
+    assert!((ef.n_start - px / 2.0).abs() < 1e-6, "n_start = {}, expected {}", ef.n_start, px / 2.0);
+    assert!((ef.n_end + px / 2.0).abs() < 1e-6, "n_end = {}, expected {}", ef.n_end, -px / 2.0);
+
+    // Just before the load: still +P/2.
+    let n_left = compute_diagram_value_at("axial", 0.5 - 1e-7, ef);
+    assert!((n_left - px / 2.0).abs() < 1e-3, "N(left) = {}, expected {}", n_left, px / 2.0);
+
+    // Just after the load: -P/2 (the single jump is exactly -px).
+    let n_right = compute_diagram_value_at("axial", 0.5 + 1e-7, ef);
+    assert!((n_right + px / 2.0).abs() < 1e-3, "N(right) = {}, expected {}", n_right, -px / 2.0);
+
+    // Ends match the recorded end forces.
+    let n_start = compute_diagram_value_at("axial", 0.0, ef);
+    let n_end = compute_diagram_value_at("axial", 1.0, ef);
+    assert!((n_start - ef.n_start).abs() < 1e-6, "diagram start mismatch");
+    assert!((n_end - ef.n_end).abs() < 1e-6, "diagram end mismatch");
+}
+
 // ==================== Combination Tests ====================
 
 #[test]

--- a/engine/tests/curved_beam_constrained_gate.rs
+++ b/engine/tests/curved_beam_constrained_gate.rs
@@ -1,0 +1,73 @@
+//! Gate: a model with constraints AND curved beams must actually analyze the
+//! curved members. `solve_3d` used to delegate to the constrained solver
+//! before `prepare_static_3d` — the only place curved beams were expanded —
+//! so a constrained model silently analyzed without the curved members
+//! (they live in a separate list, not in `elements`, so the model had no
+//! members at all → spurious mechanism/singularity).
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::make_3d_input;
+use dedaliano_engine::solver::linear;
+use dedaliano_engine::types::*;
+
+const E: f64 = 200_000.0;
+const NU: f64 = 0.3;
+const A: f64 = 0.01;
+const IY: f64 = 1e-4;
+const IZ: f64 = 1e-4;
+const J: f64 = 2e-4;
+
+fn fixed() -> Vec<bool> {
+    vec![true, true, true, true, true, true]
+}
+
+/// Semicircular arch, fixed at both springing nodes, downward load at the
+/// crown — modeled as ONE curved beam, plus a trivial EqualDOF constraint so
+/// the solve takes the constrained path.
+fn arch_with_constraint() -> SolverInput3D {
+    let mut input = make_3d_input(
+        vec![
+            (1, 0.0, 0.0, 0.0),
+            (2, 5.0, 0.0, 5.0),
+            (3, 10.0, 0.0, 0.0),
+            (4, 0.0, 5.0, 0.0), // free node for the constraint
+        ],
+        vec![(1, E, NU)],
+        vec![(1, A, IY, IZ, J)],
+        vec![(1, "frame", 1, 2, 1, 1), (2, "frame", 2, 3, 1, 1)],
+        vec![(1, fixed()), (3, fixed())],
+        vec![SolverLoad3D::Nodal(SolverNodalLoad3D {
+            node_id: 2, fx: 0.0, fy: 0.0, fz: -10.0,
+            mx: 0.0, my: 0.0, mz: 0.0, bw: None,
+        })],
+    );
+    // Replace the two straight chords with the single curved beam definition.
+    input.elements.clear();
+    input.curved_beams = vec![CurvedBeamInput {
+        node_start: 1, node_mid: 2, node_end: 3,
+        material_id: 1, section_id: 1,
+        num_segments: 10, hinge_start: false, hinge_end: false,
+    }];
+    // Any constraint forces the constrained path. Tie ALL DOFs so the free node
+    // inherits full stiffness through the link (a partial tie would leave its
+    // untied DOFs without stiffness — singular, and not what is being tested).
+    input.constraints.push(Constraint::EqualDOF(EqualDOFConstraint {
+        master_node: 2, slave_node: 4, dofs: vec![0, 1, 2, 3, 4, 5],
+    }));
+    input
+}
+
+#[test]
+fn constrained_solve_expands_curved_beams() {
+    let res = linear::solve_3d(&arch_with_constraint())
+        .expect("constrained solve with a curved beam must succeed");
+    // The crown (node 2, snapped into the expanded chain) deflects downward.
+    let crown = res.displacements.iter().find(|d| d.node_id == 2).expect("crown displacement");
+    assert!(crown.uz < 0.0, "crown must deflect downward, got {}", crown.uz);
+    assert!(crown.uz.is_finite(), "crown displacement must be finite");
+    // Reactions equilibrate the applied 10 kN.
+    let sum_fz: f64 = res.reactions.iter().map(|r| r.fz).sum();
+    assert!((sum_fz - 10.0).abs() < 1e-6, "sumFz={sum_fz}");
+}

--- a/engine/tests/validation/domains/plates_shells/quad_shell.rs
+++ b/engine/tests/validation/domains/plates_shells/quad_shell.rs
@@ -365,6 +365,46 @@ fn test_quad_thermal_uniform_expansion() {
     );
 }
 
+// ==================== Test 6b: Fully Restrained Thermal Stress ====================
+
+#[test]
+fn test_quad_thermal_fully_restrained_stress() {
+    // Single quad with all nodes fully restrained. Under uniform ΔT the total
+    // strain is zero, so the mechanical strain is -α·ΔT and the stress is
+    // σ = -E·α·ΔT / (1-ν). Without subtracting the thermal strain the solver
+    // reports σ = 0.
+    let (nodes, quads, grid) = make_quad_mesh(1, 1, 1.0, 1.0, 0.01);
+    let mut input = make_base_input(nodes, quads);
+
+    for i in 0..=1 {
+        for j in 0..=1 {
+            let nid = grid[i][j];
+            input.supports.insert(nid.to_string(), sup3d(nid, true, true, true, true, true, true));
+        }
+    }
+
+    let alpha = 1.2e-5;
+    let dt = 100.0;
+    input.loads.push(SolverLoad3D::QuadThermal(SolverPlateThermalLoad {
+        element_id: 1, dt_uniform: dt, dt_gradient: 0.0, alpha: Some(alpha),
+    }));
+
+    let result = linear::solve_3d(&input).unwrap();
+    let stress = result.quad_stresses.iter().find(|s| s.element_id == 1).unwrap();
+
+    let e_kn = E * 1000.0;
+    let expected = -e_kn * alpha * dt / (1.0 - NU);
+
+    assert!(
+        (stress.sigma_xx - expected).abs() / expected.abs() < 0.02,
+        "sigma_xx = {:.6e}, expected {:.6e}", stress.sigma_xx, expected
+    );
+    assert!(
+        (stress.sigma_yy - expected).abs() / expected.abs() < 0.02,
+        "sigma_yy = {:.6e}, expected {:.6e}", stress.sigma_yy, expected
+    );
+}
+
 // ==================== Test 7: Scordelis-Lo Barrel Vault ====================
 
 #[test]

--- a/engine/tests/validation/domains/response/warping_torsion.rs
+++ b/engine/tests/validation/domains/response/warping_torsion.rs
@@ -298,3 +298,48 @@ fn validation_warping_mixed_model() {
         "Tip should twist under torque, got rx={:.6e}", tip.rx
     );
 }
+
+// ================================================================
+// 4. Torsion Release with Warping
+// ================================================================
+//
+// When a torsion release is present at either end, the element must not
+// transmit twist, even for sections with warping (cw > 0). The warping
+// torsion block used to be written unconditionally, overwriting the release.
+
+#[test]
+fn validation_warping_torsion_release_kills_twist_transmission() {
+    let l = 3.0;
+    let torque = 1.0;
+
+    // Single element, fixed at both ends (translations + rotations + warping).
+    let mut input = make_warping_beam(
+        1, l,
+        vec![true, true, true, true, true, true],
+        Some(vec![true, true, true, true, true, true]),
+        vec![SolverLoad3D::Nodal(SolverNodalLoad3D {
+            node_id: 2, fx: 0.0, fy: 0.0, fz: 0.0,
+            mx: torque, my: 0.0, mz: 0.0, bw: None,
+        })],
+        true,
+    );
+    input.elements.get_mut("1").unwrap().release_t_start = true;
+
+    let results = linear::solve_3d(&input).unwrap();
+    let ef = results.element_forces.iter().find(|f| f.element_id == 1).unwrap();
+
+    // The released end must carry zero torque.
+    assert!(
+        ef.mx_start.abs() < 1e-10,
+        "Released torsion end must have zero torque, got mx_start={:.6e}",
+        ef.mx_start
+    );
+
+    // Node 1 reaction must not pick up torque through the released element.
+    let r1 = results.reactions.iter().find(|r| r.node_id == 1).unwrap();
+    assert!(
+        r1.mx.abs() < 1e-10,
+        "Fixed support behind torsion release must have zero reaction, got mx={:.6e}",
+        r1.mx
+    );
+}

--- a/engine/tests/validation/textbooks/timoshenko_solver.rs
+++ b/engine/tests/validation/textbooks/timoshenko_solver.rs
@@ -587,3 +587,48 @@ fn validation_timoshenko_vs_euler_bernoulli() {
         "EB deflection: actual={:.6e}, expected={:.6e}, err={:.4}%",
         d_eb, delta_eb_exact, rel_err_eb * 100.0);
 }
+
+// ================================================================
+// 9. Timoshenko Hinge FEF Consistency
+// ================================================================
+//
+// For a section with as_y and an end hinge, the fixed-end force condensation
+// must use the same Timoshenko parameter phi as the stiffness matrix. If the
+// FEF is adjusted with phi=0 while K uses phi>0, the recovered moment at the
+// hinge is not exactly zero.
+
+#[test]
+fn validation_timoshenko_hinge_fef_consistency() {
+    let l = 1.0;
+    let q = 10.0;
+
+    let mut input = make_timoshenko_beam(
+        1, l, Some(AS_Y), "fixed", Some("rollerX"),
+        vec![SolverLoad::Distributed(SolverDistributedLoad {
+            element_id: 1, q_i: -q, q_j: -q, a: None, b: None,
+        })],
+    );
+    // Propped cantilever: fixed at left, roller at right, hinge at right end.
+    input.elements.get_mut("1").unwrap().hinge_end = true;
+
+    let results = linear::solve_2d(&input).unwrap();
+    let ef = results.element_forces.iter().find(|f| f.element_id == 1).unwrap();
+
+    // The hinge must release the end moment exactly.
+    assert!(ef.m_end.abs() < 1e-8,
+        "Timoshenko hinge end moment must be zero, got {:.6e}", ef.m_end);
+
+    // Equilibrium: reactions sum to qL.
+    let r_start = results.reactions.iter().find(|r| r.node_id == 1).unwrap().rz;
+    let r_end = results.reactions.iter().find(|r| r.node_id == 2).unwrap().rz;
+    assert!((r_start + r_end - q * l).abs() < 1e-8,
+        "Vertical equilibrium failed: R_start={:.6e}, R_end={:.6e}", r_start, r_end);
+
+    // Timoshenko propped cantilever reactions must differ from EB values.
+    // EB: R_fixed = 3qL/8 = 3.75, R_prop = 5qL/8 = 6.25.
+    let r_eb_fixed = 3.0 * q * l / 8.0;
+    let r_eb_prop = 5.0 * q * l / 8.0;
+    assert!((r_start - r_eb_fixed).abs() > 1e-6 || (r_end - r_eb_prop).abs() > 1e-6,
+        "Timoshenko reactions must differ from EB: R_start={:.6e}, R_end={:.6e}",
+        r_start, r_end);
+}

--- a/web/src/lib/three/deformed-shape-3d.ts
+++ b/web/src/lib/three/deformed-shape-3d.ts
@@ -340,6 +340,7 @@ export function createDeformedLines(
   scale: number,
   _eiMap?: Map<number, ElementEI>,
   _leftHand?: boolean,
+  sections?: Map<number, { rotation?: number }>,
 ): THREE.Group {
   const group = new THREE.Group();
   group.userData = { type: 'deformed' };
@@ -381,7 +382,11 @@ export function createDeformedLines(
     if (ef && eiEntry) {
       const localY = (elem.localYx !== undefined && elem.localYy !== undefined && elem.localYz !== undefined)
         ? { x: elem.localYx, y: elem.localYy, z: elem.localYz } : undefined;
-      const rollAngle = elem.rollAngle;
+      // Effective roll = element rollAngle + section rotation, matching the
+      // solver convention (solver-service.ts). Without the section term the
+      // deformed curve lies in the wrong plane for rotated sections.
+      const secRot = sections?.get(elem.sectionId)?.rotation ?? 0;
+      const rollAngle = (elem.rollAngle ?? 0) + secRot;
       try {
         p0 = computeDeformedShape3D(
           { id: elem.nodeI, x: nI.x, y: nI.y, z: nI.z ?? 0 },

--- a/web/src/lib/three/despiece-3d.ts
+++ b/web/src/lib/three/despiece-3d.ts
@@ -25,7 +25,7 @@
 import * as THREE from 'three';
 import { computeLocalAxes3D } from '../engine/local-axes-3d';
 import { projectNodeToScene } from '../geometry/coordinate-system';
-import { createTextSprite } from './selection-helpers';
+import { createTextSpriteCached } from './selection-helpers';
 import type { ElementForces3D, Reaction3D } from '../engine/types-3d';
 import type { Element, Node, Section, Load } from '../store/model.svelte';
 
@@ -298,7 +298,7 @@ export function createDespiece3DGroup(opts: {
     if (showLabels && showThis) {
       const txt = endLabel(ex, ey, ez, axialOut, n, vy, vz, mx, my, mz, basis);
       if (txt) {
-        const lbl = createTextSprite(txt, basis === 'global' ? DESPIECE_COL.axial : DESPIECE_COL.moment, 20);
+        const lbl = createTextSpriteCached(txt, basis === 'global' ? DESPIECE_COL.axial : DESPIECE_COL.moment, 20);
         lbl.scale.set(0.6 * lSize, 0.6 * lSize, 1);
         lbl.position.set(ey.x * labelOffset, ey.y * labelOffset, ey.z * labelOffset);
         eg.add(lbl);
@@ -406,7 +406,7 @@ export function createDespiece3DGroup(opts: {
       a.userData.despieceReaction = true;
       group.add(a);
       if (showLabels) {
-        const lbl = createTextSprite(`R ${fv.length().toFixed(1)}`, DESPIECE_COL.reaction, 20);
+        const lbl = createTextSpriteCached(`R ${fv.length().toFixed(1)}`, DESPIECE_COL.reaction, 20);
         lbl.scale.set(0.6 * lSize, 0.6 * lSize, 1);
         lbl.position.set(pos.x, pos.y - labelOffset, pos.z);
         group.add(lbl);

--- a/web/src/lib/viewport3d/results-sync.ts
+++ b/web/src/lib/viewport3d/results-sync.ts
@@ -11,7 +11,7 @@ import { modelStore, uiStore, resultsStore } from '../store';
 import { createDeformedLines, type ElementEI } from '../three/deformed-shape-3d';
 import { createDiagramGroup3D, createEnvelopeDiagramGroup3D } from '../three/diagram-render-3d';
 import { createDespiece3DGroup } from '../three/despiece-3d';
-import { COLORS, setGroupColor, disposeObject, axialForceColor, verificationColor, verificationStateColor, createTextSprite, heatmapColor } from '../three/selection-helpers';
+import { COLORS, setGroupColor, disposeObject, axialForceColor, verificationStateColor, createTextSpriteCached, heatmapColor } from '../three/selection-helpers';
 import { verificationStore } from '../store/verification.svelte';
 import { createReactionArrow, createConstraintForceArrow } from '../three/create-load-arrow';
 import type { Diagram3DKind } from '../engine/diagrams-3d';
@@ -236,6 +236,7 @@ export function syncDeformed(ctx: ResultsSyncContext, scaleOverride?: number): v
     scale,
     eiMap,
     sigHand,
+    modelStore.sections,
   );
   if (modeColor !== null) {
     ctx.deformedGroup.userData.material.color.setHex(modeColor);
@@ -502,7 +503,7 @@ export function syncVerificationLabels(ctx: ResultsSyncContext): void {
     const textColor = ds === 'stale' ? '#b9b9a8' : baseColor;
     const glyph = ds === 'stale' ? '⌛ ' : status === 'fail' ? '✗ ' : status === 'warn' ? '⚠ ' : '';
 
-    const sprite = createTextSprite(`${glyph}${ratio.toFixed(2)}`, textColor, 32);
+    const sprite = createTextSpriteCached(`${glyph}${ratio.toFixed(2)}`, textColor, 32);
     sprite.position.set(mx, my + 0.15, mz); // offset slightly above element
     sprite.scale.set(0.45, 0.45, 1);
     group.add(sprite);
@@ -917,7 +918,7 @@ export function syncLabels3D(ctx: ResultsSyncContext): void {
 
     for (const [id, node] of modelStore.nodes) {
       const pos = projectNodeToScene(node, project2D);
-      const sprite = createTextSprite(String(id), '#ffffff', 28);
+      const sprite = createTextSpriteCached(String(id), '#ffffff', 28);
       sprite.position.set(
         pos.x + spriteScale * 0.3,
         pos.y + spriteScale * 0.5,
@@ -946,7 +947,7 @@ export function syncLabels3D(ctx: ResultsSyncContext): void {
       const my = (sceneI.y + sceneJ.y) / 2;
       const mz = (sceneI.z + sceneJ.z) / 2;
 
-      const sprite = createTextSprite(String(id), '#88ccff', 24);
+      const sprite = createTextSpriteCached(String(id), '#88ccff', 24);
       sprite.position.set(mx, my + spriteScale * 0.3, mz);
       sprite.scale.set(spriteScale * 0.8, spriteScale * 0.8, 1);
       ctx.elementLabelsGroup.add(sprite);
@@ -975,7 +976,7 @@ export function syncLabels3D(ctx: ResultsSyncContext): void {
       const my = (sceneI.y + sceneJ.y) / 2 - spriteScale * 0.3;
       const mz = (sceneI.z + sceneJ.z) / 2;
 
-      const sprite = createTextSprite(`${len.toFixed(2)} m`, '#88cc88', 22);
+      const sprite = createTextSpriteCached(`${len.toFixed(2)} m`, '#88cc88', 22);
       sprite.position.set(mx, my, mz);
       sprite.scale.set(spriteScale * 0.7, spriteScale * 0.7, 1);
       ctx.lengthLabelsGroup.add(sprite);

--- a/web/src/lib/viewport3d/scene-sync.ts
+++ b/web/src/lib/viewport3d/scene-sync.ts
@@ -706,7 +706,8 @@ export function syncLoads(ctx: SceneSyncContext): void {
         load.data.q, maxQ, cc,
       );
     }
-    // pointOnElement and pointOnElement3d: simplified as nodal for now
+    // pointOnElement (2D): draw the applied load in its actual local direction
+    // instead of a hard-coded downward arrow.
     else if (load.type === 'pointOnElement') {
       const elem = modelStore.elements.get(load.data.elementId);
       if (!elem) continue;
@@ -720,9 +721,59 @@ export function syncLoads(ctx: SceneSyncContext): void {
       const px = sceneI.x + (sceneJ.x - sceneI.x) * t;
       const py = sceneI.y + (sceneJ.y - sceneI.y) * t;
       const pz = sceneI.z + (sceneJ.z - sceneI.z) * t;
+
+      // Local frame in scene coordinates: ex along the element, ey perpendicular
+      // in the model plane. For 2D-in-XZ projection the model y maps to scene z.
+      const dx = sceneJ.x - sceneI.x;
+      const dz = sceneJ.z - sceneI.z;
+      const len = Math.sqrt(dx * dx + dz * dz);
+      let fx = 0, fz = 0;
+      if (len > 1e-12) {
+        const ex = dx / len, ez = dz / len;
+        // 2D local +y (perpendicular, CCW from ex) in scene coordinates
+        const eyx = -ez, eyz = ex;
+        fx = (load.data.px ?? 0) * ex + load.data.p * eyx;
+        fz = (load.data.px ?? 0) * ez + load.data.p * eyz;
+      }
       batch.addNodalLoadArrow(
         { x: px, y: py, z: pz },
-        0, 0, -Math.abs(load.data.p),
+        fx, 0, fz,
+        0, load.data.my ?? load.data.mz ?? 0, 0,
+        maxForce,
+        'double-arrow', cc,
+      );
+    }
+    // pointOnElement3d: resolve the local Y/Z load components into global space
+    // using the element's local frame, then draw the resulting arrow.
+    else if (load.type === 'pointOnElement3d') {
+      const elem = modelStore.elements.get(load.data.elementId);
+      if (!elem) continue;
+      const nI = modelStore.nodes.get(elem.nodeI);
+      const nJ = modelStore.nodes.get(elem.nodeJ);
+      if (!nI || !nJ) continue;
+      const L = Math.sqrt((nJ.x-nI.x)**2 + (nJ.y-nI.y)**2 + ((nJ.z??0)-(nI.z??0))**2);
+      const t = L > 0 ? load.data.a / L : 0.5;
+      const sceneI = projectNodeToScene(nI, project2D);
+      const sceneJ = projectNodeToScene(nJ, project2D);
+      const px = sceneI.x + (sceneJ.x - sceneI.x) * t;
+      const py = sceneI.y + (sceneJ.y - sceneI.y) * t;
+      const pz = sceneI.z + (sceneJ.z - sceneI.z) * t;
+
+      const posI = { id: 0, x: nI.x, y: nI.y, z: nI.z ?? 0 } as SolverNode3D;
+      const posJ = { id: 0, x: nJ.x, y: nJ.y, z: nJ.z ?? 0 } as SolverNode3D;
+      const elemLocalY = (elem.localYx !== undefined && elem.localYy !== undefined && elem.localYz !== undefined)
+        ? { x: elem.localYx, y: elem.localYy, z: elem.localYz } : undefined;
+      const localAxes = computeLocalAxes3D(posI, posJ, elemLocalY, elem.rollAngle);
+      const ey = { x: localAxes.ey[0], y: localAxes.ey[1], z: localAxes.ey[2] };
+      const ez = { x: localAxes.ez[0], y: localAxes.ez[1], z: localAxes.ez[2] };
+
+      const fx = load.data.py * ey.x + load.data.pz * ez.x;
+      const fy = load.data.py * ey.y + load.data.pz * ez.y;
+      const fz = load.data.py * ey.z + load.data.pz * ez.z;
+
+      batch.addNodalLoadArrow(
+        { x: px, y: py, z: pz },
+        fx, fy, fz,
         0, 0, 0,
         maxForce,
         'double-arrow', cc,


### PR DESCRIPTION
Correctness:
- Expand curved beams before constrained 3D delegation (BLOCKER)
- Shell bending moments: cb = t³ (was t²)
- 2D axial diagram: piecewise N(x) = n_start − Σpx (was double-counting)
- Timoshenko 2D hinge FEF: propagate real phi (was phi=0)
- Warping torsion: respect release_t_* in 14-DOF block
- Shell thermal stress: subtract α·ΔT and α·ΔT_grad/t from total strain

Render:
- Draw pointOnElement3d arrows in 3D viewport
- 2D pointOnElement: real perpendicular direction and sign
- Deformed shape: rollAngle + section.rotation (solver parity)

Performance:
- 2D load-vector assembly: loads_by_elem O(L) instead of O(E×L)
- 3D labels: createTextSpriteCached for node/element/verification labels

Tests: curved_beam_constrained_gate, axial diagram, Timoshenko hinge FEF, warping torsion release, restrained quad thermal stress.