### PR TITLE
fix(engine): keep member point loads and match cases by id when combining

### DIFF
--- a/engine/src/postprocess/combinations.rs
+++ b/engine/src/postprocess/combinations.rs
@@ -95,6 +95,16 @@ pub struct EnvelopeInput3D {
 
 const N_POINTS: usize = 21;
 
+/// Map each id to its slot index. Later duplicates keep the first slot, which
+/// matches the previous positional behavior for well-formed inputs.
+fn index_by_id(ids: impl Iterator<Item = usize>) -> std::collections::HashMap<usize, usize> {
+    let mut map = std::collections::HashMap::new();
+    for (i, id) in ids.enumerate() {
+        map.entry(id).or_insert(i);
+    }
+    map
+}
+
 // ==================== 2D Combination ====================
 
 /// Linearly combine AnalysisResults from multiple load cases.
@@ -127,44 +137,59 @@ pub fn combine_results_refs(factors: &[CombinationFactor], cases: &[(usize, &Ana
         })
         .collect();
 
+    // Slots are addressed by id, never by position: cases are free to list
+    // their nodes/elements in any order, and a case missing an entry simply
+    // contributes nothing to that slot instead of shifting every later one.
+    let disp_slot = index_by_id(displacements.iter().map(|d| d.node_id));
+    let reaction_slot = index_by_id(reactions.iter().map(|r| r.node_id));
+    let element_slot = index_by_id(element_forces.iter().map(|e| e.element_id));
+    let case_slot = index_by_id(cases.iter().map(|c| c.0));
+
     for cf in factors {
-        let case = cases.iter().find(|c| c.0 == cf.case_id);
-        let r = match case {
-            Some(c) => c.1,
+        let r = match case_slot.get(&cf.case_id) {
+            Some(&i) => cases[i].1,
             None => continue,
         };
         let f = cf.factor;
 
-        for (i, d) in r.displacements.iter().enumerate() {
-            if i < displacements.len() {
-                displacements[i].ux += f * d.ux;
-                displacements[i].uz += f * d.uz;
-                displacements[i].ry += f * d.ry;
-            }
+        for d in &r.displacements {
+            let Some(&i) = disp_slot.get(&d.node_id) else { continue };
+            displacements[i].ux += f * d.ux;
+            displacements[i].uz += f * d.uz;
+            displacements[i].ry += f * d.ry;
         }
-        for (i, rx) in r.reactions.iter().enumerate() {
-            if i < reactions.len() {
-                reactions[i].rx += f * rx.rx;
-                reactions[i].rz += f * rx.rz;
-                reactions[i].my += f * rx.my;
-            }
+        for rx in &r.reactions {
+            let Some(&i) = reaction_slot.get(&rx.node_id) else { continue };
+            reactions[i].rx += f * rx.rx;
+            reactions[i].rz += f * rx.rz;
+            reactions[i].my += f * rx.my;
         }
-        for (i, ef) in r.element_forces.iter().enumerate() {
-            if i < element_forces.len() {
-                let out = &mut element_forces[i];
-                out.n_start += f * ef.n_start;
-                out.n_end += f * ef.n_end;
-                out.v_start += f * ef.v_start;
-                out.v_end += f * ef.v_end;
-                out.m_start += f * ef.m_start;
-                out.m_end += f * ef.m_end;
-                out.q_i += f * ef.q_i;
-                out.q_j += f * ef.q_j;
-                for dl in &ef.distributed_loads {
-                    out.distributed_loads.push(DistributedLoadInfo {
-                        q_i: dl.q_i * f, q_j: dl.q_j * f, a: dl.a, b: dl.b,
-                    });
-                }
+        for ef in &r.element_forces {
+            let Some(&i) = element_slot.get(&ef.element_id) else { continue };
+            let out = &mut element_forces[i];
+            out.n_start += f * ef.n_start;
+            out.n_end += f * ef.n_end;
+            out.v_start += f * ef.v_start;
+            out.v_end += f * ef.v_end;
+            out.m_start += f * ef.m_start;
+            out.m_end += f * ef.m_end;
+            out.q_i += f * ef.q_i;
+            out.q_j += f * ef.q_j;
+            for dl in &ef.distributed_loads {
+                out.distributed_loads.push(DistributedLoadInfo {
+                    q_i: dl.q_i * f, q_j: dl.q_j * f, a: dl.a, b: dl.b,
+                });
+            }
+            // The diagram evaluator reconstructs interior values from these;
+            // dropping them leaves the end forces right and everything between
+            // them wrong.
+            for pl in &ef.point_loads {
+                out.point_loads.push(PointLoadInfo {
+                    a: pl.a,
+                    p: pl.p * f,
+                    px: pl.px.map(|v| v * f),
+                    my: pl.my.map(|v| v * f),
+                });
             }
         }
     }
@@ -303,62 +328,66 @@ pub fn combine_results_3d_refs(factors: &[CombinationFactor], cases: &[(usize, &
             distributed_loads_z: Vec::new(), point_loads_z: Vec::new(), bimoment_start: None, bimoment_end: None })
         .collect();
 
+    let disp_slot = index_by_id(displacements.iter().map(|d| d.node_id));
+    let reaction_slot = index_by_id(reactions.iter().map(|r| r.node_id));
+    let element_slot = index_by_id(element_forces.iter().map(|e| e.element_id));
+    let case_slot = index_by_id(cases.iter().map(|c| c.0));
+
     for cf in factors {
-        let case = cases.iter().find(|c| c.0 == cf.case_id);
-        let r = match case { Some(c) => c.1, None => continue };
+        let r = match case_slot.get(&cf.case_id) {
+            Some(&i) => cases[i].1,
+            None => continue,
+        };
         let f = cf.factor;
 
-        for (i, d) in r.displacements.iter().enumerate() {
-            if i < displacements.len() {
-                displacements[i].ux += f * d.ux;
-                displacements[i].uy += f * d.uy;
-                displacements[i].uz += f * d.uz;
-                displacements[i].rx += f * d.rx;
-                displacements[i].ry += f * d.ry;
-                displacements[i].rz += f * d.rz;
-            }
+        for d in &r.displacements {
+            let Some(&i) = disp_slot.get(&d.node_id) else { continue };
+            displacements[i].ux += f * d.ux;
+            displacements[i].uy += f * d.uy;
+            displacements[i].uz += f * d.uz;
+            displacements[i].rx += f * d.rx;
+            displacements[i].ry += f * d.ry;
+            displacements[i].rz += f * d.rz;
         }
-        for (i, rx) in r.reactions.iter().enumerate() {
-            if i < reactions.len() {
-                reactions[i].fx += f * rx.fx;
-                reactions[i].fy += f * rx.fy;
-                reactions[i].fz += f * rx.fz;
-                reactions[i].mx += f * rx.mx;
-                reactions[i].my += f * rx.my;
-                reactions[i].mz += f * rx.mz;
-            }
+        for rx in &r.reactions {
+            let Some(&i) = reaction_slot.get(&rx.node_id) else { continue };
+            reactions[i].fx += f * rx.fx;
+            reactions[i].fy += f * rx.fy;
+            reactions[i].fz += f * rx.fz;
+            reactions[i].mx += f * rx.mx;
+            reactions[i].my += f * rx.my;
+            reactions[i].mz += f * rx.mz;
         }
-        for (i, ef) in r.element_forces.iter().enumerate() {
-            if i < element_forces.len() {
-                let out = &mut element_forces[i];
-                out.n_start += f * ef.n_start;
-                out.n_end += f * ef.n_end;
-                out.vy_start += f * ef.vy_start;
-                out.vy_end += f * ef.vy_end;
-                out.vz_start += f * ef.vz_start;
-                out.vz_end += f * ef.vz_end;
-                out.mx_start += f * ef.mx_start;
-                out.mx_end += f * ef.mx_end;
-                out.my_start += f * ef.my_start;
-                out.my_end += f * ef.my_end;
-                out.mz_start += f * ef.mz_start;
-                out.mz_end += f * ef.mz_end;
-                out.q_yi += f * ef.q_yi;
-                out.q_yj += f * ef.q_yj;
-                out.q_zi += f * ef.q_zi;
-                out.q_zj += f * ef.q_zj;
-                for dl in &ef.distributed_loads_y {
-                    out.distributed_loads_y.push(DistributedLoadInfo { q_i: dl.q_i * f, q_j: dl.q_j * f, a: dl.a, b: dl.b });
-                }
-                for dl in &ef.distributed_loads_z {
-                    out.distributed_loads_z.push(DistributedLoadInfo { q_i: dl.q_i * f, q_j: dl.q_j * f, a: dl.a, b: dl.b });
-                }
-                for pl in &ef.point_loads_y {
-                    out.point_loads_y.push(PointLoadInfo3D { a: pl.a, p: pl.p * f });
-                }
-                for pl in &ef.point_loads_z {
-                    out.point_loads_z.push(PointLoadInfo3D { a: pl.a, p: pl.p * f });
-                }
+        for ef in &r.element_forces {
+            let Some(&i) = element_slot.get(&ef.element_id) else { continue };
+            let out = &mut element_forces[i];
+            out.n_start += f * ef.n_start;
+            out.n_end += f * ef.n_end;
+            out.vy_start += f * ef.vy_start;
+            out.vy_end += f * ef.vy_end;
+            out.vz_start += f * ef.vz_start;
+            out.vz_end += f * ef.vz_end;
+            out.mx_start += f * ef.mx_start;
+            out.mx_end += f * ef.mx_end;
+            out.my_start += f * ef.my_start;
+            out.my_end += f * ef.my_end;
+            out.mz_start += f * ef.mz_start;
+            out.mz_end += f * ef.mz_end;
+            out.q_yi += f * ef.q_yi;
+            out.q_yj += f * ef.q_yj;
+            out.q_zi += f * ef.q_zi;
+            out.q_zj += f * ef.q_zj;
+            for dl in &ef.distributed_loads_y {
+                out.distributed_loads_y.push(DistributedLoadInfo { q_i: dl.q_i * f, q_j: dl.q_j * f, a: dl.a, b: dl.b });
+            }
+            for dl in &ef.distributed_loads_z {
+                out.distributed_loads_z.push(DistributedLoadInfo { q_i: dl.q_i * f, q_j: dl.q_j * f, a: dl.a, b: dl.b });
+            }
+            for pl in &ef.point_loads_y {
+                out.point_loads_y.push(PointLoadInfo3D { a: pl.a, p: pl.p * f });
+            }
+            for pl in &ef.point_loads_z {
+                out.point_loads_z.push(PointLoadInfo3D { a: pl.a, p: pl.p * f });
             }
         }
     }

--- a/engine/tests/integration/combinations.rs
+++ b/engine/tests/integration/combinations.rs
@@ -1,0 +1,233 @@
+//! Data-fidelity tests for load combination assembly.
+//!
+//! A combination is a linear superposition of solved load cases. Two properties
+//! must hold and are asserted here:
+//!
+//! 1. **Load metadata survives.** `ElementForces` carries the member loads that
+//!    produced it (`point_loads`, `distributed_loads`); the diagram evaluator
+//!    needs them to reconstruct interior values between the end forces. A
+//!    combination that keeps the end forces but drops the member loads yields
+//!    correct values at t=0 and t=1 and wrong values everywhere between.
+//! 2. **Contributions land on the element they came from.** Cases are matched
+//!    by `element_id` / `node_id`, never by position in the vector.
+
+use dedaliano_engine::postprocess::combinations::*;
+use dedaliano_engine::postprocess::diagrams::compute_diagram_value_at;
+use dedaliano_engine::solver::linear::solve_2d;
+use dedaliano_engine::types::*;
+use std::collections::HashMap;
+
+// ==================== Fixtures ====================
+
+/// Simply supported beam, 6 m span, single element, pinned–roller.
+fn simply_supported_beam() -> SolverInput {
+    let mut nodes = HashMap::new();
+    nodes.insert("1".to_string(), SolverNode { id: 1, x: 0.0, z: 0.0 });
+    nodes.insert("2".to_string(), SolverNode { id: 2, x: 6.0, z: 0.0 });
+
+    let mut materials = HashMap::new();
+    materials.insert("1".to_string(), SolverMaterial { id: 1, e: 200e9, nu: 0.3 });
+
+    let mut sections = HashMap::new();
+    sections.insert("1".to_string(), SolverSection { id: 1, a: 0.05, iz: 1.0e-4, as_y: None });
+
+    let mut elements = HashMap::new();
+    elements.insert("1".to_string(), SolverElement {
+        id: 1,
+        elem_type: "frame".to_string(),
+        node_i: 1,
+        node_j: 2,
+        material_id: 1,
+        section_id: 1,
+        hinge_start: false,
+        hinge_end: false,
+    });
+
+    let sup = |id: usize, node_id: usize, ty: &str| SolverSupport {
+        id, node_id, support_type: ty.to_string(),
+        kx: None, ky: None, kz: None,
+        dx: None, dz: None, dry: None, angle: None,
+    };
+
+    let mut supports = HashMap::new();
+    supports.insert("1".to_string(), sup(1, 1, "pinned"));
+    supports.insert("2".to_string(), sup(2, 2, "rollerX"));
+
+    SolverInput {
+        nodes, materials, sections, elements, supports,
+        loads: vec![], constraints: vec![], connectors: HashMap::new(),
+    }
+}
+
+fn ef(element_id: usize, m_start: f64) -> ElementForces {
+    ElementForces {
+        element_id,
+        n_start: 0.0, n_end: 0.0,
+        v_start: 0.0, v_end: 0.0,
+        m_start, m_end: 0.0,
+        length: 1.0,
+        q_i: 0.0, q_j: 0.0,
+        point_loads: Vec::new(),
+        distributed_loads: Vec::new(),
+        hinge_start: false, hinge_end: false,
+    }
+}
+
+fn results_with(element_forces: Vec<ElementForces>) -> AnalysisResults {
+    AnalysisResults {
+        displacements: vec![],
+        reactions: vec![],
+        element_forces,
+        constraint_forces: vec![],
+        diagnostics: vec![],
+        solver_diagnostics: vec![],
+        structured_diagnostics: vec![],
+        equilibrium: None,
+        result_summary: None,
+        solver_run_meta: None,
+    }
+}
+
+// ==================== Tests ====================
+
+/// A unit-factor combination of a single case must reproduce that case's
+/// moment diagram everywhere, not just at the element ends.
+///
+/// Midspan point load P on a simply supported span: M(L/2) = P·L/4.
+/// With P = 12 kN and L = 6 m that is 18 kN·m. The end forces alone imply a
+/// linear diagram and would give 0 at midspan.
+#[test]
+fn combination_preserves_member_point_loads_in_2d_diagram() {
+    let mut input = simply_supported_beam();
+    input.loads = vec![SolverLoad::PointOnElement(SolverPointLoadOnElement {
+        element_id: 1,
+        a: 3.0,
+        p: -12_000.0,
+        px: None,
+        my: None,
+    })];
+
+    let case = solve_2d(&input).expect("solve_2d failed");
+    let case_ef = &case.element_forces[0];
+    assert_eq!(case_ef.point_loads.len(), 1, "solver must report the member point load");
+
+    let case_mid = compute_diagram_value_at("moment", 0.5, case_ef);
+    assert!(
+        (case_mid.abs() - 18_000.0).abs() < 1.0,
+        "single-case midspan moment should be P·L/4 = 18000 N·m, got {case_mid:.1}"
+    );
+
+    let combined = combine_results(&CombinationInput {
+        factors: vec![CombinationFactor { case_id: 0, factor: 1.0 }],
+        cases: vec![CaseEntry { case_id: 0, results: case.clone() }],
+    })
+    .expect("combine_results returned None");
+
+    let combined_ef = &combined.element_forces[0];
+    assert_eq!(
+        combined_ef.point_loads.len(), 1,
+        "combination dropped the member point load"
+    );
+
+    let combined_mid = compute_diagram_value_at("moment", 0.5, combined_ef);
+    assert!(
+        (combined_mid - case_mid).abs() < 1e-6,
+        "1.0-factor combination must reproduce the case diagram at midspan: \
+         combined {combined_mid:.1} vs case {case_mid:.1}"
+    );
+}
+
+/// Point load magnitudes must scale with the combination factor.
+#[test]
+fn combination_scales_member_point_loads_by_factor() {
+    let mut input = simply_supported_beam();
+    input.loads = vec![SolverLoad::PointOnElement(SolverPointLoadOnElement {
+        element_id: 1, a: 3.0, p: -12_000.0, px: None, my: None,
+    })];
+    let case = solve_2d(&input).expect("solve_2d failed");
+
+    let combined = combine_results(&CombinationInput {
+        factors: vec![CombinationFactor { case_id: 0, factor: 1.6 }],
+        cases: vec![CaseEntry { case_id: 0, results: case.clone() }],
+    })
+    .expect("combine_results returned None");
+
+    let pl = &combined.element_forces[0].point_loads;
+    assert_eq!(pl.len(), 1, "combination dropped the member point load");
+    assert!(
+        (pl[0].p - 1.6 * -12_000.0).abs() < 1e-6,
+        "point load must scale by the factor: got {}", pl[0].p
+    );
+    assert!((pl[0].a - 3.0).abs() < 1e-12, "point load position must not scale");
+
+    let mid = compute_diagram_value_at("moment", 0.5, &combined.element_forces[0]);
+    assert!(
+        (mid.abs() - 1.6 * 18_000.0).abs() < 1.0,
+        "1.6·(P·L/4) = 28800 N·m expected, got {mid:.1}"
+    );
+}
+
+/// Cases may list their element forces in any order. Each case's contribution
+/// must be added to the element it belongs to, matched by `element_id`.
+#[test]
+fn combination_matches_cases_by_element_id_not_position() {
+    // Case A lists elements 1,2; case B lists them reversed.
+    let case_a = results_with(vec![ef(1, 100.0), ef(2, 200.0)]);
+    let case_b = results_with(vec![ef(2, 20.0), ef(1, 10.0)]);
+
+    let combined = combine_results(&CombinationInput {
+        factors: vec![
+            CombinationFactor { case_id: 0, factor: 1.0 },
+            CombinationFactor { case_id: 1, factor: 1.0 },
+        ],
+        cases: vec![
+            CaseEntry { case_id: 0, results: case_a },
+            CaseEntry { case_id: 1, results: case_b },
+        ],
+    })
+    .expect("combine_results returned None");
+
+    let m = |id: usize| {
+        combined.element_forces.iter()
+            .find(|e| e.element_id == id)
+            .unwrap_or_else(|| panic!("element {id} missing from combination"))
+            .m_start
+    };
+
+    assert!((m(1) - 110.0).abs() < 1e-12, "element 1 should be 100+10, got {}", m(1));
+    assert!((m(2) - 220.0).abs() < 1e-12, "element 2 should be 200+20, got {}", m(2));
+}
+
+/// Same requirement for nodal quantities.
+#[test]
+fn combination_matches_reactions_by_node_id_not_position() {
+    let mk = |entries: Vec<(usize, f64)>| {
+        let mut r = results_with(vec![]);
+        r.reactions = entries.into_iter()
+            .map(|(node_id, rz)| Reaction { node_id, rx: 0.0, rz, my: 0.0 })
+            .collect();
+        r
+    };
+
+    let combined = combine_results(&CombinationInput {
+        factors: vec![
+            CombinationFactor { case_id: 0, factor: 1.0 },
+            CombinationFactor { case_id: 1, factor: 1.0 },
+        ],
+        cases: vec![
+            CaseEntry { case_id: 0, results: mk(vec![(1, 5.0), (2, 7.0)]) },
+            CaseEntry { case_id: 1, results: mk(vec![(2, 0.7), (1, 0.5)]) },
+        ],
+    })
+    .expect("combine_results returned None");
+
+    let rz = |id: usize| {
+        combined.reactions.iter()
+            .find(|r| r.node_id == id)
+            .unwrap_or_else(|| panic!("node {id} missing"))
+            .rz
+    };
+
+    assert!((rz(1) - 5.5).abs() < 1e-12, "node 1 should be 5.0+0.5, got {}", rz(1));
+    assert!((rz(2) - 7.7).abs() < 1e-12, "node 2 should be 7.0+0.7, got {}", rz(2));
+}

--- a/engine/tests/integration/main.rs
+++ b/engine/tests/integration/main.rs
@@ -4,6 +4,7 @@ mod common;
 mod cable_solver;
 mod cfs_check;
 mod cirsoc201_check;
+mod combinations;
 mod connection_check;
 mod corotational_3d;
 mod eccentric_connections;


### PR DESCRIPTION
Part 1 of 8 from an audit of the design-check layer and the post-processing that feeds it. Each PR groups one *type* of defect and is independent off `main`.

## What was wrong

**2D combinations dropped member point loads.** `combine_results` rebuilt each `ElementForces` with `point_loads: Vec::new()` and never repopulated it, while copying `distributed_loads`. The 3D path already carried `point_loads_y/z`, so this was an omission rather than a decision.

`compute_diagram_value_at_sorted` reconstructs interior diagram values from those loads, so **every 2D combination over a model with member point loads produced correct end forces and wrong values everywhere between** — and `compute_envelope` builds the design envelope from those diagrams. This is the production ULS path (`load_cases.rs:154`).

**Cases were combined by vector position.** Both 2D and 3D matched with an `if i < len` guard, so a case listing its nodes or elements in a different order silently added one element's forces to another's slot.

## Why the existing tests missed it

`multi_case_parity.rs` compares `solve_multi_case_2d` against a manual reference — but both sides route through `combine_results`, so both dropped point loads equally and parity held.

## Fix

- Point load components (`p`, `px`, `my`) scale with the combination factor; position `a` does not.
- Slots addressed by `element_id` / `node_id`.

## Tests

`engine/tests/integration/combinations.rs`: a 1.0-factor combination of a single case must reproduce that case's midspan moment (P·L/4 on a simply supported span); factors must scale point loads; reversed-order cases must accumulate onto the right element and node.

Written test-first — all four failed for the predicted reason (element 1 read 120 instead of 110, i.e. case B's element-2 value).

## Verification

Full engine suite green (`--test-threads=4`).

## Merge notes

Independent of the other seven PRs.