### PR TITLE
fix(landing): redirect #realtime to #basic

### DIFF
--- a/web/e2e/landing.spec.ts
+++ b/web/e2e/landing.spec.ts
@@ -959,6 +959,22 @@ test.describe('@landing landing page', () => {
     await expect(page.locator('.landing [data-section="realtime"]')).toHaveCount(0);
   });
 
+  test('#realtime redirects to #basic', async ({ page }) => {
+    // The real-time section was folded into Basic. Any external link or
+    // bookmark that still points at #realtime must land on the section that
+    // now carries the feature.
+    await bootLanding(page);
+    await page.evaluate(() => {
+      window.location.hash = '#realtime';
+    });
+    // The redirect listens on hashchange and replaces the hash.
+    await page.waitForTimeout(200);
+    expect(page.url()).toContain('#basic');
+    // The basic section must be in view.
+    const basicTop = await page.locator('.landing [data-section="basic"]').evaluate((el) => el.getBoundingClientRect().top);
+    expect(basicTop).toBeLessThan(200);
+  });
+
   test('the moving load is the arrow alone — no caption in either language', async ({ browser }) => {
     // The arrow used to carry a "UNIT MOVING LOAD" caption. It was removed; the
     // meaning now lives only in the SVG <desc>, which is not rendered text.

--- a/web/src/components/LandingPage.svelte
+++ b/web/src/components/LandingPage.svelte
@@ -17,7 +17,7 @@
   import LandingDocs from './landing/LandingDocs.svelte';
   import LandingCTA from './landing/LandingCTA.svelte';
   import LandingFooter from './landing/LandingFooter.svelte';
-  import { enterApp } from './landing/landing-utils';
+  import { enterApp, scrollToId } from './landing/landing-utils';
   import './landing/landing.css';
 
   let landingEl: HTMLDivElement;
@@ -91,6 +91,20 @@
   });
 
   onMount(() => {
+    // #realtime was removed when the section folded into Basic. Redirect any
+    // incoming link or bookmark to the section that now carries the feature,
+    // both on first load and on a later hash change.
+    const redirectRealtime = () => {
+      if (window.location.hash !== '#realtime') return;
+      history.replaceState(null, '', '#basic');
+      // Defer to the next frame so the sections are laid out before scrolling.
+      requestAnimationFrame(() => {
+        scrollToId('basic', landingEl);
+      });
+    };
+    redirectRealtime();
+    window.addEventListener('hashchange', redirectRealtime);
+
     /**
      * Safety net for the reveal animation.
      *
@@ -153,6 +167,7 @@
       observer.disconnect();
       landingEl?.removeEventListener('scroll', onScroll);
       window.removeEventListener('message', onMessage);
+      window.removeEventListener('hashchange', redirectRealtime);
       if (motionQuery.removeEventListener) motionQuery.removeEventListener('change', onMotionChange);
       else motionQuery.removeListener(onMotionChange);
     };


### PR DESCRIPTION
The real-time section was folded into Basic in PR #111. Any external link or bookmark that still points at #realtime now lands on the section that carries the feature, both on first load and on a later hash change.

Test: #realtime redirects to #basic.