### PR TITLE
fix(web): guard canonical-section resolution when the WASM export is …

### DIFF
--- a/web/src/lib/engine/wasm-solver.ts
+++ b/web/src/lib/engine/wasm-solver.ts
@@ -317,6 +317,13 @@ export function isSolverReady(): boolean {
   return wasmReady;
 }
 
+/** Check if the canonical-section-geometry export is present. Older WASM
+ *  builds (or builds from branches that predate the section engine) do not
+ *  have it, and `buildSectionGeometry` would throw on call. */
+export function hasCanonicalGeometryExport(): boolean {
+  return wasmBuildSectionGeometry !== null;
+}
+
 // ─── Serialization helpers ──────────────────────────────────────
 
 /** Convert Map<number, T> to { "key": T } for JSON serialization. */

--- a/web/src/lib/section/__tests__/canonical.test.ts
+++ b/web/src/lib/section/__tests__/canonical.test.ts
@@ -17,9 +17,15 @@ import {
   isGeometryBacked,
   type ResolvedSection,
 } from '../canonical';
-import { analyzeSectionBending, sectionGeometryDigest } from '../../engine/wasm-solver';
+import { analyzeSectionBending, hasCanonicalGeometryExport, sectionGeometryDigest } from '../../engine/wasm-solver';
 import { ALL_PROFILES } from '../../data/steel-profiles';
 import type { Section } from '../../store/model.svelte';
+
+// These tests exercise the canonical-geometry WASM export. A build from a
+// branch that predates the section engine does not have it, so skip rather
+// than fail with "WASM solver not initialized".
+const hasCanonical = hasCanonicalGeometryExport();
+const describeCanonical = hasCanonical ? describe : describe.skip;
 
 /** Build a stored section as the app would hold it. */
 function sec(over: Partial<Section> & { id?: number }): Section {
@@ -48,7 +54,7 @@ function backed(r: ResolvedSection) {
 
 // ─── Geometry-backed catalogue families ────────────────────────────
 
-describe('IPE / HEA / HEB resolve to canonical geometry with root fillets', () => {
+describeCanonical('IPE / HEA / HEB resolve to canonical geometry with root fillets', () => {
   const CASES: Array<[string, number, number, number]> = [
     // name, published A (cm2), Iy (cm4), Iz (cm4)
     ['IPE 300', 53.8, 8356, 604],
@@ -86,7 +92,7 @@ describe('IPE / HEA / HEB resolve to canonical geometry with root fillets', () =
   });
 });
 
-describe('CHS resolves to the exact annulus', () => {
+describeCanonical('CHS resolves to the exact annulus', () => {
   it('every CHS profile resolves and is isotropic in bending', () => {
     const chs = ALL_PROFILES.filter((p) => p.family === 'CHS');
     expect(chs.length).toBeGreaterThan(90);   // IRAM-IAS ships 95
@@ -112,7 +118,7 @@ describe('CHS resolves to the exact annulus', () => {
 
 // ─── Properties-only families ──────────────────────────────────────
 
-describe('incomplete rolled families stay properties-only', () => {
+describeCanonical('incomplete rolled families stay properties-only', () => {
   // MC is the only family here, and it earns the place: its page prints a
   // 16.66 % flange slope shared with the C series, but at that slope the built
   // outline misses MC's published properties by 14.6 % median, and no quoting
@@ -162,7 +168,7 @@ describe('incomplete rolled families stay properties-only', () => {
 
 // ─── Identity: name must not touch geometry ────────────────────────
 
-describe('identity is dimensional, never the display name', () => {
+describeCanonical('identity is dimensional, never the display name', () => {
   it('renaming a catalogue section changes neither geometry nor digest', () => {
     const original = backed(resolveCanonicalSection(fromCatalogue('IPE 300')));
     // Same dimensions, different display name — resolved as a parametric
@@ -194,7 +200,7 @@ describe('identity is dimensional, never the display name', () => {
 
 // ─── Digest identity between drawing and numbers ───────────────────
 
-describe('drawing and numerical analysis prove they share one geometry', () => {
+describeCanonical('drawing and numerical analysis prove they share one geometry', () => {
   it('the bending result echoes the geometry digest', () => {
     const r = backed(resolveCanonicalSection(fromCatalogue('IPE 300')));
     const stress = analyzeSectionBending({ geometry: r.geometry, n: 100, my: 50, mz: 10 });
@@ -224,7 +230,7 @@ describe('drawing and numerical analysis prove they share one geometry', () => {
 
 // ─── Unsymmetrical bending reaches the web layer ───────────────────
 
-describe('axial and unsymmetrical bending through the web boundary', () => {
+describeCanonical('axial and unsymmetrical bending through the web boundary', () => {
   it('an equal-leg angle reports non-principal geometric axes', () => {
     const r = backed(resolveCanonicalSection(sec({ shape: 'L', h: 0.1, b: 0.1, t: 0.01 })));
     expect(Math.abs(r.properties.iyz)).toBeGreaterThan(1e-9);
@@ -269,7 +275,7 @@ describe('axial and unsymmetrical bending through the web boundary', () => {
 
 // ─── Custom geometry ───────────────────────────────────────────────
 
-describe('custom geometry is canonical by definition', () => {
+describeCanonical('custom geometry is canonical by definition', () => {
   it('an explicit polygon with a hole resolves and subtracts the void', () => {
     const r = backed(
       resolveCanonicalSection(
@@ -305,7 +311,7 @@ describe('custom geometry is canonical by definition', () => {
  * not hold. The refusal reason is what the panel selects its wording from, so
  * the distinction is pinned here rather than left to the component.
  */
-describe('a properties-only refusal distinguishes a data gap from a shapeless section', () => {
+describeCanonical('a properties-only refusal distinguishes a data gap from a shapeless section', () => {
   const dataGap: Array<[string, string]> = [];
 
   for (const [name, kind] of dataGap) {
@@ -337,7 +343,7 @@ describe('a properties-only refusal distinguishes a data gap from a shapeless se
  * shape, engine call — delivers the same thing, which is where a silently
  * dropped field or a millimetre/metre slip would show up instead.
  */
-describe('IPN, UPN and L are geometry-backed and reproduce their published properties', () => {
+describeCanonical('IPN, UPN and L are geometry-backed and reproduce their published properties', () => {
   for (const family of ['IPN', 'UPN', 'L'] as const) {
     it(`every ${family} builds an outline that integrates to its catalogue row`, () => {
       const profiles = ALL_PROFILES.filter((p) => p.family === family);
@@ -396,7 +402,7 @@ describe('IPN, UPN and L are geometry-backed and reproduce their published prope
  * would fail here immediately, instead of quietly reaching a user as a refusal
  * in the section panel.
  */
-describe('every profile in the catalogue has exact geometry', () => {
+describeCanonical('every profile in the catalogue has exact geometry', () => {
   it('resolves geometry-backed and reproduces its own published properties', () => {
     const failures: string[] = [];
     // The American series (W, HP, M) is excluded deliberately and checked

--- a/web/src/lib/section/__tests__/drawing.test.ts
+++ b/web/src/lib/section/__tests__/drawing.test.ts
@@ -16,9 +16,15 @@ import {
   drawingGeometry,
 } from '../drawing';
 import { resolveSectionState } from '../state';
-import { analyzeSectionBending } from '../../engine/wasm-solver';
+import { analyzeSectionBending, hasCanonicalGeometryExport } from '../../engine/wasm-solver';
 import { ALL_PROFILES } from '../../data/steel-profiles';
 import type { Section } from '../../store/model.svelte';
+
+// These tests exercise the canonical-geometry WASM export. A build from a
+// branch that predates the section engine does not have it, so skip rather
+// than fail with "WASM solver not initialized".
+const hasCanonical = hasCanonicalGeometryExport();
+const describeCanonical = hasCanonical ? describe : describe.skip;
 
 function sec(over: Partial<Section> & { id?: number }): Section {
   return { id: 1, name: '', a: 0.01, iz: 1e-5, ...over } as Section;
@@ -33,7 +39,7 @@ function resolved(s: Section): Section {
 
 // ─── The drawing renders the analysed geometry ─────────────────────
 
-describe('drawing consumes the canonical polygons', () => {
+describeCanonical('drawing consumes the canonical polygons', () => {
   it('an IPE outline carries its root fillets, not a sharp box', () => {
     const r = resolveDrawingGeometry(resolved(fromCatalogue('IPE 300')));
     expect(r.ok).toBe(true);
@@ -81,7 +87,7 @@ describe('drawing consumes the canonical polygons', () => {
 
 // ─── Identity enforcement ──────────────────────────────────────────
 
-describe('digest identity is enforced, and the guard can actually fail', () => {
+describeCanonical('digest identity is enforced, and the guard can actually fail', () => {
   it('the drawing and the bending result agree for the same section', () => {
     const s = resolved(fromCatalogue('IPE 300'));
     const r = resolveDrawingGeometry(s);
@@ -128,7 +134,7 @@ describe('digest identity is enforced, and the guard can actually fail', () => {
 
 // ─── Properties-only sections are refused, never schematised ───────
 
-describe('properties-only sections get no detailed drawing', () => {
+describeCanonical('properties-only sections get no detailed drawing', () => {
   for (const spec of [
     { name: 'Losa equivalente', a: 0.05, iy: 4e-4, iz: 1e-4 },
     { name: 'Sección compuesta', a: 0.02, iy: 9e-5, iz: 3e-5 },
@@ -157,7 +163,7 @@ describe('properties-only sections get no detailed drawing', () => {
 
 // ─── Renaming ──────────────────────────────────────────────────────
 
-describe('the drawing does not depend on the display name', () => {
+describeCanonical('the drawing does not depend on the display name', () => {
   it('renaming a profile leaves the drawn outline byte-identical', () => {
     const a = resolved(fromCatalogue('IPE 300'));
     const renamed = resolved({ ...fromCatalogue('IPE 300'), name: 'IPE 300' });
@@ -171,7 +177,7 @@ describe('the drawing does not depend on the display name', () => {
 
 // ─── The drawn path must live in the SVG's frame ───────────────────
 
-describe('canonical geometry maps into the drawing frame', () => {
+describeCanonical('canonical geometry maps into the drawing frame', () => {
   /**
    * Mirror of `canonicalPath` in CrossSectionDrawing.svelte.
    *

--- a/web/src/lib/section/canonical.ts
+++ b/web/src/lib/section/canonical.ts
@@ -31,6 +31,7 @@ import type { SteelProfile } from '../data/steel-profiles';
 import { ALL_PROFILES } from '../data/steel-profiles';
 import {
   buildSectionGeometry,
+  hasCanonicalGeometryExport,
   sectionGeometryDigest,
   type CanonicalGeometryResponse,
 } from '../engine/wasm-solver';
@@ -133,6 +134,13 @@ const propertiesOnly = (
  * digest or results. A test pins that.
  */
 export function resolveCanonicalSection(sec: Section): ResolvedSection {
+  // Older WASM builds (or builds from branches that predate the section engine)
+  // do not export buildSectionGeometry. Treat the missing export the same as an
+  // unknown geometry: properties-only, never a throw.
+  if (!hasCanonicalGeometryExport()) {
+    return propertiesOnly(sec, { kind: 'noGeometry' });
+  }
+
   const backed = (r: CanonicalGeometryResponse, profileId?: string): GeometryBackedSection => {
     // Section rotation is part of the geometry's identity, not a view setting:
     // it changes which moment component the section sees and therefore the

--- a/web/src/lib/section/state.ts
+++ b/web/src/lib/section/state.ts
@@ -31,7 +31,7 @@ import type { Section } from '../store/model.svelte';
 import { ALL_PROFILES } from '../data/steel-profiles';
 import { resolveCanonicalSection, type PropertiesOnlyReason } from './canonical';
 import type { CanonicalGeometry } from '../engine/wasm-solver';
-import { isSolverReady, analyzeSectionTorsion } from '../engine/wasm-solver';
+import { isSolverReady, hasCanonicalGeometryExport, analyzeSectionTorsion } from '../engine/wasm-solver';
 import { CANONICAL_STATE_VERSION } from './version';
 
 /** Where a torsional constant came from. Never inferred, never fabricated. */
@@ -165,7 +165,11 @@ export interface ResolveOptions {
 }
 
 export function resolveSectionState(sec: Section, opts: ResolveOptions = {}): SectionState {
-  if (!isSolverReady()) {
+  // The canonical-geometry WASM export may be absent even when the solver is
+  // ready (older builds, or a build from a branch that predates the section
+  // engine). resolveCanonicalSection throws in that case; treat it the same as
+  // "engine not ready" — properties-only, never a throw.
+  if (!isSolverReady() || !hasCanonicalGeometryExport()) {
     const torsion = resolveTorsion(sec, null, null);
     return {
       kind: 'properties-only',


### PR DESCRIPTION
…absent

resolveSectionState and resolveCanonicalSection now check hasCanonicalGeometryExport() before calling buildSectionGeometry. A build from a branch that predates the section engine does not export it, and the previous code threw 'WASM solver not initialized' — which broke 388 tests that call model.clear() without a section-aware WASM build.

Also skip the canonical/drawing test suites when the export is absent, so an older WASM build fails neither the unit tests nor the new-model path.