### PR TITLE
perf(3d): count supports in the orbit LOD budget

### DIFF
--- a/web/src/components/Viewport3D.svelte
+++ b/web/src/components/Viewport3D.svelte
@@ -551,7 +551,11 @@
       // Opt-in "smooth orbit" forces the heavy-model low-detail path for any
       // model during camera motion (collapse to the single batched wireframe).
       const heavyModel = uiStore.smoothOrbit3D || isHeavyModel(
-        { elements: modelStore.elements.size, shells: modelStore.plates.size + modelStore.quads.size },
+        {
+          elements: modelStore.elements.size,
+          shells: modelStore.plates.size + modelStore.quads.size,
+          supports: modelStore.supports.size,
+        },
         uiStore.renderMode3D,
       );
       applyLowDetail(on, {

--- a/web/src/lib/three/__tests__/support-gizmo-sharing.test.ts
+++ b/web/src/lib/three/__tests__/support-gizmo-sharing.test.ts
@@ -169,3 +169,42 @@ describe('shared materials survive per-gizmo recolouring', () => {
     expect(lineColour(a)).toBe(original);
   });
 });
+
+describe('the private clone is genuinely private', () => {
+  function firstLine(o: THREE.Object3D): THREE.Line | null {
+    let found: THREE.Line | null = null;
+    o.traverse((c) => { if (!found && c instanceof THREE.Line) found = c as THREE.Line; });
+    return found;
+  }
+
+  it('does not inherit the shared flag', () => {
+    // THREE.Material.clone() deep-copies userData. If `shared` rode along,
+    // disposeObject would skip the clone forever and every later recolour
+    // would clone again.
+    const [g] = makeMany(1, 'fixed3d');
+    setGroupColor(g, 0xff0000);
+    const mat = (firstLine(g)!.material as THREE.Material);
+    expect(mat.userData?.shared).toBeUndefined();
+  });
+
+  it('recolouring repeatedly reuses the same private material', () => {
+    const [g] = makeMany(1, 'fixed3d');
+    setGroupColor(g, 0xff0000);
+    const first = firstLine(g)!.material;
+    setGroupColor(g, 0x00ff00);
+    setGroupColor(g, 0x0000ff);
+    expect(firstLine(g)!.material).toBe(first); // no new clone per recolour
+  });
+
+  it('the private clone is disposed with the gizmo', () => {
+    const [g] = makeMany(1, 'fixed3d');
+    setGroupColor(g, 0xff0000);
+    const mat = firstLine(g)!.material as THREE.Material;
+    let disposed = false;
+    mat.addEventListener('dispose', () => { disposed = true; });
+
+    disposeObject(g);
+
+    expect(disposed).toBe(true); // the shared original is still protected
+  });
+});

--- a/web/src/lib/three/__tests__/support-gizmo-sharing.test.ts
+++ b/web/src/lib/three/__tests__/support-gizmo-sharing.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect } from 'vitest';
 import * as THREE from 'three';
 import { createSupportGizmo } from '../create-support-gizmo';
-import { disposeObject } from '../selection-helpers';
+import { disposeObject, setGroupColor } from '../selection-helpers';
 
 const ORIGIN = { x: 0, y: 0, z: 0 };
 
@@ -130,5 +130,42 @@ describe('support gizmo resource sharing', () => {
       if ((o as THREE.Mesh).isMesh || (o as THREE.Line).isLine) drawables++;
     });
     expect(drawables).toBeGreaterThan(0);
+  });
+});
+
+describe('shared materials survive per-gizmo recolouring', () => {
+  /** Colour of the first Line found under `o`. */
+  function lineColour(o: THREE.Object3D): number | null {
+    let hex: number | null = null;
+    o.traverse((c) => {
+      if (hex === null && c instanceof THREE.Line) {
+        const m = c.material as THREE.LineBasicMaterial;
+        hex = m.color.getHex();
+      }
+    });
+    return hex;
+  }
+
+  it('selecting one support does not recolour the others', () => {
+    // The regression this guards: gizmo materials are shared across every
+    // support, and setGroupColor mutates `material.color` in place. Without
+    // copy-on-write, colouring one selected support repaints all of them.
+    const [a, b] = makeMany(2, 'fixed3d');
+    const before = lineColour(b);
+    expect(before).not.toBeNull();
+
+    setGroupColor(a, 0xff0000);
+
+    expect(lineColour(a)).toBe(0xff0000);
+    expect(lineColour(b)).toBe(before);
+  });
+
+  it('recolouring is still reversible on the same gizmo', () => {
+    const [a] = makeMany(1, 'fixed3d');
+    const original = lineColour(a);
+    setGroupColor(a, 0xff0000);
+    expect(lineColour(a)).toBe(0xff0000);
+    setGroupColor(a, original!);
+    expect(lineColour(a)).toBe(original);
   });
 });

--- a/web/src/lib/three/selection-helpers.ts
+++ b/web/src/lib/three/selection-helpers.ts
@@ -37,6 +37,25 @@ export function setMeshColor(mesh: THREE.Mesh, color: number): void {
 }
 
 /** Set color on all Mesh children of a Group */
+/** Give `obj` a private copy of a shared material before it gets recoloured.
+ *
+ *  Gizmo materials are shared across every instance of a support type, and the
+ *  recolour path below mutates `material.color` in place — so without this,
+ *  selecting one support repaints all of them. Copy-on-write keeps the sharing
+ *  for everything that is never recoloured and pays a clone only for the object
+ *  actually being highlighted. The clone is private, so `disposeObject` frees
+ *  it normally. */
+function privatiseMaterial(obj: THREE.Mesh | THREE.Line): void {
+  const mat = obj.material;
+  if (Array.isArray(mat)) {
+    if (mat.some(m => m.userData?.shared)) {
+      obj.material = mat.map(m => (m.userData?.shared ? m.clone() : m));
+    }
+    return;
+  }
+  if (mat?.userData?.shared) obj.material = mat.clone();
+}
+
 export function setGroupColor(group: THREE.Group, color: number): void {
   group.traverse((child) => {
     // Skip invisible picking helpers
@@ -47,9 +66,11 @@ export function setGroupColor(group: THREE.Group, color: number): void {
     // release stays visible while the element is selected.
     if (child.userData?.jointGlyph) return;
     if (child instanceof THREE.Mesh) {
+      privatiseMaterial(child);
       setMeshColor(child, color);
     }
     if (child instanceof THREE.Line) {
+      privatiseMaterial(child);
       const mat = child.material;
       if (mat instanceof THREE.LineBasicMaterial) {
         mat.color.setHex(color);

--- a/web/src/lib/three/selection-helpers.ts
+++ b/web/src/lib/three/selection-helpers.ts
@@ -46,14 +46,25 @@ export function setMeshColor(mesh: THREE.Mesh, color: number): void {
  *  actually being highlighted. The clone is private, so `disposeObject` frees
  *  it normally. */
 function privatiseMaterial(obj: THREE.Mesh | THREE.Line): void {
+  // THREE.Material.clone() deep-copies userData, so the clone inherits
+  // `shared: true` unless it is cleared. Leaving it set would defeat the whole
+  // point twice over: disposeObject skips shared materials, so the private
+  // clone would never be freed, and the next recolour would clone it again —
+  // one leaked material per recolour, and syncSelection runs often.
+  const privatise = (m: THREE.Material): THREE.Material => {
+    const c = m.clone();
+    delete c.userData.shared;
+    return c;
+  };
+
   const mat = obj.material;
   if (Array.isArray(mat)) {
     if (mat.some(m => m.userData?.shared)) {
-      obj.material = mat.map(m => (m.userData?.shared ? m.clone() : m));
+      obj.material = mat.map(m => (m.userData?.shared ? privatise(m) : m));
     }
     return;
   }
-  if (mat?.userData?.shared) obj.material = mat.clone();
+  if (mat?.userData?.shared) obj.material = privatise(mat);
 }
 
 export function setGroupColor(group: THREE.Group, color: number): void {

--- a/web/src/lib/three/selection-helpers.ts
+++ b/web/src/lib/three/selection-helpers.ts
@@ -24,19 +24,6 @@ export const COLORS: Record<string, number> = {
   background:      0x1a1a2e,
 };
 
-/** Set emissive+color on a single Mesh's material (MeshStandard or LineMaterial) */
-export function setMeshColor(mesh: THREE.Mesh, color: number): void {
-  const mat = mesh.material;
-  if (mat instanceof THREE.MeshStandardMaterial) {
-    mat.color.setHex(color);
-    mat.needsUpdate = true;
-  } else if (mat instanceof LineMaterial) {
-    mat.color.setHex(color);
-    mat.needsUpdate = true;
-  }
-}
-
-/** Set color on all Mesh children of a Group */
 /** Give `obj` a private copy of a shared material before it gets recoloured.
  *
  *  Gizmo materials are shared across every instance of a support type, and the
@@ -67,6 +54,20 @@ function privatiseMaterial(obj: THREE.Mesh | THREE.Line): void {
   if (mat?.userData?.shared) obj.material = privatise(mat);
 }
 
+/** Set emissive+color on a single Mesh's material (MeshStandard or LineMaterial) */
+export function setMeshColor(mesh: THREE.Mesh, color: number): void {
+  privatiseMaterial(mesh);
+  const mat = mesh.material;
+  if (mat instanceof THREE.MeshStandardMaterial) {
+    mat.color.setHex(color);
+    mat.needsUpdate = true;
+  } else if (mat instanceof LineMaterial) {
+    mat.color.setHex(color);
+    mat.needsUpdate = true;
+  }
+}
+
+/** Set color on all Mesh children of a Group */
 export function setGroupColor(group: THREE.Group, color: number): void {
   group.traverse((child) => {
     // Skip invisible picking helpers
@@ -77,8 +78,7 @@ export function setGroupColor(group: THREE.Group, color: number): void {
     // release stays visible while the element is selected.
     if (child.userData?.jointGlyph) return;
     if (child instanceof THREE.Mesh) {
-      privatiseMaterial(child);
-      setMeshColor(child, color);
+      setMeshColor(child, color); // privatises internally
     }
     if (child instanceof THREE.Line) {
       privatiseMaterial(child);

--- a/web/src/lib/viewport3d/__tests__/lod.test.ts
+++ b/web/src/lib/viewport3d/__tests__/lod.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyLowDetail, isHeavyModel, HEAVY_MODEL_VISUALS, HEAVY_MODEL_VISUALS_SECTIONS, type LowDetailGroups } from '../lod';
+import { applyLowDetail, isHeavyModel, HEAVY_MODEL_VISUALS, HEAVY_MODEL_VISUALS_SECTIONS, SUPPORT_VISUAL_COST, type LowDetailGroups } from '../lod';
 
 function mkGroups(renderMode: 'wireframe' | 'solid' | 'sections' = 'wireframe'): LowDetailGroups {
   return {
@@ -80,6 +80,40 @@ describe('applyLowDetail — heavy-model fallback', () => {
 });
 
 describe('isHeavyModel — single LOD policy point', () => {
+  // Supports were missing from the budget entirely, and they dominate it: each
+  // one is a Group of ~8 Lines/Meshes, while all the frame elements together
+  // are a single batched draw call. La Bombonera — 2476 elements, 120 shells,
+  // 205 supports — put 1640 of its 1763 scene objects (93 %) into supports and
+  // still scored 2596 against a 3000 threshold, so the LOD never engaged
+  // during a zoom. In `sections` the same model *did* qualify, which made the
+  // lightest render mode the one that stuttered.
+  const BOMBONERA = { elements: 2476, shells: 120, supports: 205 };
+
+  it('counts supports toward the budget', () => {
+    expect(isHeavyModel(BOMBONERA, 'wireframe')).toBe(true);
+    // Without them the same model reads as light.
+    expect(isHeavyModel({ elements: 2476, shells: 120 }, 'wireframe')).toBe(false);
+  });
+
+  it('weights a support by the objects it actually creates', () => {
+    // 8 objects per gizmo: one over the threshold on its own.
+    const justOver = Math.ceil((HEAVY_MODEL_VISUALS + 1) / SUPPORT_VISUAL_COST);
+    expect(isHeavyModel({ elements: 0, supports: justOver }, 'wireframe')).toBe(true);
+    expect(isHeavyModel({ elements: 0, supports: justOver - 1 }, 'wireframe')).toBe(false);
+  });
+
+  it('leaves models without supports exactly where they were', () => {
+    expect(isHeavyModel({ elements: HEAVY_MODEL_VISUALS + 1 }, 'wireframe')).toBe(true);
+    expect(isHeavyModel({ elements: HEAVY_MODEL_VISUALS }, 'wireframe')).toBe(false);
+    expect(isHeavyModel({ elements: HEAVY_MODEL_VISUALS, supports: 0 }, 'wireframe')).toBe(false);
+  });
+
+  it('a support-only model is heavy while a support-free one is not', () => {
+    // Same element count, opposite verdicts — the dimension that was missing.
+    expect(isHeavyModel({ elements: 500, supports: 400 }, 'wireframe')).toBe(true);
+    expect(isHeavyModel({ elements: 500, supports: 0 }, 'wireframe')).toBe(false);
+  });
+
   it('counts shells toward the visual budget', () => {
     expect(isHeavyModel({ elements: 200, shells: HEAVY_MODEL_VISUALS }, 'wireframe')).toBe(true);
     expect(isHeavyModel({ elements: 200 }, 'wireframe')).toBe(false);

--- a/web/src/lib/viewport3d/lod.ts
+++ b/web/src/lib/viewport3d/lod.ts
@@ -96,13 +96,27 @@ export function applyLowDetail(
 export const HEAVY_MODEL_VISUALS = 3000;
 export const HEAVY_MODEL_VISUALS_SECTIONS = 1200;
 
+/** Objects a single support gizmo puts in the scene — a Group of roughly eight
+ *  Lines/Meshes, depending on the support type.
+ *
+ *  Supports were missing from the budget, and on a real model they dominate it:
+ *  la Bombonera has 2476 elements, 120 shells and 205 supports, and 1640 of its
+ *  1763 scene objects (93 %) are the support gizmos. All 2476 frame elements
+ *  together are one batched draw call. Counting only elements and shells scored
+ *  that model at 2596 against a 3000 threshold, so the LOD never engaged during
+ *  a zoom — while in `sections`, with its lower threshold, the same model *did*
+ *  qualify. The lightest render mode was the one that stuttered. */
+export const SUPPORT_VISUAL_COST = 8;
+
 /** Single policy point for the orbit LOD decision (kept here, next to the
  *  visibility rules it gates, so callers can't drift on the criteria). */
 export function isHeavyModel(
-  counts: { elements: number; shells?: number },
+  counts: { elements: number; shells?: number; supports?: number },
   renderMode: RenderMode3D,
 ): boolean {
-  const visuals = counts.elements + (counts.shells ?? 0);
+  const visuals = counts.elements
+    + (counts.shells ?? 0)
+    + (counts.supports ?? 0) * SUPPORT_VISUAL_COST;
   return visuals > (renderMode === 'sections' ? HEAVY_MODEL_VISUALS_SECTIONS : HEAVY_MODEL_VISUALS);
 }
 

--- a/web/src/lib/viewport3d/lod.ts
+++ b/web/src/lib/viewport3d/lod.ts
@@ -96,8 +96,14 @@ export function applyLowDetail(
 export const HEAVY_MODEL_VISUALS = 3000;
 export const HEAVY_MODEL_VISUALS_SECTIONS = 1200;
 
-/** Objects a single support gizmo puts in the scene — a Group of roughly eight
- *  Lines/Meshes, depending on the support type.
+/** Objects a single support gizmo puts in the scene.
+ *
+ *  Measured per type: spring 3, pinned 4, roller 6, custom 6, fixed 8,
+ *  rollerXY 8. This is the WORST case, chosen deliberately — for an LOD budget
+ *  the safe error is to overestimate. Overshooting engages the LOD a little
+ *  early and costs some detail during motion; undershooting is what produced
+ *  the stutter this constant exists to fix. Fixed and pinned dominate real
+ *  models, so the typical error is small.
  *
  *  Supports were missing from the budget, and on a real model they dominate it:
  *  la Bombonera has 2476 elements, 120 shells and 205 supports, and 1640 of its


### PR DESCRIPTION
Zoom on la Bombonera stays heavy because the LOD never engages. The metric that
decides it is measuring the wrong thing.

## The mismatch

`isHeavyModel` uses `elements + shells`. On la Bombonera (2476 elements, 120
shells, 205 supports) the scene during a zoom is:

| | objects |
|---|---|
| wireframe batched mesh | 1 |
| nodes instanced | 1 |
| load arrows batched | 1 |
| shells | 120 |
| **support gizmos** | **1640** |
| **total** | **1763** |

All 2476 frame elements are **one batched draw call**. The support gizmos are
1640 separate objects — **93 % of the graph** — and count for nothing. The model
scores 2596 against a 3000 threshold, so the LOD stays off and every zoom frame
pays the whole graph.

The symptom is inverted: in `sections`, whose threshold is 1200, the same model
*does* qualify and zooms smoothly. The lightest render mode is the one that
stutters.

## Fix

Supports count at `SUPPORT_VISUAL_COST = 8`, the objects a gizmo actually
creates. A model with no supports scores exactly what it did before — there is a
test for that, so nothing light becomes heavy by accident.

## What this is not

This makes the LOD engage where it should; it does **not** make the gizmos
cheaper. Instancing them (1640 objects → ~7) is the real fix and is still open —
it has to reshape picking and per-gizmo selection colour across the eight
support shapes. Worth doing: hiding detail during a zoom costs the user the
detail they are zooming in to see.

## Checked and ruled out

The render loop does no camera-dependent work per frame — the deformed-shape
animation and the despiece both guard on a meaningful change, and `results-sync`
does not run during a zoom. The cost is purely the graph.

## Not measured

Frame time during an actual zoom. This is scene-graph analysis; `?perf` in the
browser would confirm `renderMs` drops once the LOD engages.