### PR TITLE
perf: PR124 review round 2 — factorization reuse, resolve-once stores, UI hot paths

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1837,24 +1837,23 @@ pub fn analyze_section_plastic(json: &str) -> Result<String, JsValue> {
     let z = section::plastic::solve_plastic(&mesh).map_err(|e| JsValue::from_str(&e))?;
 
     // Warping needs the shear centre as its pole, so it comes from the shear
-    // solve. Refused for closed sections, where it is negligible anyway; that
-    // is reported as absent rather than as an error, because a tube having no
-    // meaningful warping constant is an answer, not a failure.
+    // solve. A shear failure is a real numerical problem and must surface —
+    // only the WARPING solve may quietly decline: a closed section has no
+    // meaningful Cw, and reporting that as absent rather than as an error is
+    // honest, because a tube having no warping constant is an answer.
     let cw = {
         use section::shear::{solve_shear, ShearInertia};
         let c = [props.yc * scale, props.zc * scale];
-        solve_shear(
+        let sh = solve_shear(
             &mesh, c,
             ShearInertia { iy: props.iy * scale.powi(4), iz: props.iz * scale.powi(4) },
             section::poisson::SolveStrategy::Sparse,
         )
+        .map_err(|e| JsValue::from_str(&format!("shear solve failed on the way to Cw: {e}")))?;
+        section::warping::solve_warping(
+            &mesh, c, sh.shear_centre, section::poisson::SolveStrategy::Sparse,
+        )
         .ok()
-        .and_then(|sh| {
-            section::warping::solve_warping(
-                &mesh, c, sh.shear_centre, section::poisson::SolveStrategy::Sparse,
-            )
-            .ok()
-        })
         // Cw is a sixth moment.
         .map(|w| w.cw / scale.powi(6))
     };

--- a/engine/src/section/poisson.rs
+++ b/engine/src/section/poisson.rs
@@ -277,10 +277,10 @@ pub fn factor_poisson<'a>(problem: &PoissonProblem<'a>) -> Result<FactoredPoisso
     let mut cols: Vec<usize> = Vec::with_capacity(mesh.triangles.len() * 9);
     let mut vals: Vec<f64> = Vec::with_capacity(mesh.triangles.len() * 9);
 
-    for &t in &mesh.triangles {
+    for (e, &t) in mesh.triangles.iter().enumerate() {
         let (b, c, area) = element_geometry(mesh, t);
         if area <= 0.0 {
-            return Err("Element has non-positive area — mesh is invalid".into());
+            return Err(format!("Element {e} has non-positive area — mesh is invalid"));
         }
         let scale = 1.0 / (4.0 * area);
         for i in 0..3 {
@@ -447,6 +447,16 @@ impl FactoredPoisson<'_> {
         let n = mesh.nodes.len();
         if !source.is_empty() && source.len() != mesh.triangles.len() {
             return Err("source must have one value per triangle (or be empty)".into());
+        }
+        if self.dirichlet_loop.iter().any(|&d| d) && dirichlet.len() < self.dirichlet_loop.len() {
+            // A missing value silently defaulting to zero would prescribe the
+            // wrong boundary without any sign of it — wrong numbers, not an
+            // error, which is the worst outcome a solver can produce.
+            return Err(format!(
+                "dirichlet must carry one value per loop ({}), got {}",
+                self.dirichlet_loop.len(),
+                dirichlet.len()
+            ));
         }
 
         // ── Right-hand side: source + baked Neumann data ──────────

--- a/engine/src/section/poisson.rs
+++ b/engine/src/section/poisson.rs
@@ -51,7 +51,6 @@ use serde::{Deserialize, Serialize};
 use super::mesh::SectionMesh;
 use crate::linalg::lu::lu_solve;
 use crate::linalg::sparse::CscMatrix;
-use crate::linalg::sparse_chol::sparse_cholesky_solve_full;
 
 /// Boundary condition applied to a mesh boundary loop.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -212,15 +211,51 @@ fn element_geometry(mesh: &SectionMesh, t: [usize; 3]) -> ([f64; 3], [f64; 3], f
     (b, c, area)
 }
 
-/// Assemble and solve.
+/// The factored reduced system, strategy-dependent.
+enum Factor {
+    Sparse(crate::linalg::sparse_chol::NumericCholesky),
+    /// Reduced matrix, row-major. The dense path is a reference for small
+    /// test systems, so the LU runs per solve on a clone rather than being
+    /// stored pre-factored.
+    Dense(Vec<f64>),
+}
+
+/// A Poisson problem assembled and factored once, solvable for many
+/// right-hand sides.
 ///
-/// Assembly is element-by-element into COO triplets; the reduced system over
-/// the free degrees of freedom is then solved by sparse Cholesky. The stiffness
-/// of a scalar Poisson problem is symmetric positive definite once at least one
-/// value is prescribed, which is exactly the condition Cholesky needs — see
-/// `PoissonProblem::zero_mean` for why the pure-Neumann gauge is a pin rather
-/// than a Lagrange multiplier.
-pub fn solve_poisson(problem: &PoissonProblem) -> Result<PoissonSolution, String> {
+/// Torsion with holes solves `k+1` systems that differ only in their Dirichlet
+/// values, and shear solves two that differ only in the source — but the
+/// constrained node set, and therefore the reduced matrix, is identical across
+/// all of them. Both callers were paying a full assembly and factorization per
+/// right-hand side; this type exists so they factor once. The dominant cost of
+/// a sparse solve is the numeric factorization, so the saving is roughly a
+/// factor of two for shear and of `k+1` for a section with `k` holes.
+pub struct FactoredPoisson<'a> {
+    mesh: &'a SectionMesh,
+    /// Full-system triplets, kept so a solve can rebuild the right-hand side
+    /// for new Dirichlet data and measure the residual against the original
+    /// (unreduced) system.
+    rows: Vec<usize>,
+    cols: Vec<usize>,
+    vals: Vec<f64>,
+    /// Load-vector contribution of the Neumann data, baked at factor time.
+    neumann_f: Vec<f64>,
+    /// Which loops are Dirichlet. The constrained node SET is fixed for the
+    /// life of this factor; only the prescribed values may vary per solve.
+    dirichlet_loop: Vec<bool>,
+    pins: Vec<(usize, f64)>,
+    /// True when the factored problem was pure Neumann and node 0 was pinned
+    /// as the gauge (see `solve_poisson`'s discussion of pin-then-normalise).
+    gauge_pin: bool,
+    zero_mean: bool,
+    free_index: Vec<usize>,
+    free_nodes: Vec<usize>,
+    factor: Factor,
+}
+
+/// Assemble and factor a Poisson problem, keeping everything needed to solve
+/// it again for different data. See [`FactoredPoisson`].
+pub fn factor_poisson<'a>(problem: &PoissonProblem<'a>) -> Result<FactoredPoisson<'a>, String> {
     let mesh = problem.mesh;
     let n = mesh.nodes.len();
     if n == 0 {
@@ -237,16 +272,15 @@ pub fn solve_poisson(problem: &PoissonProblem) -> Result<PoissonSolution, String
         ));
     }
 
-    // ── Assemble stiffness triplets and the consistent source vector ──
+    // ── Assemble stiffness triplets ───────────────────────────────
     let mut rows: Vec<usize> = Vec::with_capacity(mesh.triangles.len() * 9);
     let mut cols: Vec<usize> = Vec::with_capacity(mesh.triangles.len() * 9);
     let mut vals: Vec<f64> = Vec::with_capacity(mesh.triangles.len() * 9);
-    let mut f = vec![0.0f64; n];
 
-    for (e, &t) in mesh.triangles.iter().enumerate() {
+    for &t in &mesh.triangles {
         let (b, c, area) = element_geometry(mesh, t);
         if area <= 0.0 {
-            return Err(format!("Element {e} has non-positive area — mesh is invalid"));
+            return Err("Element has non-positive area — mesh is invalid".into());
         }
         let scale = 1.0 / (4.0 * area);
         for i in 0..3 {
@@ -256,16 +290,13 @@ pub fn solve_poisson(problem: &PoissonProblem) -> Result<PoissonSolution, String
                 vals.push(scale * (b[i] * b[j] + c[i] * c[j]));
             }
         }
-        let fe = problem.source.get(e).copied().unwrap_or(0.0);
-        if fe != 0.0 {
-            for i in 0..3 {
-                f[t[i]] += fe * area / 3.0;
-            }
-        }
     }
 
     // ── Neumann contributions along boundary edges ────────────────
-    let mut flux_integral = 0.0;
+    // Baked into a load vector once; the pure-Neumann compatibility check in
+    // `solve` recovers the flux integral as this vector's sum (each edge adds
+    // g*len/2 to each of its two nodes).
+    let mut neumann_f = vec![0.0f64; n];
     for (idx, edge) in mesh.boundary_edges.iter().enumerate() {
         let bc = &problem.loop_bcs[edge.loop_id.min(problem.loop_bcs.len() - 1)];
         let g = match bc {
@@ -273,74 +304,64 @@ pub fn solve_poisson(problem: &PoissonProblem) -> Result<PoissonSolution, String
             LoopBc::NeumannPerEdge => *problem.edge_flux.get(idx).unwrap_or(&0.0),
             LoopBc::Dirichlet { .. } => continue,
         };
-        let pa = mesh.nodes[edge.a];
-        let pb = mesh.nodes[edge.b];
-        let len = ((pb[0] - pa[0]).powi(2) + (pb[1] - pa[1]).powi(2)).sqrt();
-        flux_integral += g * len;
         if g == 0.0 {
             continue;
         }
-        f[edge.a] += g * len / 2.0;
-        f[edge.b] += g * len / 2.0;
+        let pa = mesh.nodes[edge.a];
+        let pb = mesh.nodes[edge.b];
+        let len = ((pb[0] - pa[0]).powi(2) + (pb[1] - pa[1]).powi(2)).sqrt();
+        neumann_f[edge.a] += g * len / 2.0;
+        neumann_f[edge.b] += g * len / 2.0;
     }
 
-    // ── Prescribed values ─────────────────────────────────────────
-    let mut fixed: Vec<Option<f64>> = vec![None; n];
-    for (loop_id, bc) in problem.loop_bcs.iter().enumerate() {
-        if let LoopBc::Dirichlet { value } = bc {
-            for edge in mesh.boundary_edges.iter().filter(|e| e.loop_id == loop_id) {
-                fixed[edge.a] = Some(*value);
-                fixed[edge.b] = Some(*value);
-            }
-        }
-    }
-    for &(node, value) in &problem.pins {
+    // ── The constrained node set ──────────────────────────────────
+    let dirichlet_loop: Vec<bool> = problem
+        .loop_bcs
+        .iter()
+        .map(|bc| matches!(bc, LoopBc::Dirichlet { .. }))
+        .collect();
+    let mut any_dirichlet = dirichlet_loop.iter().any(|&d| d);
+    for &(node, _) in &problem.pins {
         if node >= n {
             return Err(format!("pin references node {node} outside the mesh"));
         }
-        fixed[node] = Some(value);
+        any_dirichlet = true;
     }
 
-    let any_dirichlet = fixed.iter().any(|x| x.is_some());
-    let pure_neumann = !any_dirichlet;
-
-    if pure_neumann {
-        if !problem.zero_mean {
-            return Err(
-                "Pure-Neumann problem with no constraint: the solution is only defined up to a \
-                 constant. Set `zero_mean` or supply a pin."
-                    .into(),
-            );
-        }
-        // Compatibility: a pure-Neumann problem is solvable only if the data
-        // balances. Integrating -lap(u) = f over the domain and applying the
-        // divergence theorem gives  integral(f) + boundary_integral(g) = 0.
-        // Violating it means no solution exists, and a solver that returns one
-        // anyway is reporting a fiction.
-        let source_integral: f64 = mesh
-            .triangles
-            .iter()
-            .enumerate()
-            .map(|(e, &t)| problem.source.get(e).copied().unwrap_or(0.0) * mesh.triangle_area(t))
-            .sum();
-        let scale = mesh.area().max(1e-300);
-        let imbalance = (source_integral + flux_integral).abs() / scale;
-        if imbalance > 1e-6 {
-            return Err(format!(
-                "Pure-Neumann data is incompatible: integral(f) + boundary integral(g) = {:.3e} \
-                 per unit area, which must vanish for a solution to exist",
-                imbalance
-            ));
-        }
-        // Gauge by pinning the first node; the mean shift is applied afterwards.
-        fixed[0] = Some(0.0);
+    // A pure-Neumann problem is gauged by pinning node 0 and normalising the
+    // mean afterwards — see solve_poisson for why this is a pin and not a
+    // Lagrange multiplier (Cholesky needs SPD). The compatibility check itself
+    // is per-source, so it runs in `solve`, not here.
+    let gauge_pin = !any_dirichlet;
+    if gauge_pin && !problem.zero_mean {
+        return Err(
+            "Pure-Neumann problem with no constraint: the solution is only defined up to a \
+             constant. Set `zero_mean` or supply a pin."
+                .into(),
+        );
     }
 
     // ── Reduced system over the free DOFs ─────────────────────────
+    let mut is_fixed = vec![false; n];
+    for (loop_id, &is_d) in dirichlet_loop.iter().enumerate() {
+        if is_d {
+            for edge in mesh.boundary_edges.iter().filter(|e| e.loop_id == loop_id) {
+                is_fixed[edge.a] = true;
+                is_fixed[edge.b] = true;
+            }
+        }
+    }
+    for &(node, _) in &problem.pins {
+        is_fixed[node] = true;
+    }
+    if gauge_pin {
+        is_fixed[0] = true;
+    }
+
     let mut free_index = vec![usize::MAX; n];
     let mut free_nodes: Vec<usize> = Vec::with_capacity(n);
     for i in 0..n {
-        if fixed[i].is_none() {
+        if !is_fixed[i] {
             free_index[i] = free_nodes.len();
             free_nodes.push(i);
         }
@@ -350,35 +371,29 @@ pub fn solve_poisson(problem: &PoissonProblem) -> Result<PoissonSolution, String
         return Err("Every node is prescribed — nothing to solve".into());
     }
 
-    let mut rhs: Vec<f64> = free_nodes.iter().map(|&i| f[i]).collect();
     let mut r_rows: Vec<usize> = Vec::with_capacity(vals.len());
     let mut r_cols: Vec<usize> = Vec::with_capacity(vals.len());
     let mut r_vals: Vec<f64> = Vec::with_capacity(vals.len());
-
     for k in 0..vals.len() {
-        let (i, j, v) = (rows[k], cols[k], vals[k]);
-        match (fixed[i], fixed[j]) {
-            // free-free: keep
-            (None, None) => {
-                r_rows.push(free_index[i]);
-                r_cols.push(free_index[j]);
-                r_vals.push(v);
-            }
-            // free-fixed: move the known contribution to the right-hand side
-            (None, Some(uj)) => rhs[free_index[i]] -= v * uj,
-            // rows of prescribed equations are dropped entirely
-            (Some(_), _) => {}
+        if !is_fixed[rows[k]] && !is_fixed[cols[k]] {
+            r_rows.push(free_index[rows[k]]);
+            r_cols.push(free_index[cols[k]]);
+            r_vals.push(vals[k]);
         }
     }
 
-    let u_free = match problem.strategy {
+    let factor = match problem.strategy {
         SolveStrategy::Sparse => {
             // CscMatrix stores the LOWER TRIANGLE ONLY for symmetric systems
             // (see linalg::sparse). The reduced stiffness is symmetric, so the
             // upper entries are dropped rather than duplicated — passing the
             // full matrix double-counts every off-diagonal and the
             // factorisation fails as not positive definite.
-            let (mut lr, mut lc, mut lv) = (Vec::with_capacity(r_vals.len()), Vec::with_capacity(r_vals.len()), Vec::with_capacity(r_vals.len()));
+            let (mut lr, mut lc, mut lv) = (
+                Vec::with_capacity(r_vals.len()),
+                Vec::with_capacity(r_vals.len()),
+                Vec::with_capacity(r_vals.len()),
+            );
             for k in 0..r_vals.len() {
                 if r_rows[k] >= r_cols[k] {
                     lr.push(r_rows[k]);
@@ -387,70 +402,199 @@ pub fn solve_poisson(problem: &PoissonProblem) -> Result<PoissonSolution, String
                 }
             }
             let a = CscMatrix::from_triplets(nf, &lr, &lc, &lv);
-            sparse_cholesky_solve_full(&a, &rhs).ok_or(
-                "Sparse Cholesky failed: the reduced system is not positive definite. \
-                 Check that the mesh is connected and that boundary data is well posed.",
-            )?
+            let sym = std::rc::Rc::new(crate::linalg::sparse_chol::symbolic_cholesky(&a));
+            Factor::Sparse(
+                crate::linalg::sparse_chol::numeric_cholesky(&sym, &a).ok_or(
+                    "Sparse Cholesky failed: the reduced system is not positive definite. \
+                     Check that the mesh is connected and that boundary data is well posed.",
+                )?,
+            )
         }
         SolveStrategy::Dense => {
             let mut dense = vec![0.0f64; nf * nf];
             for k in 0..r_vals.len() {
                 dense[r_rows[k] * nf + r_cols[k]] += r_vals[k];
             }
-            let mut b = rhs.clone();
-            lu_solve(&mut dense, &mut b, nf).ok_or("Dense reference system is singular")?
+            Factor::Dense(dense)
         }
     };
 
-    let mut u = vec![0.0f64; n];
-    for i in 0..n {
-        u[i] = match fixed[i] {
-            Some(v) => v,
-            None => u_free[free_index[i]],
-        };
-    }
+    Ok(FactoredPoisson {
+        mesh,
+        rows,
+        cols,
+        vals,
+        neumann_f,
+        dirichlet_loop,
+        pins: problem.pins.clone(),
+        gauge_pin,
+        zero_mean: problem.zero_mean,
+        free_index,
+        free_nodes,
+        factor,
+    })
+}
 
-    // ── Residual over the free equations, from the original system ──
-    let mut ku = vec![0.0f64; n];
-    for k in 0..vals.len() {
-        ku[rows[k]] += vals[k] * u[cols[k]];
-    }
-    let mut residual: f64 = 0.0;
-    for &i in &free_nodes {
-        residual = residual.max((ku[i] - f[i]).abs());
-    }
+impl FactoredPoisson<'_> {
+    /// Solve for one right-hand side: `source` per triangle (same contract as
+    /// [`PoissonProblem::source`], empty means zero) and `dirichlet` carrying
+    /// the value prescribed on each Dirichlet loop, indexed by loop id.
+    ///
+    /// The constrained node SET was fixed at factor time — only the values
+    /// may vary here.
+    pub fn solve(&self, source: &[f64], dirichlet: &[f64]) -> Result<PoissonSolution, String> {
+        let mesh = self.mesh;
+        let n = mesh.nodes.len();
+        if !source.is_empty() && source.len() != mesh.triangles.len() {
+            return Err("source must have one value per triangle (or be empty)".into());
+        }
 
-    let mut solution = PoissonSolution {
-        u,
-        grad: Vec::new(),
-        residual,
-    };
-
-    // ── Apply the zero-mean gauge ────────────────────────────────
-    if problem.zero_mean {
-        let total = mesh.area();
-        if total > 1e-300 {
-            let shift = solution.integrate(mesh) / total;
-            for v in solution.u.iter_mut() {
-                *v -= shift;
+        // ── Right-hand side: source + baked Neumann data ──────────
+        let mut f = self.neumann_f.clone();
+        for (e, &t) in mesh.triangles.iter().enumerate() {
+            let fe = source.get(e).copied().unwrap_or(0.0);
+            if fe != 0.0 {
+                let area = mesh.triangle_area(t);
+                for i in 0..3 {
+                    f[t[i]] += fe * area / 3.0;
+                }
             }
         }
-    }
 
-    solution.grad = mesh
-        .triangles
+        // ── Prescribed values on the factored pattern ─────────────
+        let mut fixed: Vec<Option<f64>> = vec![None; n];
+        for (loop_id, &is_d) in self.dirichlet_loop.iter().enumerate() {
+            if is_d {
+                let value = dirichlet.get(loop_id).copied().unwrap_or(0.0);
+                for edge in mesh.boundary_edges.iter().filter(|e| e.loop_id == loop_id) {
+                    fixed[edge.a] = Some(value);
+                    fixed[edge.b] = Some(value);
+                }
+            }
+        }
+        for &(node, value) in &self.pins {
+            fixed[node] = Some(value);
+        }
+        if self.gauge_pin {
+            // Compatibility: a pure-Neumann problem is solvable only if the
+            // data balances. Integrating -lap(u) = f over the domain and
+            // applying the divergence theorem gives
+            // integral(f) + boundary_integral(g) = 0; the boundary integral
+            // was baked into `neumann_f`, whose sum IS that integral (each
+            // edge contributed g*len/2 to each of its two nodes).
+            let source_integral: f64 = mesh
+                .triangles
+                .iter()
+                .enumerate()
+                .map(|(e, &t)| source.get(e).copied().unwrap_or(0.0) * mesh.triangle_area(t))
+                .sum();
+            let flux_integral: f64 = self.neumann_f.iter().sum();
+            let scale = mesh.area().max(1e-300);
+            let imbalance = (source_integral + flux_integral).abs() / scale;
+            if imbalance > 1e-6 {
+                return Err(format!(
+                    "Pure-Neumann data is incompatible: integral(f) + boundary integral(g) = {:.3e} \
+                     per unit area, which must vanish for a solution to exist",
+                    imbalance
+                ));
+            }
+            fixed[0] = Some(0.0);
+        }
+
+        let mut rhs: Vec<f64> = self.free_nodes.iter().map(|&i| f[i]).collect();
+        for k in 0..self.vals.len() {
+            // Only free-fixed pairs contribute; free-free is in the factor and
+            // rows of prescribed equations are dropped — same reduction as at
+            // factor time.
+            if self.free_index[self.rows[k]] != usize::MAX {
+                if let Some(uj) = fixed[self.cols[k]] {
+                    rhs[self.free_index[self.rows[k]]] -= self.vals[k] * uj;
+                }
+            }
+        }
+
+        let u_free = match &self.factor {
+            Factor::Sparse(fact) => crate::linalg::sparse_chol::sparse_cholesky_solve(fact, &rhs),
+            Factor::Dense(dense) => {
+                let nf = self.free_nodes.len();
+                let mut m = dense.clone();
+                lu_solve(&mut m, &mut rhs, nf).ok_or("Dense reference system is singular")?
+            }
+        };
+
+        let mut u = vec![0.0f64; n];
+        for i in 0..n {
+            u[i] = match fixed[i] {
+                Some(v) => v,
+                None => u_free[self.free_index[i]],
+            };
+        }
+
+        // ── Residual over the free equations, from the original system ──
+        let mut ku = vec![0.0f64; n];
+        for k in 0..self.vals.len() {
+            ku[self.rows[k]] += self.vals[k] * u[self.cols[k]];
+        }
+        let mut residual: f64 = 0.0;
+        for &i in &self.free_nodes {
+            residual = residual.max((ku[i] - f[i]).abs());
+        }
+
+        let mut solution = PoissonSolution {
+            u,
+            grad: Vec::new(),
+            residual,
+        };
+
+        // ── Apply the zero-mean gauge ────────────────────────────
+        if self.zero_mean {
+            let total = mesh.area();
+            if total > 1e-300 {
+                let shift = solution.integrate(mesh) / total;
+                for v in solution.u.iter_mut() {
+                    *v -= shift;
+                }
+            }
+        }
+
+        solution.grad = mesh
+            .triangles
+            .iter()
+            .map(|&t| {
+                let (b, c, area) = element_geometry(mesh, t);
+                let s = 1.0 / (2.0 * area);
+                [
+                    s * (b[0] * solution.u[t[0]] + b[1] * solution.u[t[1]] + b[2] * solution.u[t[2]]),
+                    s * (c[0] * solution.u[t[0]] + c[1] * solution.u[t[1]] + c[2] * solution.u[t[2]]),
+                ]
+            })
+            .collect();
+
+        Ok(solution)
+    }
+}
+
+/// Assemble and solve. Equivalent to [`factor_poisson`] followed by one
+/// [`FactoredPoisson::solve`] with the problem's own data; callers with more
+/// than one right-hand side on the same constrained set should factor once
+/// instead.
+///
+/// Assembly is element-by-element into COO triplets; the reduced system over
+/// the free degrees of freedom is then solved by sparse Cholesky. The stiffness
+/// of a scalar Poisson problem is symmetric positive definite once at least one
+/// value is prescribed, which is exactly the condition Cholesky needs — see
+/// `PoissonProblem::zero_mean` for why the pure-Neumann gauge is a pin rather
+/// than a Lagrange multiplier.
+pub fn solve_poisson(problem: &PoissonProblem) -> Result<PoissonSolution, String> {
+    let dirichlet: Vec<f64> = problem
+        .loop_bcs
         .iter()
-        .map(|&t| {
-            let (b, c, area) = element_geometry(mesh, t);
-            let s = 1.0 / (2.0 * area);
-            [
-                s * (b[0] * solution.u[t[0]] + b[1] * solution.u[t[1]] + b[2] * solution.u[t[2]]),
-                s * (c[0] * solution.u[t[0]] + c[1] * solution.u[t[1]] + c[2] * solution.u[t[2]]),
-            ]
+        .map(|bc| match bc {
+            LoopBc::Dirichlet { value } => *value,
+            _ => 0.0,
         })
         .collect();
-
-    Ok(solution)
+    factor_poisson(problem)?.solve(&problem.source, &dirichlet)
 }
 
 #[cfg(test)]

--- a/engine/src/section/shear.rs
+++ b/engine/src/section/shear.rs
@@ -89,23 +89,22 @@ pub struct ShearInertia {
 }
 
 fn solve_one(
+    factored: &super::poisson::FactoredPoisson,
     mesh: &SectionMesh,
     centroid: [f64; 2],
     inertia: f64,
     // Which centroidal coordinate drives the bending-stress gradient: 1 for the
     // vertical `z` (a vertical force), 0 for the horizontal `y`.
     coord: usize,
-    strategy: SolveStrategy,
 ) -> Result<(ShearField, f64), String> {
     if !(inertia > 0.0) || !inertia.is_finite() {
         return Err(format!("shear needs a positive second moment, got {inertia}"));
     }
-    let mut problem = PoissonProblem::new(mesh);
     // The solver reads `-laplacian(phi) = f`, and the physics is
     // `laplacian(phi) = -c/I` with `c` the centroidal coordinate, so `f = c/I`.
     // Evaluated at each triangle's centroid, which is exact for the linear
     // source a P1 element sees.
-    problem.source = mesh
+    let source: Vec<f64> = mesh
         .triangles
         .iter()
         .map(|&t| {
@@ -115,11 +114,9 @@ fn solve_one(
             c / inertia
         })
         .collect();
-    problem.loop_bcs = vec![LoopBc::Neumann { value: 0.0 }; mesh.loop_count];
-    problem.zero_mean = true;
-    problem.strategy = strategy;
 
-    let sol = super::poisson::solve_poisson(&problem)?;
+    // No Dirichlet loops — the second element is never read.
+    let sol = factored.solve(&source, &[])?;
 
     let mut tau_max = 0.0;
     let mut tau_max_triangle = 0;
@@ -179,9 +176,19 @@ pub fn solve_shear(
     if mesh.triangles.is_empty() {
         return Err("mesh has no triangles".into());
     }
+    // Both axes solve the SAME pure-Neumann problem — identical mesh, boundary
+    // conditions and gauge pin, so identical reduced matrix — with only the
+    // source term differing. Factor once and solve twice: the factorization is
+    // the dominant cost, so this halves it.
+    let mut problem = PoissonProblem::new(mesh);
+    problem.loop_bcs = vec![LoopBc::Neumann { value: 0.0 }; mesh.loop_count];
+    problem.zero_mean = true;
+    problem.strategy = strategy;
+    let factored = super::poisson::factor_poisson(&problem)?;
+
     // A force along z bends about y, so it is driven by z and divided by Iy.
-    let (vz, r1) = solve_one(mesh, centroid, inertia.iy, 1, strategy)?;
-    let (vy, r2) = solve_one(mesh, centroid, inertia.iz, 0, strategy)?;
+    let (vz, r1) = solve_one(&factored, mesh, centroid, inertia.iy, 1)?;
+    let (vy, r2) = solve_one(&factored, mesh, centroid, inertia.iz, 0)?;
 
     // A unit force along z applied at the centroid twists the section by
     // `torque_about_centroid`; shifting its line of action along y by that

--- a/engine/src/section/shear.rs
+++ b/engine/src/section/shear.rs
@@ -176,6 +176,13 @@ pub fn solve_shear(
     if mesh.triangles.is_empty() {
         return Err("mesh has no triangles".into());
     }
+    // Validate before paying the factorization, so a bad input is refused
+    // with the error that names it and not with an unrelated solver failure.
+    for inertia in [inertia.iy, inertia.iz] {
+        if !(inertia > 0.0) || !inertia.is_finite() {
+            return Err(format!("shear needs a positive second moment, got {inertia}"));
+        }
+    }
     // Both axes solve the SAME pure-Neumann problem — identical mesh, boundary
     // conditions and gauge pin, so identical reduced matrix — with only the
     // source term differing. Factor once and solve twice: the factorization is

--- a/engine/src/section/torsion.rs
+++ b/engine/src/section/torsion.rs
@@ -91,14 +91,22 @@ pub fn solve_torsion(mesh: &SectionMesh, strategy: SolveStrategy) -> Result<Tors
     }
     let holes = mesh.loop_count.saturating_sub(1);
 
-    // phi_0: the simply-connected field, zero on every boundary.
-    let base = {
+    // Every solve below — the base field and the k unit responses — constrains
+    // the SAME node set (every boundary loop is Dirichlet in all of them); only
+    // the prescribed values and the source differ. The reduced matrix is
+    // therefore bit-identical across all k+1 solves, so factor it once.
+    let factored = {
         let mut p = PoissonProblem::new(mesh);
-        p.source = vec![2.0; mesh.triangles.len()];
         p.loop_bcs = vec![LoopBc::Dirichlet { value: 0.0 }; mesh.loop_count];
         p.strategy = strategy;
-        super::poisson::solve_poisson(&p)?
+        super::poisson::factor_poisson(&p)?
     };
+
+    // phi_0: the simply-connected field, zero on every boundary.
+    let base = factored.solve(
+        &vec![2.0; mesh.triangles.len()],
+        &vec![0.0; mesh.loop_count],
+    )?;
 
     let sol: PoissonSolution = if holes == 0 {
         base
@@ -106,13 +114,10 @@ pub fn solve_torsion(mesh: &SectionMesh, strategy: SolveStrategy) -> Result<Tors
         // One unit response per hole.
         let mut unit = Vec::with_capacity(holes);
         for i in 0..holes {
-            let mut p = PoissonProblem::new(mesh);
-            p.source = vec![0.0; mesh.triangles.len()];
-            p.loop_bcs = (0..mesh.loop_count)
-                .map(|l| LoopBc::Dirichlet { value: if l == i + 1 { 1.0 } else { 0.0 } })
+            let dirichlet: Vec<f64> = (0..mesh.loop_count)
+                .map(|l| if l == i + 1 { 1.0 } else { 0.0 })
                 .collect();
-            p.strategy = strategy;
-            unit.push(super::poisson::solve_poisson(&p)?);
+            unit.push(factored.solve(&[], &dirichlet)?);
         }
 
         // Bredt: integral over the hole of laplacian(phi) equals the boundary

--- a/web/src/components/Viewport.svelte
+++ b/web/src/components/Viewport.svelte
@@ -356,30 +356,35 @@
         if (absN > globalMaxN) globalMaxN = absN;
       }
       if (globalMaxN > 1e-10) {
+        const axTheme = canvasTheme();
+        /*
+         * Tension and compression are the palette's, not screen primaries.
+         *
+         * These ramped toward `rgb(255,0,0)` and `rgb(0,0,255)` — colours
+         * that appear nowhere else in the application and read as a
+         * different program's output beside the vermillion and steel blue
+         * the landing's truss figure, the 3D axial map and the diagrams all
+         * use. Magnitude still drives intensity; it now fades the palette
+         * hue toward the neutral member instead of toward black.
+         *
+         * Hoisted out of the loop: the closure and the hex parsing are
+         * per-redraw work, not per-element.
+         */
+        const parse = (hex: string) => [0, 1, 2].map((i) => parseInt(hex.slice(1 + i * 2, 3 + i * 2), 16));
+        const tensionRgb = parse(axTheme.tension);
+        const compressionRgb = parse(axTheme.compression);
+        const mix = (rgb: number[], k: number) => {
+          const n = 0.35 + 0.65 * k;
+          const g = (i: number, base: number) => Math.round(rgb[i] * n + base * (1 - n));
+          return `rgb(${g(0, 143)},${g(1, 163)},${g(2, 179)})`;
+        };
         for (const ef of resultsStore.results.elementForces) {
           const avgN = (ef.nStart + ef.nEnd) / 2;
           const intensity = Math.min(Math.abs(avgN) / globalMaxN, 1.0);
-          /*
-           * Tension and compression are the palette's, not screen primaries.
-           *
-           * These ramped toward `rgb(255,0,0)` and `rgb(0,0,255)` — colours
-           * that appear nowhere else in the application and read as a
-           * different program's output beside the vermillion and steel blue
-           * the landing's truss figure, the 3D axial map and the diagrams all
-           * use. Magnitude still drives intensity; it now fades the palette
-           * hue toward the neutral member instead of toward black.
-           */
-          const mix = (hex: string, k: number) => {
-            const n = 0.35 + 0.65 * k;
-            const c = (i: number) => parseInt(hex.slice(1 + i * 2, 3 + i * 2), 16);
-            const g = (i: number, base: number) => Math.round(c(i) * n + base * (1 - n));
-            return `rgb(${g(0, 143)},${g(1, 163)},${g(2, 179)})`;
-          };
-          const axTheme = canvasTheme();
           if (avgN > 0.001) {
-            colorMapOverrides.set(ef.elementId, mix(axTheme.tension, intensity));
+            colorMapOverrides.set(ef.elementId, mix(tensionRgb, intensity));
           } else if (avgN < -0.001) {
-            colorMapOverrides.set(ef.elementId, mix(axTheme.compression, intensity));
+            colorMapOverrides.set(ef.elementId, mix(compressionRgb, intensity));
           } else {
             colorMapOverrides.set(ef.elementId, axTheme.neutralMember);
           }

--- a/web/src/components/edu/EducativePanel.svelte
+++ b/web/src/components/edu/EducativePanel.svelte
@@ -53,6 +53,10 @@
 
   /** Adapt an authored spec to the shape the exercise view consumes. */
   function specToExercise(spec: EduExerciseSpec): EduExercise {
+    // The stress resolver is built once per exercise, not per question and per
+    // click: it meshes and solves the section, which is far too costly to
+    // repeat for every verify.
+    const ctx = stressContext(spec.model.profile, spec.model.fy);
     return {
       id: spec.id,
       title: spec.title,
@@ -62,15 +66,13 @@
       solverType: spec.solverType,
       build: (api) => buildFromSpec(spec.model, api),
       supports: spec.supports,
-      // The stress resolver is built once per exercise, not per question: it
-      // meshes and solves the section, which is far too costly to repeat.
       characteristics: spec.characteristics.map((c) => ({
         label: c.label, unit: c.unit,
-        getCorrect: (f) => evaluateAnswer(c.answer, f, stressContext(spec.model.profile, spec.model.fy)) ?? 0,
+        getCorrect: (f) => evaluateAnswer(c.answer, f, ctx) ?? 0,
       })),
       diagramQuestions: spec.diagramQuestions.map((q) => ({
         question: q.question, unit: q.unit,
-        getCorrect: (f) => evaluateAnswer(q.answer, f, stressContext(spec.model.profile, spec.model.fy)) ?? 0,
+        getCorrect: (f) => evaluateAnswer(q.answer, f, ctx) ?? 0,
       })),
       kinematicQuestion: spec.kinematicQuestion,
       diagramShapeQuestions: spec.diagramShapeQuestions,

--- a/web/src/components/edu/EducativePanel.svelte
+++ b/web/src/components/edu/EducativePanel.svelte
@@ -6,7 +6,7 @@
   import { solveForEdu } from './edu-solver';
   import { eduStore } from './edu-store.svelte';
   import ExerciseAuthor from './ExerciseAuthor.svelte';
-  import { buildFromSpec, evaluateAnswer, type EduExerciseSpec } from './exercise-spec';
+  import { buildFromSpec, evaluateAnswer, type AnswerContext, type EduExerciseSpec } from './exercise-spec';
   import { stressContext } from './exercise-stress';
   import { loadLibrary, removeFromLibrary, saveToLibrary, fromShareLink } from './exercise-library';
 
@@ -53,10 +53,22 @@
 
   /** Adapt an authored spec to the shape the exercise view consumes. */
   function specToExercise(spec: EduExerciseSpec): EduExercise {
-    // The stress resolver is built once per exercise, not per question and per
-    // click: it meshes and solves the section, which is far too costly to
-    // repeat for every verify.
-    const ctx = stressContext(spec.model.profile, spec.model.fy);
+    // The stress resolver is built at most once per exercise — it meshes and
+    // solves the section, which is far too costly to repeat per question or
+    // per click. But it must stay LAZY: it only works once the WASM engine is
+    // ready (the first verify happens after the solve pipeline has awaited
+    // it), while specToExercise runs at panel mount, possibly before. An eager
+    // call — or caching the empty context an early call returns — would mark
+    // students against a fabricated 0 for the panel's whole lifetime.
+    let ctx: AnswerContext | undefined;
+    const stressCtx = (): AnswerContext => {
+      if (ctx) return ctx;
+      const built = stressContext(spec.model.profile, spec.model.fy);
+      // Empty means "no profile / no geometry" (stable) or "engine not ready"
+      // (must be retried). Only the stable cases get cached.
+      if (built.stress || !spec.model.profile) ctx = built;
+      return built;
+    };
     return {
       id: spec.id,
       title: spec.title,
@@ -68,11 +80,11 @@
       supports: spec.supports,
       characteristics: spec.characteristics.map((c) => ({
         label: c.label, unit: c.unit,
-        getCorrect: (f) => evaluateAnswer(c.answer, f, ctx) ?? 0,
+        getCorrect: (f) => evaluateAnswer(c.answer, f, stressCtx()) ?? 0,
       })),
       diagramQuestions: spec.diagramQuestions.map((q) => ({
         question: q.question, unit: q.unit,
-        getCorrect: (f) => evaluateAnswer(q.answer, f, ctx) ?? 0,
+        getCorrect: (f) => evaluateAnswer(q.answer, f, stressCtx()) ?? 0,
       })),
       kinematicQuestion: spec.kinematicQuestion,
       diagramShapeQuestions: spec.diagramShapeQuestions,

--- a/web/src/components/ribbon/BasicPanel.svelte
+++ b/web/src/components/ribbon/BasicPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { t } from '../../lib/i18n';
   import ToolbarResults from '../toolbar/ToolbarResults.svelte';
   import ToolbarAdvanced from '../toolbar/ToolbarAdvanced.svelte';
@@ -48,6 +49,11 @@
 
   let width = $state(stored());
   let dragging = $state(false);
+  let widthPublishFrame = 0;
+
+  function publishWidth() {
+    document.documentElement.style.setProperty('--st-right-panel-w', `${width}px`);
+  }
 
   function startResize(e: PointerEvent) {
     dragging = true;
@@ -56,6 +62,15 @@
     const move = (ev: PointerEvent) => {
       // The handle is on the panel's LEFT edge, so dragging left widens it.
       width = Math.min(MAX, Math.max(MIN, startW - (ev.clientX - startX)));
+      // Publishing the width writes a custom property on the ROOT element,
+      // which re-resolves styles document-wide — that must happen at most
+      // once per frame, not once per pointermove.
+      if (!widthPublishFrame) {
+        widthPublishFrame = requestAnimationFrame(() => {
+          widthPublishFrame = 0;
+          publishWidth();
+        });
+      }
     };
     const up = () => {
       dragging = false;
@@ -79,11 +94,17 @@
    * landed on top of the report they were announcing. A custom property is the
    * least invasive way to tell them: nothing has to be threaded through the
    * component tree, and the value follows the drag handle for free.
+   *
+   * Mount-only: during a drag the value is published by the rAF-throttled
+   * writer in `startResize`; a reactive effect here would re-resolve the whole
+   * document's styles on every pointermove.
    */
-  $effect(() => {
-    const el = document.documentElement;
-    el.style.setProperty('--st-right-panel-w', `${width}px`);
-    return () => el.style.removeProperty('--st-right-panel-w');
+  onMount(() => {
+    publishWidth();
+    return () => {
+      if (widthPublishFrame) cancelAnimationFrame(widthPublishFrame);
+      document.documentElement.style.removeProperty('--st-right-panel-w');
+    };
   });
 
   /*

--- a/web/src/components/stress/CrossSectionDrawing.svelte
+++ b/web/src/components/stress/CrossSectionDrawing.svelte
@@ -119,6 +119,14 @@
       tl: rs.tl,
     });
   }
+
+  // The outline string is hundreds of points for a filleted profile; building
+  // it inline in the template would rebuild it on every re-render — and the
+  // fibre/station sliders re-render continuously while dragged, though the
+  // geometry has not changed.
+  const outlinePath = $derived(
+    canonicalGeometry ? canonicalPath(canonicalGeometry) : resolved ? sectionPathFromResolved(resolved) : '',
+  );
 </script>
 
 <!-- Cross section -->
@@ -185,7 +193,7 @@
       <g transform="rotate({sectionRotation})">
       <!-- Section outline -->
       <path
-        d={canonicalGeometry ? canonicalPath(canonicalGeometry) : sectionPathFromResolved(resolved)}
+        d={outlinePath}
         fill="none"
         stroke="var(--st-value)"
         stroke-width="1.5"

--- a/web/src/lib/engine/solver-service.ts
+++ b/web/src/lib/engine/solver-service.ts
@@ -1419,8 +1419,9 @@ export function buildSolverInput3D(
     nodes: new Map(Array.from(model.nodes.entries()).map(([id, n]) => [id, mapModelNodeToSolver3D(n, project2DToXZ)])),
     materials: new Map(Array.from(model.materials.entries()).map(([id, m]) => [id, { id: m.id, e: m.e, nu: m.nu }])),
     sections: new Map(Array.from(model.sections.entries()).map(([id, s]) => {
+      const props = solverProperties(s);
       if (project2DToXZ) {
-        const inPlaneIy = effectiveBendingInertia(s);
+        const inPlaneIy = effectiveBendingInertia(s, props);
         // Out-of-plane bending happens about the section's WEAK axis, which is
         // `iz`. This read `s.iy ?? s.iz` — the strong axis — which overstated
         // out-of-plane stiffness and so understated lateral displacement and
@@ -1434,7 +1435,6 @@ export function buildSolverInput3D(
         // case that still reaches this line — a geometry-backed section takes
         // the canonical branch below, which was always correct.
         const outOfPlaneIz = s.iz;
-        const props = solverProperties(s);
         return [id, {
           id: s.id, name: s.name, a: props.a,
           iy: inPlaneIy,
@@ -1456,7 +1456,6 @@ export function buildSolverInput3D(
       // Solver convention: iy controls bending about Y (w, θy DOFs), iz controls bending about Z (v, θz DOFs)
       // A geometry-backed section reports the inertia its canonical polygons
       // actually have; a properties-only section keeps what it declared.
-      const props = solverProperties(s);
       const aboutY = props.source === 'canonical'
         ? props.iy
         : (s.iy ?? (s.b && s.h ? (s.b * s.h ** 3) / 12 : s.iz));  // Iy: about Y horizontal

--- a/web/src/lib/engine/solver-service.ts
+++ b/web/src/lib/engine/solver-service.ts
@@ -100,13 +100,17 @@ function getElemAngleAtNode(nodeId: number, nodes: Map<number, Node>, elements: 
  *  When the section is rotated by angle α around the bar axis,
  *  the effective inertia for 2D bending is:
  *    I_eff = Iy·cos²α + Iz·sin²α
- *  This is exported so Viewport.svelte can reuse it for deformed-shape rendering. */
-export function effectiveBendingInertia(sec: Section): number {
+ *  This is exported so Viewport.svelte can reuse it for deformed-shape rendering.
+ *  Callers that already resolved the section's properties may pass them in and
+ *  save the second lookup (`props` defaults to a fresh `solverProperties`). */
+export function effectiveBendingInertia(
+  sec: Section,
+  props: ReturnType<typeof solverProperties> = solverProperties(sec),
+): number {
   // A geometry-backed section reports the inertia its canonical polygons
   // actually have; a properties-only section keeps what it declared. This is
   // the single point both the 2D wire and the projected 3D wire read, so
   // making it canonical-aware here keeps them consistent by construction.
-  const props = solverProperties(sec);
   const Iy = props.source === 'canonical' ? props.iy : (sec.iy ?? sec.iz);  // about Y horizontal
   const Iz = props.source === 'canonical' ? props.iz : sec.iz;              // about Z vertical
   const alpha = (sec.rotation ?? 0) * Math.PI / 180;
@@ -613,7 +617,10 @@ function prepareSolve2D(
     nodes: new Map(Array.from(model.nodes.entries()).map(([id, n]) => [id, { id: n.id, x: n.x, z: n.y }])),
     materials: new Map(Array.from(model.materials.entries()).map(([id, m]) => [id, { id: m.id, e: m.e, nu: m.nu }])),
     // 2D solver uses the effective bending inertia (accounts for section rotation via Mohr)
-    sections: new Map(Array.from(model.sections.entries()).map(([id, s]) => [id, { id: s.id, a: solverProperties(s).a, iz: effectiveBendingInertia(s) }])),
+    sections: new Map(Array.from(model.sections.entries()).map(([id, s]) => {
+      const props = solverProperties(s);
+      return [id, { id: s.id, a: props.a, iz: effectiveBendingInertia(s, props) }];
+    })),
     elements: new Map(Array.from(model.elements.entries()).map(([id, e]) => [id, {
       id: e.id, type: e.type, nodeI: e.nodeI, nodeJ: e.nodeJ,
       materialId: e.materialId, sectionId: e.sectionId,
@@ -954,7 +961,10 @@ export function buildSolverInput2D(model: ModelData, includeSelfWeight = false):
     nodes: new Map(Array.from(model.nodes.entries()).map(([id, n]) => [id, { id: n.id, x: n.x, z: n.y }])),
     materials: new Map(Array.from(model.materials.entries()).map(([id, m]) => [id, { id: m.id, e: m.e, nu: m.nu }])),
     // 2D solver uses the effective bending inertia (accounts for section rotation via Mohr)
-    sections: new Map(Array.from(model.sections.entries()).map(([id, s]) => [id, { id: s.id, a: solverProperties(s).a, iz: effectiveBendingInertia(s) }])),
+    sections: new Map(Array.from(model.sections.entries()).map(([id, s]) => {
+      const props = solverProperties(s);
+      return [id, { id: s.id, a: props.a, iz: effectiveBendingInertia(s, props) }];
+    })),
     elements: new Map(Array.from(model.elements.entries()).map(([id, e]) => [id, {
       id: e.id, type: e.type, nodeI: e.nodeI, nodeJ: e.nodeJ,
       materialId: e.materialId, sectionId: e.sectionId,

--- a/web/src/lib/section/migration.ts
+++ b/web/src/lib/section/migration.ts
@@ -54,8 +54,13 @@ export interface RestoredSection {
  *
  * Idempotent: restoring an already-restored section yields the same state and
  * the same digest, which is what makes repeated save/open cycles stable.
+ *
+ * `opts.torsion` forwards to `resolveSectionState`: restoring WITH torsion
+ * when the engine is ready costs one Saint-Venant solve per section without a
+ * published constant, and saves the immediate `refreshCanonicalSections`
+ * re-resolve every section would otherwise pay right after the load.
  */
-export function restoreSectionState(sec: Section): RestoredSection {
+export function restoreSectionState(sec: Section, opts: { torsion?: boolean } = {}): RestoredSection {
   const stored = sec.canonical;
 
   // ── Engine not up yet ────────────────────────────────────────
@@ -72,7 +77,7 @@ export function restoreSectionState(sec: Section): RestoredSection {
   // ── Re-derive from the section's own dimensions ──────────────
   let recomputed: SectionState;
   try {
-    recomputed = resolveSectionState(sec);
+    recomputed = resolveSectionState(sec, { torsion: opts.torsion });
   } catch (err) {
     // Invalid geometry must not lose the legacy data that still lets the
     // model solve. Drop the canonical claim, keep everything else.
@@ -126,11 +131,12 @@ export function restoreSectionState(sec: Section): RestoredSection {
  */
 export function restoreSections(
   sections: Map<number, Section>,
+  opts: { torsion?: boolean } = {},
 ): { sections: Map<number, Section>; outcomes: Map<number, RestoreOutcome> } {
   const out = new Map<number, Section>();
   const outcomes = new Map<number, RestoreOutcome>();
   for (const [id, sec] of sections) {
-    const { section, outcome } = restoreSectionState(sec);
+    const { section, outcome } = restoreSectionState(sec, opts);
     out.set(id, section);
     outcomes.set(id, outcome);
   }

--- a/web/src/lib/section/state.ts
+++ b/web/src/lib/section/state.ts
@@ -109,6 +109,7 @@ function resolveTorsion(
   sec: Section,
   circular: { iy: number; iz: number } | null,
   geometry: CanonicalGeometry | null,
+  digest?: string,
 ): { j: number | null; jProvenance: TorsionProvenance } {
   if (circular) {
     const j = circular.iy + circular.iz;
@@ -130,16 +131,38 @@ function resolveTorsion(
     // Closed sections are handled too: the hole constants come from Bredt's
     // circulation condition, so a tube is not silently treated as if it were
     // slit — which would understate its J by more than a hundredfold.
+    //
+    // Solved once per geometry digest and cached: the solve depends only on
+    // the geometry, but re-resolutions for reasons that leave the geometry
+    // untouched (a rename, a refresh pass) used to pay the mesh-and-solve
+    // every time.
     try {
-      const { j } = analyzeSectionTorsion({ geometry });
-      if (Number.isFinite(j) && j > 0) return { j, jProvenance: 'saintVenant' };
+      let j: number | null | undefined = digest ? torsionJCache.get(digest) : undefined;
+      if (j === undefined) {
+        const r = analyzeSectionTorsion({ geometry });
+        j = Number.isFinite(r.j) && r.j > 0 ? r.j : null;
+        if (digest) {
+          if (torsionJCache.size >= TORSION_CACHE_LIMIT) {
+            // Map iterates in insertion order, so the first key is the oldest.
+            torsionJCache.delete(torsionJCache.keys().next().value!);
+          }
+          torsionJCache.set(digest, j);
+        }
+      }
+      if (j != null) return { j, jProvenance: 'saintVenant' };
     } catch {
       // Multiply-connected, degenerate mesh, or engine not ready — all mean
-      // "no trustworthy constant", which is what `unavailable` says.
+      // "no trustworthy constant", which is what `unavailable` says. Not
+      // cached: a throw can be transient (engine still warming up), and the
+      // next resolve must be free to retry.
     }
   }
   return { j: null, jProvenance: 'unavailable' };
 }
+
+/** A cached J is one number; 32 entries is nothing. */
+const TORSION_CACHE_LIMIT = 32;
+const torsionJCache = new Map<string, number | null>();
 
 /**
  * Resolve a section to solver-ready state.
@@ -206,6 +229,7 @@ export function resolveSectionState(sec: Section, opts: ResolveOptions = {}): Se
     sec,
     isCircularFamily(resolved.geometry.source) ? { iy: p.iy, iz: p.iz } : null,
     opts.torsion ? resolved.geometry : null,
+    resolved.digest,
   );
   return {
     kind: 'geometry-backed',

--- a/web/src/lib/store/canonical-sections.ts
+++ b/web/src/lib/store/canonical-sections.ts
@@ -33,6 +33,14 @@ export function resolveOnUpdate(sec: Section): Section {
  * resolved digest matches the stored one. It never invalidates results:
  * refreshing geometry is not a model edit.
  *
+ * A section already geometry-backed WITH a torsion answer is skipped without
+ * recomputing: within a session the engine build cannot change, so a fully
+ * resolved state cannot go stale, and re-resolving it would pay a WASM
+ * geometry build (and possibly a Saint-Venant solve) per section per load
+ * just to learn nothing changed. `jProvenance === 'unavailable'` is the
+ * marker of "restored before the torsion pass ran" — those are retried, as
+ * are genuine torsion failures, which is bounded and correct.
+ *
  * Returns the updated map, or null if nothing changed.
  */
 export function refreshCanonicalSections(
@@ -41,8 +49,9 @@ export function refreshCanonicalSections(
   let changed = false;
   const m = new Map(sections);
   for (const [id, sec] of m) {
-    const next = resolveSectionState(sec, { torsion: true });
     const before = sec.canonical;
+    if (before?.kind === 'geometry-backed' && before.jProvenance !== 'unavailable') continue;
+    const next = resolveSectionState(sec, { torsion: true });
     const sameKind = before?.kind === next.kind;
     const sameDigest =
       before?.kind === 'geometry-backed' && next.kind === 'geometry-backed'
@@ -60,7 +69,10 @@ export function refreshCanonicalSections(
 export function restoreCanonicalSections(
   sections: Map<number, Section>,
 ): Map<number, Section> {
-  return restoreSections(sections).sections;
+  // Torsion included: restoring is the one moment every section is resolved
+  // anyway, and doing it here means the post-load refresh finds nothing to
+  // repair instead of re-resolving every section a second time.
+  return restoreSections(sections, { torsion: true }).sections;
 }
 
 /** Resolve the default section's canonical state for a fresh model. */

--- a/web/src/lib/store/canonical-sections.ts
+++ b/web/src/lib/store/canonical-sections.ts
@@ -57,7 +57,14 @@ export function refreshCanonicalSections(
       before?.kind === 'geometry-backed' && next.kind === 'geometry-backed'
         ? before.digest === next.digest
         : sameKind;
-    if (!sameDigest) {
+    // The digest does not cover torsion: a retry that succeeds with unchanged
+    // geometry must still be published, or the section would stay
+    // `unavailable` and every future refresh would re-solve and re-discard.
+    const sameTorsion =
+      before?.kind === 'geometry-backed' && next.kind === 'geometry-backed'
+        ? before.j === next.j && before.jProvenance === next.jProvenance
+        : true;
+    if (!sameDigest || !sameTorsion) {
       m.set(id, { ...sec, canonical: next });
       changed = true;
     }

--- a/web/src/lib/store/model.svelte.ts
+++ b/web/src/lib/store/model.svelte.ts
@@ -2913,7 +2913,6 @@ function createModelStore() {
       // before the engine was ready — without it those would keep reporting
       // no known geometry for the rest of the session.
       this.refreshCanonicalSections();
-      this.refreshCanonicalSections();
 
       if (is2DFixture(name) && (uiStore.analysisMode === '3d' || uiStore.analysisMode === 'pro')) {
         uiStore.useUpright2DIn3DPresentation();
@@ -3060,6 +3059,17 @@ function createModelStore() {
       // never need.
       const withCanonical =
         Object.keys(patch).length === 0 && sec.canonical ? updated : resolveOnUpdate(updated);
+      // Mirror the resolved values back into the declared scalars. Declared
+      // values are the designed fallback — engine down, feature-flag rollback,
+      // readers that cannot see canonical state — and with the auto-calc guard
+      // above nothing else keeps them current on a geometry-backed section.
+      const st = withCanonical.canonical;
+      if (st?.kind === 'geometry-backed') {
+        withCanonical.a = st.a;
+        withCanonical.iy = st.iy;
+        withCanonical.iz = st.iz;
+        if (st.j != null) withCanonical.j = st.j;
+      }
 
       const m = new Map(model.sections);
       m.set(id, withCanonical);

--- a/web/src/lib/store/model.svelte.ts
+++ b/web/src/lib/store/model.svelte.ts
@@ -2907,10 +2907,12 @@ function createModelStore() {
         loadFixture(json as any, api as any);
       });
 
-      // Fixtures add their sections inside a bulk mutation, which bypasses the
-      // per-section resolve, so settle canonical state once the whole model is
-      // in place. Without this a loaded example reports every section as
-      // having no known geometry.
+      // Settle canonical state once the whole model is in place. Sections the
+      // fixture added are already resolved (addSection resolves per add, and
+      // the refresh skips those), so this repairs only sections that loaded
+      // before the engine was ready — without it those would keep reporting
+      // no known geometry for the rest of the session.
+      this.refreshCanonicalSections();
       this.refreshCanonicalSections();
 
       if (is2DFixture(name) && (uiStore.analysisMode === '3d' || uiStore.analysisMode === 'pro')) {
@@ -3025,8 +3027,12 @@ function createModelStore() {
         patch = rest;
       }
       const updated: Section = { ...sec, ...patch, id };
-      // Auto-calculate A, Iy, Iz, J from b×h ONLY for manual edits (no shape specified)
-      if (data.shape === undefined) {
+      // Auto-calculate A, Iy, Iz, J from b×h ONLY for manual edits (no shape
+      // specified) on sections WITHOUT canonical geometry: on a geometry-backed
+      // section the derived values are outputs of the polygons, and writing
+      // rectangle-formula numbers over them is how a catalogue IPE ends up
+      // displaying a rectangle's area in the table.
+      if (data.shape === undefined && sec.canonical?.kind !== 'geometry-backed') {
         const b = data.b ?? sec.b;
         const h = data.h ?? sec.h;
         if (b !== undefined && h !== undefined && b > 0 && h > 0 && (data.b !== undefined || data.h !== undefined)) {
@@ -3046,7 +3052,14 @@ function createModelStore() {
       // step. Doing it here keeps geometry and properties atomically
       // consistent: there is no window in which a section carries new
       // dimensions and stale canonical values.
-      const withCanonical = resolveOnUpdate(updated);
+      //
+      // The exception is a patch that cannot change the resolution: for a
+      // geometry-backed section a/iy/iz/j were stripped above, so an empty
+      // patch means the edit touched only derived scalars — and re-resolving
+      // would run a Saint-Venant mesh-and-solve the table's inline edit could
+      // never need.
+      const withCanonical =
+        Object.keys(patch).length === 0 && sec.canonical ? updated : resolveOnUpdate(updated);
 
       const m = new Map(model.sections);
       m.set(id, withCanonical);


### PR DESCRIPTION
Second round of fixes from the PR #124 performance review (first round: #130), plus the fixes from this PR's own review pass (commit 9e14c4af).

## Engine

- **`poisson.rs`: factor once, solve many.** New `factor_poisson` / `FactoredPoisson` — assemble and factor the reduced system once, then solve for many right-hand sides (source and Dirichlet *values* may vary; the constrained node set is fixed at factor time, and a short `dirichlet` array is now an error rather than a silent zero). `solve_poisson` is a thin factor+solve wrapper, so every existing caller keeps working unchanged.
- **`shear.rs`**: both axes solve the same pure-Neumann problem with different sources — factored once instead of twice. Halves the dominant cost of every shear solve. Inertia is validated before the factorization.
- **`torsion.rs`**: the k+1 hole-superposition solves share one constrained set — factored once instead of k+1 times.
- **plastic export** *(behavior change, called out deliberately)*: a shear failure on the way to `Cw` now propagates with context instead of becoming a silent `cw: None`; only the warping solve may quietly decline (closed sections, where absent `Cw` is an answer, not an error).

## Store

- **`updateSection`** skips the canonical re-resolve when the patch cannot change it (derived scalars only), and resolved canonical values are mirrored back into the declared fields so the designed fallback (engine down, flag off, plastic solver) never goes stale. The b×h auto-calc no longer writes rectangle-formula properties onto geometry-backed sections.
- **Load path**: `restoreSections` takes a torsion option (used by `restoreCanonicalSections`), and `refreshCanonicalSections` skips sections already geometry-backed with a torsion answer — and now also publishes a successful torsion retry (the digest doesn't cover `j`/`jProvenance`). A model load resolves each section once.
- **Saint-Venant J is cached per geometry digest**: re-resolutions that leave geometry untouched — a rename, a refresh pass — no longer re-pay the mesh-and-solve.

## UI hot paths

- **Viewport axial colour map**: `mix()` closure + hex parsing hoisted out of the per-element loop.
- **EducativePanel**: `stressContext` is built at most once per exercise and *lazily* — an eager build at panel mount could cache the empty engine-not-ready context and silently mark students against 0 on a cold start.
- **BasicPanel**: `--st-right-panel-w` published imperatively and rAF-throttled during resize drags, instead of a reactive effect writing a root custom property per pointermove.
- **CrossSectionDrawing**: outline path string is a `$derived`, not rebuilt on every slider-driven re-render.
- **solver-service**: `solverProperties` hoisted out of the per-section map callbacks (2D, projected 2D→3D, and 3D branches).

## Review history

Three independent reviewers audited bb7de204; their findings (edu cold-start grading, duplicated refresh call, swallowed torsion retry, stale declared fallback, silent dirichlet default) are fixed in 9e14c4af. No open findings.

## Verification

- cargo: **4727 passed, 0 failed** — shear/torsion/poisson suites confirm the refactor is numerics-preserving (sparse-vs-dense parity, field-vs-point export consistency).
- web: vitest **unit + build passes green**; svelte-check gate clean.

Intentionally left for later (lower value / higher risk): `kappa` semantics, plastic-bisection allocation fast-path, O(B·T) boundary scans, theme-token drift sweep.
