### PR TITLE
fix(engine,web): audit follow-up — plate/nodal thermal stress + 3D lo…

### DIFF
--- a/engine/src/element/plate.rs
+++ b/engine/src/element/plate.rs
@@ -708,18 +708,29 @@ pub fn plate_consistent_mass(
 
 /// Recover plate stresses at the element centroid from local displacements.
 ///
+/// Thermal strains are subtracted before applying the constitutive law:
+/// ε_mech = ε_total − α·ΔT_uniform (membrane), κ_mech = κ_total − α·ΔT_gradient/t (bending).
+/// Without this correction a fully restrained plate under ΔT reports σ = 0
+/// instead of σ = −E·α·ΔT/(1−ν).
+///
 /// # Arguments
 /// * `coords`  – 3 node positions in 3D global space
 /// * `e`       – Young's modulus (kN/m²)
 /// * `nu`      – Poisson's ratio
 /// * `t`       – shell thickness (m)
 /// * `u_local` – 18-element displacement vector in the **local** coordinate system
+/// * `alpha`   – coefficient of thermal expansion (1/°C), 0 = no thermal correction
+/// * `dt_uniform`  – uniform temperature change (°C)
+/// * `dt_gradient` – through-thickness temperature gradient (°C)
 pub fn plate_stress_recovery(
     coords: &[[f64; 3]; 3],
     e: f64,
     nu: f64,
     t: f64,
     u_local: &[f64],
+    alpha: f64,
+    dt_uniform: f64,
+    dt_gradient: f64,
 ) -> PlateStressLocal {
     assert!(u_local.len() >= 18, "u_local must have at least 18 entries");
 
@@ -744,6 +755,11 @@ pub fn plate_stress_recovery(
             eps[i] += b_cst[i * 6 + j] * u_mem[j];
         }
     }
+
+    // Subtract thermal strains (mechanical strain drives stress)
+    let eps_th = alpha * dt_uniform;
+    eps[0] -= eps_th;
+    eps[1] -= eps_th;
 
     // D_membrane
     let dm_coeff = e * t / (1.0 - nu * nu);
@@ -787,6 +803,11 @@ pub fn plate_stress_recovery(
             kappa[i] += b_dkt[i * 9 + j] * u_bend[j];
         }
     }
+
+    // Subtract thermal curvatures (mechanical curvature drives moment)
+    let kappa_th = alpha * dt_gradient / t;
+    kappa[0] -= kappa_th;
+    kappa[1] -= kappa_th;
 
     // D_bending
     let db_coeff = e * t * t * t / (12.0 * (1.0 - nu * nu));

--- a/engine/src/element/quad.rs
+++ b/engine/src/element/quad.rs
@@ -830,16 +830,24 @@ pub fn quad_pressure_load(coords: &[[f64; 3]; 4], pressure: f64) -> Vec<f64> {
 
 /// Compute von Mises stress at each of the 4 nodes by evaluating at Gauss points
 /// and extrapolating (bilinear extrapolation from 2×2 Gauss points to corners).
+///
+/// Thermal strains are subtracted before applying the constitutive law, matching
+/// the centroid path.
 pub fn quad_nodal_von_mises(
     coords: &[[f64; 3]; 4],
     u_local: &[f64; 24],
     e: f64,
     nu: f64,
     _t: f64,
+    alpha: f64,
+    dt_uniform: f64,
 ) -> Vec<f64> {
     let (ex, ey, _) = quad_local_axes(coords);
     let pts = project_to_2d(coords, &ex, &ey);
     let gauss = gauss_2x2();
+
+    // Thermal strain to subtract (mechanical strain drives stress)
+    let eps_th = alpha * dt_uniform;
 
     // Evaluate von Mises at each Gauss point
     let mut gp_vm = [0.0; 4];
@@ -864,6 +872,10 @@ pub fn quad_nodal_von_mises(
             eps_yy += dn_dy[i] * uy;
             gamma_xy += dn_dy[i] * ux + dn_dx[i] * uy;
         }
+
+        // Subtract thermal strain before constitutive law
+        eps_xx -= eps_th;
+        eps_yy -= eps_th;
 
         let c = e / (1.0 - nu * nu);
         let sxx = c * (eps_xx + nu * eps_yy);
@@ -894,6 +906,10 @@ pub fn quad_nodal_von_mises(
 /// Compute full stress tensor at each of the 4 nodes by evaluating at Gauss points
 /// and extrapolating (bilinear extrapolation from 2×2 Gauss points to corners).
 ///
+/// Thermal strains are subtracted before applying the constitutive law, matching
+/// the centroid path. Without this correction a fully restrained shell under ΔT
+/// reports σ = 0 instead of σ = −E·α·ΔT/(1−ν).
+///
 /// Returns a Vec of 4 `QuadNodalStress` structs, one per corner node, with
 /// membrane stresses (sigma_xx, sigma_yy, tau_xy), bending moments (mx, my, mxy),
 /// and von Mises stress.
@@ -903,6 +919,9 @@ pub fn quad_stress_at_nodes(
     e: f64,
     nu: f64,
     t: f64,
+    alpha: f64,
+    dt_uniform: f64,
+    dt_gradient: f64,
 ) -> Vec<crate::types::QuadNodalStress> {
     let (ex, ey, _) = quad_local_axes(coords);
     let pts = project_to_2d(coords, &ex, &ey);
@@ -911,6 +930,10 @@ pub fn quad_stress_at_nodes(
     // Evaluate full stress tensor at each Gauss point
     let c = e / (1.0 - nu * nu);
     let cb = e * t * t * t / (12.0 * (1.0 - nu * nu));
+
+    // Thermal strain/curvature to subtract (mechanical strain drives stress)
+    let eps_th = alpha * dt_uniform;
+    let kappa_th = alpha * dt_gradient / t;
 
     let mut gp_sxx = [0.0; 4];
     let mut gp_syy = [0.0; 4];
@@ -951,6 +974,12 @@ pub fn quad_stress_at_nodes(
             kappa_yy += dn_dy[i] * rx;
             kappa_xy += dn_dx[i] * rx - dn_dy[i] * ry;
         }
+
+        // Subtract thermal strains before constitutive law
+        eps_xx -= eps_th;
+        eps_yy -= eps_th;
+        kappa_xx -= kappa_th;
+        kappa_yy -= kappa_th;
 
         gp_sxx[gp] = c * (eps_xx + nu * eps_yy);
         gp_syy[gp] = c * (nu * eps_xx + eps_yy);

--- a/engine/src/element/quad9.rs
+++ b/engine/src/element/quad9.rs
@@ -696,16 +696,24 @@ pub fn quad9_stresses(
 
 /// Compute von Mises stress at each of the 9 nodes by evaluating at 3×3 Gauss points
 /// and using least-squares projection to nodes.
+///
+/// Thermal strains are subtracted before applying the constitutive law, matching
+/// the centroid path.
 pub fn quad9_nodal_von_mises(
     coords: &[[f64; 3]; 9],
     u_local: &[f64],
     e: f64,
     nu: f64,
     _t: f64,
+    alpha: f64,
+    dt_uniform: f64,
 ) -> Vec<f64> {
     let (ex, ey, _) = quad9_local_axes(coords);
     let pts = project_to_2d_9(coords, &ex, &ey);
     let gauss = gauss_3x3();
+
+    // Thermal strain to subtract (mechanical strain drives stress)
+    let eps_th = alpha * dt_uniform;
 
     // Evaluate von Mises at each Gauss point
     let mut gp_vm = [0.0; 9];
@@ -730,6 +738,10 @@ pub fn quad9_nodal_von_mises(
             eps_yy += dn_dy[i] * uy;
             gamma_xy += dn_dy[i] * ux + dn_dx[i] * uy;
         }
+
+        // Subtract thermal strain before constitutive law
+        eps_xx -= eps_th;
+        eps_yy -= eps_th;
 
         let c = e / (1.0 - nu * nu);
         let sxx = c * (eps_xx + nu * eps_yy);
@@ -776,12 +788,18 @@ fn lagrange_1d_3_at(s: f64, pts: &[f64; 3]) -> [f64; 3] {
 }
 
 /// Compute full stress tensor at each of the 9 nodes.
+///
+/// Thermal strains are subtracted before applying the constitutive law, matching
+/// the centroid path.
 pub fn quad9_stress_at_nodes(
     coords: &[[f64; 3]; 9],
     u_local: &[f64],
     e: f64,
     nu: f64,
     t: f64,
+    alpha: f64,
+    dt_uniform: f64,
+    dt_gradient: f64,
 ) -> Vec<crate::types::QuadNodalStress> {
     let (ex, ey, _) = quad9_local_axes(coords);
     let pts = project_to_2d_9(coords, &ex, &ey);
@@ -789,6 +807,10 @@ pub fn quad9_stress_at_nodes(
 
     let c = e / (1.0 - nu * nu);
     let cb = e * t * t * t / (12.0 * (1.0 - nu * nu));
+
+    // Thermal strain/curvature to subtract (mechanical strain drives stress)
+    let eps_th = alpha * dt_uniform;
+    let kappa_th = alpha * dt_gradient / t;
 
     let mut gp_sxx = [0.0; 9];
     let mut gp_syy = [0.0; 9];
@@ -829,6 +851,12 @@ pub fn quad9_stress_at_nodes(
             kappa_yy += dn_dy[i] * rx;
             kappa_xy += dn_dx[i] * rx - dn_dy[i] * ry;
         }
+
+        // Subtract thermal strains before constitutive law
+        eps_xx -= eps_th;
+        eps_yy -= eps_th;
+        kappa_xx -= kappa_th;
+        kappa_yy -= kappa_th;
 
         gp_sxx[gp] = c * (eps_xx + nu * eps_yy);
         gp_syy[gp] = c * (nu * eps_xx + eps_yy);

--- a/engine/src/solver/cable.rs
+++ b/engine/src/solver/cable.rs
@@ -634,7 +634,7 @@ pub fn solve_cable_3d(
         displacements,
         reactions,
         element_forces,
-        plate_stresses: linear::compute_plate_stresses(input, &dof_num, &u_full),
+        plate_stresses: linear::compute_plate_stresses(input, &dof_num, &u_full, None),
         quad_stresses: linear::compute_quad_stresses(input, &dof_num, &u_full, None),
         quad_nodal_stresses: vec![],
         constraint_forces,

--- a/engine/src/solver/constraints.rs
+++ b/engine/src/solver/constraints.rs
@@ -1302,9 +1302,9 @@ pub fn solve_constrained_3d(input: &ConstrainedInput3D) -> Result<AnalysisResult
         // mirroring the unconstrained solve_3d branch. Without this, any model
         // with constraints (rigid diaphragms, eccentric connections, member/
         // shell offsets) returns no shell stresses → empty contours/tables.
-        plate_stresses: linear::compute_plate_stresses(&input.solver, &dof_num, &u_full),
+        plate_stresses: linear::compute_plate_stresses(&input.solver, &dof_num, &u_full, None),
         quad_stresses: linear::compute_quad_stresses(&input.solver, &dof_num, &u_full, None),
-        quad_nodal_stresses: linear::compute_quad_nodal_stresses(&input.solver, &dof_num, &u_full),
+        quad_nodal_stresses: linear::compute_quad_nodal_stresses(&input.solver, &dof_num, &u_full, None),
         constraint_forces,
         diagnostics: vec![],
         solver_diagnostics: vec![],

--- a/engine/src/solver/contact.rs
+++ b/engine/src/solver/contact.rs
@@ -1206,7 +1206,7 @@ pub fn solve_contact_3d(input: &ContactInput3D) -> Result<ContactResult3D, Strin
         displacements,
         reactions: vec![],
         element_forces,
-        plate_stresses: linear::compute_plate_stresses(&input.solver, &dof_num, &u_full),
+        plate_stresses: linear::compute_plate_stresses(&input.solver, &dof_num, &u_full, None),
         quad_stresses: linear::compute_quad_stresses(&input.solver, &dof_num, &u_full, None),
         quad_nodal_stresses: vec![],
         constraint_forces: vec![],

--- a/engine/src/solver/fiber_nonlinear.rs
+++ b/engine/src/solver/fiber_nonlinear.rs
@@ -754,7 +754,7 @@ pub fn solve_fiber_nonlinear_3d(input: &FiberNonlinearInput3D) -> Result<FiberNo
             displacements,
             reactions: vec![],
             element_forces,
-            plate_stresses: super::linear::compute_plate_stresses(&input.solver, &dof_num, &u_full),
+            plate_stresses: super::linear::compute_plate_stresses(&input.solver, &dof_num, &u_full, None),
             quad_stresses: super::linear::compute_quad_stresses(&input.solver, &dof_num, &u_full, None),
             quad_nodal_stresses: vec![],
             constraint_forces,

--- a/engine/src/solver/geometric_stiffness.rs
+++ b/engine/src/solver/geometric_stiffness.rs
@@ -422,7 +422,8 @@ pub fn add_plate_geometric_stiffness_3d(
         let u_local_vec = transform_displacement(&u_global, &t_plate, 18);
 
         // Compute membrane stress resultants via plate stress recovery
-        let s = crate::element::plate_stress_recovery(&coords, e, nu, plate.thickness, &u_local_vec);
+        // No thermal correction here: geometric stiffness uses the total stress state.
+        let s = crate::element::plate_stress_recovery(&coords, e, nu, plate.thickness, &u_local_vec, 0.0, 0.0, 0.0);
         let nxx = s.sigma_xx * plate.thickness;
         let nyy = s.sigma_yy * plate.thickness;
         let nxy = s.tau_xy * plate.thickness;

--- a/engine/src/solver/linear.rs
+++ b/engine/src/solver/linear.rs
@@ -1622,7 +1622,7 @@ impl PreparedStatic3D {
         reactions.sort_by_key(|r| r.node_id);
         let mut element_forces = compute_internal_forces_3d_with_loads(input, loads, dof_num, &u_full);
         element_forces.sort_by_key(|ef| ef.element_id);
-        let plate_stresses = compute_plate_stresses(input, dof_num, &u_full);
+        let plate_stresses = compute_plate_stresses(input, dof_num, &u_full, Some(loads));
         let quad_stresses = compute_quad_stresses(input, dof_num, &u_full, Some(loads));
 
         let equilibrium = compute_equilibrium_summary_3d(&f, &reactions_vec, dof_num, 0.0, &p.inclined_transforms);
@@ -1641,7 +1641,7 @@ impl PreparedStatic3D {
             element_forces,
             plate_stresses,
             quad_stresses,
-            quad_nodal_stresses: compute_quad_nodal_stresses(input, dof_num, &u_full),
+            quad_nodal_stresses: compute_quad_nodal_stresses(input, dof_num, &u_full, Some(loads)),
             constraint_forces: vec![],
             diagnostics: p.diagnostics.clone(),
             solver_diagnostics: vec![],
@@ -1740,7 +1740,7 @@ impl PreparedStatic3D {
         let mut element_forces = compute_internal_forces_3d_with_loads(input, loads, dof_num, &u_full);
         element_forces.sort_by_key(|ef| ef.element_id);
 
-        let plate_stresses = compute_plate_stresses(input, dof_num, &u_full);
+        let plate_stresses = compute_plate_stresses(input, dof_num, &u_full, Some(loads));
         let quad_stresses = compute_quad_stresses(input, dof_num, &u_full, Some(loads));
 
         let equilibrium = compute_equilibrium_summary_3d(&f, &reactions_vec, dof_num, rel_residual, &p.inclined_transforms);
@@ -1837,7 +1837,7 @@ impl PreparedStatic3D {
             element_forces,
             plate_stresses,
             quad_stresses,
-            quad_nodal_stresses: compute_quad_nodal_stresses(input, dof_num, &u_full),
+            quad_nodal_stresses: compute_quad_nodal_stresses(input, dof_num, &u_full, Some(loads)),
             constraint_forces: vec![],
             diagnostics: p.diagnostics.clone(),
             solver_diagnostics: solver_diags,
@@ -2005,7 +2005,7 @@ impl PreparedStatic3D {
         let reactions_us = now_micros().saturating_sub(t0);
 
         let t0 = now_micros();
-        let plate_stresses = compute_plate_stresses(input, dof_num, &u_full);
+        let plate_stresses = compute_plate_stresses(input, dof_num, &u_full, Some(loads));
         let quad_stresses = compute_quad_stresses(input, dof_num, &u_full, Some(loads));
         let stress_recovery_us = now_micros().saturating_sub(t0);
 
@@ -2133,7 +2133,7 @@ impl PreparedStatic3D {
             element_forces,
             plate_stresses,
             quad_stresses,
-            quad_nodal_stresses: compute_quad_nodal_stresses(input, dof_num, &u_full),
+            quad_nodal_stresses: compute_quad_nodal_stresses(input, dof_num, &u_full, Some(loads)),
             constraint_forces: vec![],
             diagnostics: p.diagnostics.clone(),
             solver_diagnostics: solver_diags,
@@ -2209,7 +2209,7 @@ impl PreparedStatic3D {
         reactions.sort_by_key(|r| r.node_id);
         let mut element_forces = compute_internal_forces_3d_with_loads(input, loads, dof_num, &u_full);
         element_forces.sort_by_key(|ef| ef.element_id);
-        let plate_stresses = compute_plate_stresses(input, dof_num, &u_full);
+        let plate_stresses = compute_plate_stresses(input, dof_num, &u_full, Some(loads));
         let quad_stresses = compute_quad_stresses(input, dof_num, &u_full, Some(loads));
 
         // Compute actual residual: ||K·u − F||_free / ||F||_free
@@ -2302,7 +2302,7 @@ impl PreparedStatic3D {
 
         let mut results = AnalysisResults3D {
             displacements, reactions, element_forces, plate_stresses, quad_stresses,
-            quad_nodal_stresses: compute_quad_nodal_stresses(input, dof_num, &u_full),
+            quad_nodal_stresses: compute_quad_nodal_stresses(input, dof_num, &u_full, Some(loads)),
             constraint_forces: vec![], diagnostics: p.diagnostics.clone(),
             solver_diagnostics: solver_diags, structured_diagnostics: structured, equilibrium: Some(equilibrium), timings: Some(timings), result_summary: None,
             solver_run_meta: Some(SolverRunMeta::new(
@@ -3690,6 +3690,7 @@ pub(crate) fn compute_plate_stresses(
     input: &SolverInput3D,
     dof_num: &DofNumbering,
     u: &[f64],
+    loads: Option<&[SolverLoad3D]>,
 ) -> Vec<PlateStress> {
     let mut stresses = Vec::new();
 
@@ -3697,6 +3698,18 @@ pub(crate) fn compute_plate_stresses(
         input.nodes.values().map(|n| (n.id, n)).collect();
     let mat_map: std::collections::HashMap<usize, &SolverMaterial> =
         input.materials.values().map(|m| (m.id, m)).collect();
+
+    // Index thermal loads by element id so stress recovery can subtract the
+    // thermal strain from the total strain (σ = C·ε_mech, not C·ε_total).
+    let loads_ref = loads.unwrap_or(&input.loads);
+    let mut thermal_by_elem: std::collections::HashMap<usize, (f64, f64, f64)> =
+        std::collections::HashMap::new();
+    for load in loads_ref {
+        if let SolverLoad3D::PlateThermal(tl) = load {
+            let alpha = tl.alpha.unwrap_or(1.2e-5);
+            thermal_by_elem.insert(tl.element_id, (alpha, tl.dt_uniform, tl.dt_gradient));
+        }
+    }
 
     for plate in input.plates.values() {
         let mat = mat_map[&plate.material_id];
@@ -3721,7 +3734,8 @@ pub(crate) fn compute_plate_stresses(
         let u_local = crate::linalg::transform_displacement(&u_global, &t_plate, 18);
 
         // Recover stresses at centroid
-        let s = crate::element::plate_stress_recovery(&coords, e, nu, plate.thickness, &u_local);
+        let (alpha, dt_uniform, dt_gradient) = thermal_by_elem.get(&plate.id).copied().unwrap_or((0.0, 0.0, 0.0));
+        let s = crate::element::plate_stress_recovery(&coords, e, nu, plate.thickness, &u_local, alpha, dt_uniform, dt_gradient);
 
         // Also recover nodal stresses for stress smoothing
         let nodal = crate::element::plate_stress_at_nodes(&coords, e, nu, plate.thickness, &u_local);
@@ -3807,7 +3821,7 @@ pub(crate) fn compute_quad_stresses(
         let s = crate::element::quad::quad_stresses(&coords, &u_local, e, nu, quad.thickness, alpha, dt_uniform, dt_gradient);
 
         // Nodal stresses at 4 Gauss-extrapolated points
-        let nodal_vm = crate::element::quad::quad_nodal_von_mises(&coords, &u_local, e, nu, quad.thickness);
+        let nodal_vm = crate::element::quad::quad_nodal_von_mises(&coords, &u_local, e, nu, quad.thickness, alpha, dt_uniform);
 
         stresses.push(QuadStress {
             element_id: quad.id,
@@ -3838,7 +3852,7 @@ pub(crate) fn compute_quad_stresses(
         let u_local_vec = crate::linalg::transform_displacement(&u_global, &t_q9, 54);
         let (alpha, dt_uniform, dt_gradient) = thermal_by_elem.get(&q9.id).copied().unwrap_or((0.0, 0.0, 0.0));
         let s = crate::element::quad9::quad9_stresses(&coords, &u_local_vec, e, nu, q9.thickness, alpha, dt_uniform, dt_gradient);
-        let nodal_vm = crate::element::quad9::quad9_nodal_von_mises(&coords, &u_local_vec, e, nu, q9.thickness);
+        let nodal_vm = crate::element::quad9::quad9_nodal_von_mises(&coords, &u_local_vec, e, nu, q9.thickness, alpha, dt_uniform);
         stresses.push(QuadStress {
             element_id: q9.id,
             sigma_xx: s.sigma_xx,
@@ -3916,6 +3930,7 @@ pub(crate) fn compute_quad_nodal_stresses(
     input: &SolverInput3D,
     dof_num: &DofNumbering,
     u: &[f64],
+    loads: Option<&[SolverLoad3D]>,
 ) -> Vec<QuadNodalStress> {
     let mut stresses = Vec::new();
 
@@ -3923,6 +3938,25 @@ pub(crate) fn compute_quad_nodal_stresses(
         input.nodes.values().map(|n| (n.id, n)).collect();
     let mat_map: std::collections::HashMap<usize, &SolverMaterial> =
         input.materials.values().map(|m| (m.id, m)).collect();
+
+    // Index thermal loads by element id so stress recovery can subtract the
+    // thermal strain from the total strain (σ = C·ε_mech, not C·ε_total).
+    let loads_ref = loads.unwrap_or(&input.loads);
+    let mut thermal_by_elem: std::collections::HashMap<usize, (f64, f64, f64)> =
+        std::collections::HashMap::new();
+    for load in loads_ref {
+        match load {
+            SolverLoad3D::QuadThermal(tl) => {
+                let alpha = tl.alpha.unwrap_or(1.2e-5);
+                thermal_by_elem.insert(tl.element_id, (alpha, tl.dt_uniform, tl.dt_gradient));
+            }
+            SolverLoad3D::Quad9Thermal(tl) => {
+                let alpha = tl.alpha.unwrap_or(1.2e-5);
+                thermal_by_elem.insert(tl.element_id, (alpha, tl.dt_uniform, tl.dt_gradient));
+            }
+            _ => {}
+        }
+    }
 
     for quad in input.quads.values() {
         let mat = mat_map[&quad.material_id];
@@ -3948,7 +3982,8 @@ pub(crate) fn compute_quad_nodal_stresses(
         let mut u_local = [0.0; 24];
         u_local.copy_from_slice(&u_local_vec);
 
-        let nodal = crate::element::quad::quad_stress_at_nodes(&coords, &u_local, e, nu, quad.thickness);
+        let (alpha, dt_uniform, dt_gradient) = thermal_by_elem.get(&quad.id).copied().unwrap_or((0.0, 0.0, 0.0));
+        let nodal = crate::element::quad::quad_stress_at_nodes(&coords, &u_local, e, nu, quad.thickness, alpha, dt_uniform, dt_gradient);
         for mut ns in nodal {
             ns.node_index = quad.nodes[ns.node_index];
             stresses.push(ns);
@@ -3969,7 +4004,8 @@ pub(crate) fn compute_quad_nodal_stresses(
         let u_global: Vec<f64> = q9_dofs.iter().map(|&d| u[d]).collect();
         let t_q9 = crate::element::quad9::quad9_transform_3d(&coords);
         let u_local_vec = crate::linalg::transform_displacement(&u_global, &t_q9, 54);
-        let nodal = crate::element::quad9::quad9_stress_at_nodes(&coords, &u_local_vec, e, nu, q9.thickness);
+        let (alpha, dt_uniform, dt_gradient) = thermal_by_elem.get(&q9.id).copied().unwrap_or((0.0, 0.0, 0.0));
+        let nodal = crate::element::quad9::quad9_stress_at_nodes(&coords, &u_local_vec, e, nu, q9.thickness, alpha, dt_uniform, dt_gradient);
         for mut ns in nodal {
             ns.node_index = q9.nodes[ns.node_index];
             stresses.push(ns);

--- a/engine/src/solver/material_nonlinear.rs
+++ b/engine/src/solver/material_nonlinear.rs
@@ -1033,7 +1033,7 @@ pub fn solve_nonlinear_material_3d(
             displacements,
             reactions,
             element_forces,
-            plate_stresses: compute_plate_stresses(solver, &dof_num, &u_full),
+            plate_stresses: compute_plate_stresses(solver, &dof_num, &u_full, None),
             quad_stresses: compute_quad_stresses(solver, &dof_num, &u_full, None),
             quad_nodal_stresses: vec![],
             constraint_forces,

--- a/engine/src/solver/pdelta.rs
+++ b/engine/src/solver/pdelta.rs
@@ -419,7 +419,7 @@ pub fn solve_pdelta_3d(
     };
 
     Ok(PDeltaResult3D {
-        results: AnalysisResults3D { displacements, reactions, element_forces, plate_stresses: compute_plate_stresses(input, &dof_num, &u_current), quad_stresses: compute_quad_stresses(input, &dof_num, &u_current, None), quad_nodal_stresses: vec![], constraint_forces, diagnostics: vec![], solver_diagnostics: vec![], structured_diagnostics: vec![], equilibrium: None, timings: None, result_summary: None, solver_run_meta: None },
+        results: AnalysisResults3D { displacements, reactions, element_forces, plate_stresses: compute_plate_stresses(input, &dof_num, &u_current, None), quad_stresses: compute_quad_stresses(input, &dof_num, &u_current, None), quad_nodal_stresses: vec![], constraint_forces, diagnostics: vec![], solver_diagnostics: vec![], structured_diagnostics: vec![], equilibrium: None, timings: None, result_summary: None, solver_run_meta: None },
         iterations,
         converged,
         is_stable: converged && max_ratio < 100.0,

--- a/engine/src/solver/ssi.rs
+++ b/engine/src/solver/ssi.rs
@@ -374,7 +374,7 @@ pub fn solve_ssi_3d(input: &SSIInput3D) -> Result<SSIResult3D, String> {
             displacements,
             reactions: vec![],
             element_forces,
-            plate_stresses: linear::compute_plate_stresses(&input.solver, &dof_num, &u_full),
+            plate_stresses: linear::compute_plate_stresses(&input.solver, &dof_num, &u_full, None),
             quad_stresses: linear::compute_quad_stresses(&input.solver, &dof_num, &u_full, None),
             quad_nodal_stresses: vec![],
             constraint_forces,

--- a/engine/src/solver/staged.rs
+++ b/engine/src/solver/staged.rs
@@ -1301,7 +1301,7 @@ fn build_results_from_u_3d(
     reactions.sort_by_key(|r| r.node_id);
 
     // Plate stresses (delegated to existing function)
-    let plate_stresses = compute_plate_stresses(stage_input, dof_num, u);
+    let plate_stresses = compute_plate_stresses(stage_input, dof_num, u, None);
 
     AnalysisResults3D {
         displacements,

--- a/engine/src/solver/winkler.rs
+++ b/engine/src/solver/winkler.rs
@@ -283,7 +283,7 @@ pub fn solve_winkler_3d(input: &WinklerInput3D) -> Result<AnalysisResults3D, Str
 
     Ok(AnalysisResults3D {
         displacements, reactions, element_forces,
-        plate_stresses: compute_plate_stresses(&input.solver, &dof_num, &u_full),
+        plate_stresses: compute_plate_stresses(&input.solver, &dof_num, &u_full, None),
         quad_stresses: compute_quad_stresses(&input.solver, &dof_num, &u_full, None),
         quad_nodal_stresses: vec![],
         constraint_forces,

--- a/engine/tests/integration/plate_improvements.rs
+++ b/engine/tests/integration/plate_improvements.rs
@@ -87,7 +87,7 @@ fn plate_nodal_stress_output() {
     assert!(has_nonzero, "At least one nodal stress should be non-zero");
 
     // Also verify centroid stress recovery
-    let centroid = plate_stress_recovery(&coords, e, nu, t, &u_local);
+    let centroid = plate_stress_recovery(&coords, e, nu, t, &u_local, 0.0, 0.0, 0.0);
     assert!(centroid.von_mises >= 0.0);
 }
 
@@ -126,6 +126,34 @@ fn plate_thermal_load_produces_forces() {
     assert!(
         max_f_zero < 1e-15,
         "Zero temperature should produce zero loads"
+    );
+}
+
+#[test]
+fn plate_thermal_fully_restrained_stress() {
+    // Fully restrained plate: u=0, so ε_total=0 and σ = -E·α·ΔT/(1-ν).
+    let coords = [
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [0.5, 0.866, 0.0],
+    ];
+    let e = 200e6;
+    let nu = 0.3;
+    let t = 0.01;
+    let alpha = 12e-6;
+    let dt = 100.0;
+
+    let u_local = vec![0.0; 18];
+    let s = plate_stress_recovery(&coords, e, nu, t, &u_local, alpha, dt, 0.0);
+
+    let expected = -e * alpha * dt / (1.0 - nu);
+    assert!(
+        (s.sigma_xx - expected).abs() / expected.abs() < 1e-6,
+        "sigma_xx = {:.6e}, expected {:.6e}", s.sigma_xx, expected
+    );
+    assert!(
+        (s.sigma_yy - expected).abs() / expected.abs() < 1e-6,
+        "sigma_yy = {:.6e}, expected {:.6e}", s.sigma_yy, expected
     );
 }
 
@@ -435,7 +463,7 @@ fn plate_membrane_patch_test() {
     u_local[12] = eps_xx * 1.0;
     u_local[13] = -nu * eps_xx * 1.5;
 
-    let stress = plate_stress_recovery(&coords, e, nu, t, &u_local);
+    let stress = plate_stress_recovery(&coords, e, nu, t, &u_local, 0.0, 0.0, 0.0);
 
     let expected_sigma_xx = e * eps_xx;
     assert!(

--- a/web/src/lib/viewport3d/scene-sync.ts
+++ b/web/src/lib/viewport3d/scene-sync.ts
@@ -29,6 +29,7 @@ import {
   projectNodeToScene,
   shouldProjectModelToXZ,
 } from '../geometry/coordinate-system';
+import { computeLoadDirection } from '../canvas/draw-loads';
 
 /** Stable per-axis release fingerprint for the two ends of an element — 6 bits
  *  (I: my,mz,t then J: my,mz,t) so the element-cache signature rebuilds the mesh
@@ -729,11 +730,14 @@ export function syncLoads(ctx: SceneSyncContext): void {
       const len = Math.sqrt(dx * dx + dz * dz);
       let fx = 0, fz = 0;
       if (len > 1e-12) {
-        const ex = dx / len, ez = dz / len;
-        // 2D local +y (perpendicular, CCW from ex) in scene coordinates
-        const eyx = -ez, eyz = ex;
-        fx = (load.data.px ?? 0) * ex + load.data.p * eyx;
-        fz = (load.data.px ?? 0) * ez + load.data.p * eyz;
+        const cosTheta = dx / len;
+        const sinTheta = dz / len;
+        // Honor angle/isGlobal exactly like the 2D canvas renderer
+        // (computeLoadDirection returns viewport xy, which maps to scene xz).
+        const dir = computeLoadDirection(load.data.angle ?? 0, load.data.isGlobal ?? false, cosTheta, sinTheta);
+        const ex = cosTheta, ez = sinTheta;
+        fx = (load.data.px ?? 0) * ex + load.data.p * dir.dx;
+        fz = (load.data.px ?? 0) * ez + load.data.p * dir.dy;
       }
       batch.addNodalLoadArrow(
         { x: px, y: py, z: pz },


### PR DESCRIPTION
…ad direction

Follow-up to PR #109 review:
- Plate thermal stress: subtract α·ΔT and α·ΔT_grad/t in plate_stress_recovery
- Quad/quad9 nodal stress: same correction in quad_stress_at_nodes, quad_nodal_von_mises, quad9_stress_at_nodes, quad9_nodal_von_mises
- 2D pointOnElement 3D render: honor angle/isGlobal via computeLoadDirection (same helper as the 2D canvas renderer)

Tests: plate_thermal_fully_restrained_stress.