### PR TITLE
fix(engine): E2 linear solver core audit — 8 correctness fixes

### DIFF
--- a/engine/src/solver/assembly.rs
+++ b/engine/src/solver/assembly.rs
@@ -1904,7 +1904,17 @@ pub fn assemble_sparse_2d(input: &SolverInput, dof_num: &DofNumbering) -> Sparse
                 }
             }
         } else {
-            let k_local = frame_local_stiffness_2d(e, sec.a, sec.iz, l, elem.hinge_start, elem.hinge_end, 0.0);
+            // Timoshenko shear parameter, matching the dense path (and the
+            // FEF builder below, which already computes phi from as_y —
+            // passing 0.0 here paired Euler-Bernoulli stiffness with
+            // Timoshenko fixed-end forces).
+            let phi = if let Some(as_y) = sec.as_y {
+                let g = e / (2.0 * (1.0 + mat.nu));
+                12.0 * e * sec.iz / (g * as_y * l * l)
+            } else {
+                0.0
+            };
+            let k_local = frame_local_stiffness_2d(e, sec.a, sec.iz, l, elem.hinge_start, elem.hinge_end, phi);
             let t = frame_transform_2d(cos, sin);
             let k_glob = transform_stiffness(&k_local, &t, 6);
             let elem_dofs = dof_num.element_dofs(elem.node_i, elem.node_j);
@@ -2952,4 +2962,81 @@ fn curved_shell_coords(node_map: &std::collections::HashMap<usize, &SolverNode3D
         coords[i] = [n.x, n.y, n.z];
     }
     coords
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Cantilever with a Timoshenko (as_y) section: phi ≈ 0.156, large enough
+    /// that an Euler-Bernoulli K is visibly different.
+    fn make_timoshenko_cantilever() -> SolverInput {
+        let mut nodes = HashMap::new();
+        nodes.insert("1".into(), SolverNode { id: 1, x: 0.0, z: 0.0 });
+        nodes.insert("2".into(), SolverNode { id: 2, x: 2.0, z: 0.0 });
+
+        let mut materials = HashMap::new();
+        materials.insert("1".into(), SolverMaterial { id: 1, e: 200_000.0, nu: 0.3 });
+
+        let mut sections = HashMap::new();
+        sections.insert("1".into(), SolverSection { id: 1, a: 0.01, iz: 1e-4, as_y: Some(0.005) });
+
+        let mut elements = HashMap::new();
+        elements.insert("1".into(), SolverElement {
+            id: 1, elem_type: "frame".into(),
+            node_i: 1, node_j: 2, material_id: 1, section_id: 1,
+            hinge_start: false, hinge_end: false,
+        });
+
+        let mut supports = HashMap::new();
+        supports.insert("1".into(), SolverSupport {
+            id: 1, node_id: 1, support_type: "fixed".into(),
+            kx: None, ky: None, kz: None,
+            dx: None, dz: None, dry: None, angle: None,
+        });
+
+        SolverInput {
+            nodes, materials, sections, elements, supports,
+            loads: vec![], constraints: vec![], connectors: HashMap::new(),
+        }
+    }
+
+    /// The legacy triplet sparse 2D assembler (used by 2D buckling) must
+    /// produce the same K_ff as the dense assembler for Timoshenko sections.
+    /// It used to hardcode phi = 0, pairing Euler-Bernoulli stiffness with
+    /// Timoshenko fixed-end forces.
+    #[test]
+    fn legacy_sparse_2d_matches_dense_with_timoshenko_section() {
+        let input = make_timoshenko_cantilever();
+        let dof_num = DofNumbering::build_2d(&input);
+        let n = dof_num.n_total;
+        let nf = dof_num.n_free;
+
+        let dense = assemble_stiffness_2d(&input, &dof_num);
+        let sparse = assemble_sparse_2d(&input, &dof_num);
+        let k_sparse = sparse.k_ff.to_dense_symmetric();
+
+        // Shear-deformation-sensitive entry: the bending diagonal at the tip.
+        // phi ≈ 0.156 shifts this term by ~13% vs Euler-Bernoulli.
+        let k_tip_bend_dense = dense.k[1 * n + 1];
+        let k_tip_bend_sparse = k_sparse[1 * nf + 1];
+        let scale = k_tip_bend_dense.abs();
+        assert!(
+            (k_tip_bend_sparse - k_tip_bend_dense).abs() <= 1e-9 * scale,
+            "K_ff mismatch (Timoshenko): sparse {} vs dense {}",
+            k_tip_bend_sparse, k_tip_bend_dense
+        );
+
+        for i in 0..nf {
+            for j in 0..nf {
+                let kd = dense.k[i * n + j];
+                let ks = k_sparse[i * nf + j];
+                assert!(
+                    (ks - kd).abs() <= 1e-9 * scale.max(1.0),
+                    "K_ff[{i}][{j}] mismatch: sparse {ks} vs dense {kd}"
+                );
+            }
+        }
+    }
 }

--- a/engine/src/solver/constraints.rs
+++ b/engine/src/solver/constraints.rs
@@ -777,6 +777,39 @@ pub fn solve_constrained_2d(input: &ConstrainedInput) -> Result<AnalysisResults,
     let mut u_r = vec![0.0; nr];
     for sup in input.solver.supports.values() {
         if sup.support_type == "spring" { continue; }
+
+        if sup.support_type == "inclinedRoller" {
+            // Prescribed translations are given in GLOBAL coords; the
+            // restrained inclined DOF (local_dof 1) is the normal direction.
+            // Rotate into the inclined frame, mirroring prepare_static_2d.
+            if let Some(theta) = sup.angle {
+                let c = theta.cos();
+                let s = theta.sin();
+                let u_normal = sup.dx.unwrap_or(0.0) * s + sup.dz.unwrap_or(0.0) * c;
+                if u_normal.abs() > 1e-15 {
+                    if let Some(&d) = dof_num.map.get(&(sup.node_id, 1)) {
+                        if d >= nf { u_r[d - nf] = u_normal; }
+                    }
+                }
+            } else {
+                if let Some(v) = sup.dz {
+                    if v.abs() > 1e-15 {
+                        if let Some(&d) = dof_num.map.get(&(sup.node_id, 1)) {
+                            if d >= nf { u_r[d - nf] = v; }
+                        }
+                    }
+                }
+            }
+            if let Some(v) = sup.dry {
+                if v.abs() > 1e-15 {
+                    if let Some(&d) = dof_num.map.get(&(sup.node_id, 2)) {
+                        if d >= nf { u_r[d - nf] = v; }
+                    }
+                }
+            }
+            continue;
+        }
+
         let prescribed: [(usize, Option<f64>); 3] = [
             (0, sup.dx), (1, sup.dz), (2, sup.dry),
         ];
@@ -1064,6 +1097,35 @@ pub fn solve_constrained_3d(input: &ConstrainedInput3D) -> Result<AnalysisResult
     // Build prescribed displacements
     let mut u_r = vec![0.0; nr];
     for sup in input.solver.supports.values() {
+        // Inclined supports: prescribed translations are given in GLOBAL
+        // coords; the restrained inclined DOF (local_dof 0) is the normal
+        // direction in the rotated frame. Project onto the normal —
+        // mirroring prepare_static_3d.
+        if sup.is_inclined.unwrap_or(false) {
+            if let (Some(nx), Some(ny), Some(nz)) = (sup.normal_x, sup.normal_y, sup.normal_z) {
+                let n_len = (nx * nx + ny * ny + nz * nz).sqrt();
+                if n_len > 1e-12 {
+                    let u_normal = (nx * sup.dx.unwrap_or(0.0)
+                        + ny * sup.dy.unwrap_or(0.0)
+                        + nz * sup.dz.unwrap_or(0.0)) / n_len;
+                    if u_normal.abs() > 1e-15 {
+                        if let Some(&d) = dof_num.map.get(&(sup.node_id, 0)) {
+                            if d >= nf { u_r[d - nf] = u_normal; }
+                        }
+                    }
+                    for (i, pd) in [sup.drx, sup.dry, sup.drz].iter().enumerate() {
+                        if let Some(val) = pd {
+                            if val.abs() > 1e-15 {
+                                if let Some(&d) = dof_num.map.get(&(sup.node_id, 3 + i)) {
+                                    if d >= nf { u_r[d - nf] = *val; }
+                                }
+                            }
+                        }
+                    }
+                    continue;
+                }
+            }
+        }
         let prescribed = [sup.dx, sup.dy, sup.dz, sup.drx, sup.dry, sup.drz];
         for (i, pd) in prescribed.iter().enumerate() {
             if let Some(val) = pd {
@@ -1901,5 +1963,60 @@ mod tests {
         // The diaphragm should change the slave's displacement compared to free
         assert!((d2_dia.ux - d2_free.ux).abs() > 1e-10,
             "Diaphragm should actually constrain the slave node's motion");
+    }
+
+    #[test]
+    fn test_inclined_support_prescribed_displacement_matches_unconstrained() {
+        // An inclinedRoller with a prescribed settlement: prescribed (dx, dz)
+        // are GLOBAL and must be rotated into the inclined frame. The
+        // constrained solve used to assign raw dz to the restrained (normal)
+        // slot; prepare_static_2d rotates. Parity between the two paths is
+        // the reference.
+        let theta = std::f64::consts::FRAC_PI_4;
+        let delta = 0.001;
+
+        let mut solver = make_two_beam_model();
+        // Replace the fixed support at node 0 with an inclined roller
+        // carrying a prescribed global settlement, and fix node 2 instead so
+        // the model stays stable.
+        solver.supports.clear();
+        solver.supports.insert("0".into(), SolverSupport {
+            id: 0, node_id: 0, support_type: "inclinedRoller".into(),
+            kx: None, ky: None, kz: None,
+            dx: Some(delta), dz: Some(delta), dry: None, angle: Some(theta),
+        });
+        solver.supports.insert("2".into(), SolverSupport {
+            id: 2, node_id: 2, support_type: "fixed".into(),
+            kx: None, ky: None, kz: None,
+            dx: None, dz: None, dry: None, angle: None,
+        });
+        solver.loads = vec![];
+
+        // Reference: plain linear solve (rotates prescribed displacements).
+        let reference = linear::solve_2d(&solver).unwrap();
+
+        // Constrained path (dummy-but-real constraint forces the delegation).
+        let input = ConstrainedInput {
+            solver: solver.clone(),
+            constraints: vec![Constraint::EqualDOF(EqualDOFConstraint {
+                master_node: 0, slave_node: 1, dofs: vec![2],
+            })],
+        };
+        let constrained = solve_constrained_2d(&input).unwrap();
+
+        let d0_ref = reference.displacements.iter().find(|d| d.node_id == 0).unwrap();
+        let d0_con = constrained.displacements.iter().find(|d| d.node_id == 0).unwrap();
+
+        // The prescribed DOF is the normal-direction displacement:
+        // u_normal = dx·sinθ + dz·cosθ = δ√2.
+        let expected = delta * 2.0 * std::f64::consts::FRAC_1_SQRT_2;
+        let u_normal_ref = d0_ref.ux * theta.sin() + d0_ref.uz * theta.cos();
+        assert!((u_normal_ref - expected).abs() < 1e-12,
+            "reference path: normal disp {} expected {}", u_normal_ref, expected);
+
+        let u_normal_con = d0_con.ux * theta.sin() + d0_con.uz * theta.cos();
+        assert!((u_normal_con - expected).abs() < 1e-12,
+            "constrained path: normal disp {} expected {} (raw-dz bug would give {})",
+            u_normal_con, expected, delta);
     }
 }

--- a/engine/src/solver/constraints.rs
+++ b/engine/src/solver/constraints.rs
@@ -797,6 +797,15 @@ pub fn solve_constrained_2d(input: &ConstrainedInput) -> Result<AnalysisResults,
         Some(&input.solver.nodes), None,
     );
 
+    // Error-severity constraint diagnostics (e.g. circular chains) mean the
+    // transform cannot represent the model: chained substitution leaves the
+    // cycled DOFs with all-zero C rows, which silently drops their stiffness
+    // AND their loads from the reduced system. That result must not be
+    // presented as final.
+    if let Some(d) = constraint_diags.iter().find(|d| d.severity == Severity::Error) {
+        return Err(format!("Invalid constraints: {}", d.message));
+    }
+
     // Build constraint transform on free DOFs only
     let ct = build_constraint_transform(
         &input.constraints, &dof_num,
@@ -1072,6 +1081,15 @@ pub fn solve_constrained_3d(input: &ConstrainedInput3D) -> Result<AnalysisResult
         &input.constraints, &dof_num,
         None, Some(&input.solver.nodes),
     );
+
+    // Error-severity constraint diagnostics (e.g. circular chains) mean the
+    // transform cannot represent the model: chained substitution leaves the
+    // cycled DOFs with all-zero C rows, which silently drops their stiffness
+    // AND their loads from the reduced system. That result must not be
+    // presented as final.
+    if let Some(d) = constraint_diags.iter().find(|d| d.severity == Severity::Error) {
+        return Err(format!("Invalid constraints: {}", d.message));
+    }
 
     let ct = build_constraint_transform(
         &input.constraints, &dof_num,
@@ -1758,6 +1776,29 @@ mod tests {
             "Diaphragm ux: got {} expected {}", d2.ux, expected_ux);
         assert!((d2.uz - expected_uy).abs() < 1e-8,
             "Diaphragm uz: got {} expected {}", d2.uz, expected_uy);
+    }
+
+    #[test]
+    fn test_circular_constraint_chain_returns_error() {
+        // A -> B -> A EqualDOF cycle: the transformation method cannot
+        // represent it (both DOFs become dependent with all-zero C rows,
+        // silently dropping their stiffness and loads). Must be a hard
+        // error, not partial results presented as final.
+        let solver = make_two_beam_model();
+        let input = ConstrainedInput {
+            solver,
+            constraints: vec![
+                Constraint::EqualDOF(EqualDOFConstraint {
+                    master_node: 2, slave_node: 1, dofs: vec![1],
+                }),
+                Constraint::EqualDOF(EqualDOFConstraint {
+                    master_node: 1, slave_node: 2, dofs: vec![1],
+                }),
+            ],
+        };
+        let err = solve_constrained_2d(&input).unwrap_err();
+        assert!(err.contains("Invalid constraints"),
+            "expected hard error for circular constraint chain, got: {}", err);
     }
 
     #[test]

--- a/engine/src/solver/dof.rs
+++ b/engine/src/solver/dof.rs
@@ -86,7 +86,7 @@ impl DofNumbering {
         // makes that DOF restrained). Sort supports by ID for determinism.
         let mut sorted_supports: Vec<&SolverSupport3D> = input.supports.values().collect();
         sorted_supports.sort_by_key(|s| {
-            // Sort by node_id (primary), then by number of restrained DOFs descending
+            // Sort by node_id (primary), then by number of restrained DOFs ascending
             // so the most-restrained support is last (wins on overwrite)
             let n_restrained = [s.rx, s.ry, s.rz, s.rrx, s.rry, s.rrz]
                 .iter().filter(|&&b| b).count();

--- a/engine/src/solver/linear.rs
+++ b/engine/src/solver/linear.rs
@@ -1300,6 +1300,41 @@ pub fn prepare_static_3d(input: &SolverInput3D) -> Result<PreparedStatic3D, Stri
     // Build prescribed displacement vector u_r for restrained DOFs
     let mut u_r = vec![0.0; nr];
     for sup in input.supports.values() {
+        // Inclined supports: prescribed translations are given in GLOBAL
+        // coords, but the restrained inclined DOF (local_dof 0) lives in the
+        // rotated frame where it is the normal direction. Project the global
+        // prescribed translation onto the normal — mirroring the 2D
+        // inclinedRoller handling in prepare_static_2d.
+        if sup.is_inclined.unwrap_or(false) {
+            if let (Some(nx), Some(ny), Some(nz)) = (sup.normal_x, sup.normal_y, sup.normal_z) {
+                let n_len = (nx * nx + ny * ny + nz * nz).sqrt();
+                if n_len > 1e-12 {
+                    let u_normal = (nx * sup.dx.unwrap_or(0.0)
+                        + ny * sup.dy.unwrap_or(0.0)
+                        + nz * sup.dz.unwrap_or(0.0)) / n_len;
+                    if u_normal.abs() > 1e-15 {
+                        if let Some(&d) = dof_num.map.get(&(sup.node_id, 0)) {
+                            if d >= nf {
+                                u_r[d - nf] = u_normal;
+                            }
+                        }
+                    }
+                    // Rotational prescribed values use the standard flags.
+                    for (i, pd) in [sup.drx, sup.dry, sup.drz].iter().enumerate() {
+                        if let Some(val) = pd {
+                            if val.abs() > 1e-15 {
+                                if let Some(&d) = dof_num.map.get(&(sup.node_id, 3 + i)) {
+                                    if d >= nf {
+                                        u_r[d - nf] = *val;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    continue;
+                }
+            }
+        }
         let prescribed = [sup.dx, sup.dy, sup.dz, sup.drx, sup.dry, sup.drz];
         for (i, pd) in prescribed.iter().enumerate() {
             if let Some(val) = pd {

--- a/engine/src/solver/linear.rs
+++ b/engine/src/solver/linear.rs
@@ -2484,15 +2484,18 @@ pub(crate) fn build_reactions_3d(
         let mut vals = [0.0f64; 6];
 
         // Handle each DOF individually: restrained DOFs from reactions_vec,
-        // spring DOFs (free with stiffness) from R = -k * u
+        // spring DOFs (free with stiffness) from R = -k * u. A spring DOF is
+        // free regardless of the restraint flags (DofNumbering gives springs
+        // precedence), so the flag is not consulted on the free branch —
+        // otherwise a support with both a flag and a stiffness would report
+        // zero reaction while the spring force is real.
         let spring_stiffs = [sup.kx, sup.ky, sup.kz, sup.krx, sup.kry, sup.krz];
-        let restrained_flags = [sup.rx, sup.ry, sup.rz, sup.rrx, sup.rry, sup.rrz];
         for i in 0..6.min(dof_num.dofs_per_node) {
             if let Some(&d) = dof_num.map.get(&(sup.node_id, i)) {
                 if d >= nf {
                     // Restrained DOF: reaction from solve
                     vals[i] = reactions_vec[d - nf];
-                } else if !restrained_flags[i] {
+                } else {
                     // Free DOF: check for spring stiffness
                     let k = spring_stiffs[i].unwrap_or(0.0);
                     if k > 0.0 {

--- a/engine/src/solver/load_cases.rs
+++ b/engine/src/solver/load_cases.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::solver::linear::{prepare_static_2d, prepare_static_3d, solve_3d};
+use crate::solver::linear::{prepare_static_2d, prepare_static_3d, solve_2d, solve_3d};
 use crate::postprocess::combinations::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -88,6 +88,28 @@ pub struct MultiCaseResult3D {
     pub envelope: FullEnvelope3D,
 }
 
+/// Fail fast when a combination references a load case that does not exist.
+/// An unknown case name used to be silently dropped from the combination,
+/// producing a combined result (and envelope) missing that case's
+/// contribution, presented as final.
+fn validate_combination_case_names<'a>(
+    load_case_names: impl Iterator<Item = &'a str>,
+    combinations: &[CombinationDef],
+) -> Result<(), String> {
+    let names: std::collections::HashSet<&str> = load_case_names.collect();
+    for combo in combinations {
+        for case_name in combo.factors.keys() {
+            if !names.contains(case_name.as_str()) {
+                return Err(format!(
+                    "Combination '{}' references unknown load case '{}'",
+                    combo.name, case_name
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 // ==================== 2D Multi-Case Solver ====================
 
 pub fn solve_multi_case_2d(input: &MultiCaseInput) -> Result<MultiCaseResult, String> {
@@ -97,14 +119,25 @@ pub fn solve_multi_case_2d(input: &MultiCaseInput) -> Result<MultiCaseResult, St
     if input.combinations.is_empty() {
         return Err("No combinations defined".into());
     }
+    validate_combination_case_names(
+        input.load_cases.iter().map(|lc| lc.name.as_str()),
+        &input.combinations,
+    )?;
+
+    // Constraints delegate to the constrained solver per case — keep the
+    // legacy per-case path for that (rare) configuration, mirroring the 3D
+    // multi-case entry point. Clearing them here would silently solve the
+    // unconstrained structure and present the results as final.
+    if !input.solver.constraints.is_empty() {
+        return solve_multi_case_2d_per_case(input);
+    }
 
     // Prepare the structure once (assembly + factorization of K).
-    // Historical behavior: constraints and connectors are ignored in
-    // multi-case 2D, and only the per-case load lists are used.
+    // Connectors are load-independent stiffness: they stay in the prepared
+    // structure exactly as a single `solve_2d` would assemble them. Only the
+    // per-case load lists replace the model's own load list.
     let mut solver = input.solver.clone();
     solver.loads = vec![];
-    solver.constraints = vec![];
-    solver.connectors = HashMap::new();
 
     let prepared = prepare_static_2d(&solver)
         .map_err(|e| format!("Failed to solve case '{}': {}", input.load_cases[0].name, e))?;
@@ -176,6 +209,10 @@ pub fn solve_multi_case_3d(input: &MultiCaseInput3D) -> Result<MultiCaseResult3D
     if input.combinations.is_empty() {
         return Err("No combinations defined".into());
     }
+    validate_combination_case_names(
+        input.load_cases.iter().map(|lc| lc.name.as_str()),
+        &input.combinations,
+    )?;
 
     // Constraints delegate to the constrained solver per case — keep the
     // legacy per-case path for that (rare) configuration.
@@ -184,11 +221,11 @@ pub fn solve_multi_case_3d(input: &MultiCaseInput3D) -> Result<MultiCaseResult3D
     }
 
     // Prepare the structure once (assembly + factorization of K).
-    // Historical behavior: connectors are ignored in multi-case 3D, and only
-    // the per-case load lists are used.
+    // Connectors are load-independent stiffness: they stay in the prepared
+    // structure exactly as a single `solve_3d` would assemble them. Only the
+    // per-case load lists replace the model's own load list.
     let mut solver = input.solver.clone();
     solver.loads = vec![];
-    solver.connectors = HashMap::new();
 
     let prepared = prepare_static_3d(&solver)
         .map_err(|e| format!("Failed to solve case '{}': {}", input.load_cases[0].name, e))?;
@@ -271,7 +308,7 @@ fn solve_multi_case_3d_per_case(input: &MultiCaseInput3D) -> Result<MultiCaseRes
             curved_shells: input.solver.curved_shells.clone(),
             curved_beams: input.solver.curved_beams.clone(),
             constraints: input.solver.constraints.clone(),
-            connectors: HashMap::new(),
+            connectors: input.solver.connectors.clone(),
         };
 
         let results = solve_3d(&case_input)
@@ -319,6 +356,76 @@ fn solve_multi_case_3d_per_case(input: &MultiCaseInput3D) -> Result<MultiCaseRes
         .collect();
 
     Ok(MultiCaseResult3D {
+        case_results,
+        combination_results,
+        envelope,
+    })
+}
+
+/// Legacy per-case 2D multi-case path: one full `solve_2d` per load case
+/// (which auto-delegates to the constrained solver). Retained for models with
+/// constraints, mirroring `solve_multi_case_3d_per_case`.
+fn solve_multi_case_2d_per_case(input: &MultiCaseInput) -> Result<MultiCaseResult, String> {
+    let mut case_results = Vec::new();
+    let mut case_map: HashMap<String, usize> = HashMap::new();
+
+    for (idx, lc) in input.load_cases.iter().enumerate() {
+        let case_input = SolverInput {
+            nodes: input.solver.nodes.clone(),
+            materials: input.solver.materials.clone(),
+            sections: input.solver.sections.clone(),
+            elements: input.solver.elements.clone(),
+            supports: input.solver.supports.clone(),
+            loads: lc.loads.clone(),
+            constraints: input.solver.constraints.clone(),
+            connectors: input.solver.connectors.clone(),
+        };
+
+        let results = solve_2d(&case_input)
+            .map_err(|e| format!("Failed to solve case '{}': {}", lc.name, e))?;
+
+        case_map.insert(lc.name.clone(), idx);
+        case_results.push(CaseResult {
+            name: lc.name.clone(),
+            results,
+        });
+    }
+
+    let case_refs: Vec<(usize, &AnalysisResults)> = case_results
+        .iter()
+        .enumerate()
+        .map(|(idx, cr)| (idx, &cr.results))
+        .collect();
+    let mut combo_names: Vec<String> = Vec::new();
+    let mut all_combined_results: Vec<AnalysisResults> = Vec::new();
+
+    for combo in &input.combinations {
+        let mut combo_factors = Vec::new();
+        for (case_name, &factor) in &combo.factors {
+            if let Some(&idx) = case_map.get(case_name) {
+                combo_factors.push(CombinationFactor {
+                    case_id: idx,
+                    factor,
+                });
+            }
+        }
+
+        if let Some(combined) = combine_results_refs(&combo_factors, &case_refs) {
+            all_combined_results.push(combined);
+            combo_names.push(combo.name.clone());
+        }
+    }
+
+    let envelope = compute_envelope(&all_combined_results)
+        .ok_or_else(|| "Failed to compute envelope".to_string())?;
+
+    let combination_results = combo_names
+        .into_iter()
+        .zip(all_combined_results)
+        .map(|(name, results)| CombinedResult { name, results })
+        .collect();
+
+    Ok(MultiCaseResult {
         case_results,
         combination_results,
         envelope,

--- a/engine/src/solver/load_cases.rs
+++ b/engine/src/solver/load_cases.rs
@@ -92,11 +92,20 @@ pub struct MultiCaseResult3D {
 /// An unknown case name used to be silently dropped from the combination,
 /// producing a combined result (and envelope) missing that case's
 /// contribution, presented as final.
+///
+/// Also fail fast on duplicate load case names: the case lookup map keeps
+/// only the last case with a given name, so a combination factor would
+/// silently drop the earlier case's contribution.
 fn validate_combination_case_names<'a>(
     load_case_names: impl Iterator<Item = &'a str>,
     combinations: &[CombinationDef],
 ) -> Result<(), String> {
-    let names: std::collections::HashSet<&str> = load_case_names.collect();
+    let mut names: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for name in load_case_names {
+        if !names.insert(name) {
+            return Err(format!("Duplicate load case name '{}'", name));
+        }
+    }
     for combo in combinations {
         for case_name in combo.factors.keys() {
             if !names.contains(case_name.as_str()) {

--- a/engine/src/solver/pre_solve_gates.rs
+++ b/engine/src/solver/pre_solve_gates.rs
@@ -232,7 +232,8 @@ pub fn check_instability_risk_2d(input: &SolverInput) -> Vec<StructuredDiagnosti
     let mut rot_restrained: HashSet<usize> = HashSet::new();
     for sup in input.supports.values() {
         match sup.support_type.as_str() {
-            "fixed" | "guidedX" | "guidedY" => {
+            // guidedZ is a 2D alias of guidedY (dof::is_dof_restrained_2d): ux+ry fixed
+            "fixed" | "guidedX" | "guidedY" | "guidedZ" => {
                 rot_restrained.insert(sup.node_id);
             }
             _ => {

--- a/engine/src/solver/reduction.rs
+++ b/engine/src/solver/reduction.rs
@@ -143,6 +143,18 @@ fn chol_solve(l: &[f64], rhs: &[f64], n: usize) -> Vec<f64> {
 ///
 /// Recovery: u_I = K_II^{-1} * (F_I - K_IB * u_B)
 pub fn guyan_reduce_2d(input: &GuyanInput) -> Result<GuyanResult, String> {
+    // The reduction hardcodes u_r = 0 in the recovery/reaction path, so
+    // prescribed support displacements would be silently ignored.
+    for sup in input.solver.supports.values() {
+        let prescribed = [sup.dx, sup.dz, sup.dry];
+        if prescribed.iter().flatten().any(|v| v.abs() > 1e-15) {
+            return Err(format!(
+                "Guyan reduction does not support prescribed support displacements (node {})",
+                sup.node_id
+            ));
+        }
+    }
+
     let dof_num = DofNumbering::build_2d(&input.solver);
     let nf = dof_num.n_free;
     let n = dof_num.n_total;
@@ -593,6 +605,19 @@ pub fn craig_bampton_2d(input: &CraigBamptonInput) -> Result<CraigBamptonResult,
 
 /// Perform Guyan (static) condensation on a 3D model.
 pub fn guyan_reduce_3d(input: &GuyanInput3D) -> Result<GuyanResult3D, String> {
+    // Same limitation as the 2D path: u_r = 0 is hardcoded in the
+    // recovery/reaction path, so prescribed support displacements would be
+    // silently ignored.
+    for sup in input.solver.supports.values() {
+        let prescribed = [sup.dx, sup.dy, sup.dz, sup.drx, sup.dry, sup.drz];
+        if prescribed.iter().flatten().any(|v| v.abs() > 1e-15) {
+            return Err(format!(
+                "Guyan reduction does not support prescribed support displacements (node {})",
+                sup.node_id
+            ));
+        }
+    }
+
     let dof_num = DofNumbering::build_3d(&input.solver);
     let nf = dof_num.n_free;
     let n = dof_num.n_total;

--- a/engine/src/solver/sparse_assembly.rs
+++ b/engine/src/solver/sparse_assembly.rs
@@ -150,7 +150,17 @@ pub fn assemble_2d_sparse(input: &SolverInput, dof_num: &DofNumbering) -> Triple
                 diag_vals[truss_dofs[i]] += k_elem[i * 4 + i];
             }
         } else {
-            let k_local = frame_local_stiffness_2d(e, sec.a, sec.iz, l, elem.hinge_start, elem.hinge_end, 0.0);
+            // Timoshenko shear parameter, matching the dense path (and the
+            // FEF builder below, which already computes phi from as_y —
+            // passing 0.0 here paired Euler-Bernoulli stiffness with
+            // Timoshenko fixed-end forces).
+            let phi = if let Some(as_y) = sec.as_y {
+                let g = e / (2.0 * (1.0 + mat.nu));
+                12.0 * e * sec.iz / (g * as_y * l * l)
+            } else {
+                0.0
+            };
+            let k_local = frame_local_stiffness_2d(e, sec.a, sec.iz, l, elem.hinge_start, elem.hinge_end, phi);
             let t = frame_transform_2d(cos, sin);
             let k_glob = transform_stiffness(&k_local, &t, 6);
             let elem_dofs = dof_num.element_dofs(elem.node_i, elem.node_j);
@@ -694,7 +704,17 @@ pub fn assemble_elements_parallel_2d(input: &SolverInput, dof_num: &DofNumbering
                 local_diag.push((truss_dofs[i], k_elem[i * 4 + i]));
             }
         } else {
-            let k_local = frame_local_stiffness_2d(e, sec.a, sec.iz, l, elem.hinge_start, elem.hinge_end, 0.0);
+            // Timoshenko shear parameter, matching the dense path (and the
+            // FEF builder below, which already computes phi from as_y —
+            // passing 0.0 here paired Euler-Bernoulli stiffness with
+            // Timoshenko fixed-end forces).
+            let phi = if let Some(as_y) = sec.as_y {
+                let g = e / (2.0 * (1.0 + mat.nu));
+                12.0 * e * sec.iz / (g * as_y * l * l)
+            } else {
+                0.0
+            };
+            let k_local = frame_local_stiffness_2d(e, sec.a, sec.iz, l, elem.hinge_start, elem.hinge_end, phi);
             let t = frame_transform_2d(cos, sin);
             let k_glob = transform_stiffness(&k_local, &t, 6);
             let elem_dofs = dof_num.element_dofs(elem.node_i, elem.node_j);
@@ -713,15 +733,9 @@ pub fn assemble_elements_parallel_2d(input: &SolverInput, dof_num: &DofNumbering
                 local_diag.push((elem_dofs[i], k_glob[i * ndof + i]));
             }
 
-            // Timoshenko shear parameter for hinge FEF condensation. The sparse
-            // stiffness path above still uses phi=0 (legacy), but the FEF must
-            // at least be consistent with the dense solve for as_y sections.
-            let phi = if let Some(as_y) = sec.as_y {
-                let g = e / (2.0 * (1.0 + mat.nu));
-                12.0 * e * sec.iz / (g * as_y * l * l)
-            } else {
-                0.0
-            };
+            // The stiffness path's phi above is reused for hinge FEF
+            // condensation, so fixed-end forces stay consistent with the
+            // element stiffness for as_y sections.
 
             // Compute FEF contributions for this element
             for load in &input.loads {

--- a/engine/tests/chained_constraints.rs
+++ b/engine/tests/chained_constraints.rs
@@ -416,6 +416,45 @@ fn circular_constraint_depth_4_does_not_panic() {
     }
 }
 
+/// A circular chain must now fail loudly: solving it would disconnect the
+/// cycled DOFs (all-zero C rows) and silently drop their loads, presenting
+/// partial results as final.
+#[test]
+fn circular_constraint_returns_error_not_partial_results() {
+    let l = 4.0;
+    let nodes = vec![
+        (1, 0.0, 0.0, 0.0), (2, l, 0.0, 0.0),
+        (3, 0.0, 3.0, 0.0), (4, l, 3.0, 0.0),
+    ];
+    let elems = vec![
+        (1, "frame", 1, 2, 1, 1),
+        (2, "frame", 3, 4, 1, 1),
+    ];
+    let sups = vec![(1, fixed()), (3, fixed())];
+    let loads = vec![SolverLoad3D::Nodal(SolverNodalLoad3D {
+        node_id: 2, fx: 0.0, fy: 0.0, fz: -10.0,
+        mx: 0.0, my: 0.0, mz: 0.0, bw: None,
+    })];
+
+    let mut input = make_3d_input(
+        nodes,
+        vec![(1, E, NU)],
+        vec![(1, A, IY, IZ, J)],
+        elems, sups, loads,
+    );
+
+    input.constraints.push(Constraint::EqualDOF(EqualDOFConstraint {
+        master_node: 4, slave_node: 2, dofs: vec![2],
+    }));
+    input.constraints.push(Constraint::EqualDOF(EqualDOFConstraint {
+        master_node: 2, slave_node: 4, dofs: vec![2],
+    }));
+
+    let err = linear::solve_3d(&input).unwrap_err();
+    assert!(err.contains("Invalid constraints"),
+        "circular chain must be a hard error, got: {}", err);
+}
+
 /// Self-referencing constraint: A is slave and master of itself.
 #[test]
 fn self_referencing_constraint_does_not_panic() {

--- a/engine/tests/core/diagnostics.rs
+++ b/engine/tests/core/diagnostics.rs
@@ -721,6 +721,38 @@ fn pre_solve_instability_risk_truss_no_rotation() {
 }
 
 #[test]
+fn pre_solve_instability_risk_guided_z_not_flagged() {
+    // guidedZ restrains ux + ry (see dof::is_dof_restrained_2d, where it is
+    // an alias of guidedY). A truss-only node with a guidedZ support HAS
+    // rotational restraint and must not be flagged as an instability risk.
+    // The gate used to miss "guidedZ" in its rotation-restraint list.
+    // L-shaped stable truss: node 0 guidedZ, node 1 rollerX, node 2 pinned.
+    let input = make_input(
+        vec![(0, 0.0, 0.0), (1, 6.0, 0.0), (2, 0.0, 6.0)],
+        vec![(1, 200e3, 0.3)],
+        vec![(1, 0.01, 1e-4)],
+        vec![
+            (1, "truss", 0, 1, 1, 1, false, false),
+            (2, "truss", 0, 2, 1, 1, false, false),
+        ],
+        vec![(1, 0, "guidedZ"), (2, 1, "rollerX"), (3, 2, "pinned")],
+        vec![SolverLoad::Nodal(SolverNodalLoad {
+            node_id: 1, fx: 10.0, fz: 0.0, my: 0.0,
+        })],
+    );
+    let results = solve_2d(&input).unwrap();
+
+    let flagged_nodes: std::collections::HashSet<usize> = results.structured_diagnostics.iter()
+        .filter(|d| d.code == DiagnosticCode::InstabilityRisk)
+        .flat_map(|d| d.node_ids.iter().copied())
+        .collect();
+    assert!(!flagged_nodes.contains(&0),
+        "node 0 (guidedZ — ry restrained) must not be flagged, got {:?}", flagged_nodes);
+    assert!(flagged_nodes.contains(&1),
+        "node 1 (rollerX, truss-only) should still be flagged, got {:?}", flagged_nodes);
+}
+
+#[test]
 fn pre_solve_clean_model_no_warnings() {
     // A clean 2D model with frame elements and proper supports should have
     // no pre-solve diagnostics (DisconnectedNode, NearDuplicateNodes, InstabilityRisk).

--- a/engine/tests/integration/load_cases.rs
+++ b/engine/tests/integration/load_cases.rs
@@ -442,3 +442,193 @@ fn load_cases_2d_superposition_correct() {
     assert!((uy_combo - (uy_a + uy_b)).abs() < 1e-10,
         "Superposition: {} ≈ {} + {} = {}", uy_combo, uy_a, uy_b, uy_a + uy_b);
 }
+
+
+// ==================== E2 audit: multi-case fidelity ====================
+
+/// A connector is load-independent stiffness: a multi-case solve must assemble
+/// it exactly like a single `solve_2d`. Before the E2 fix, multi-case 2D
+/// silently cleared `solver.connectors` and returned the unconnected
+/// structure's results as final.
+#[test]
+fn load_cases_2d_connectors_are_not_dropped() {
+    let mut model = make_beam_2d();
+    // Node 4 is a fixed anchor; a stiff connector ties midspan node 2 to it.
+    model.nodes.insert("4".to_string(), SolverNode { id: 4, x: 5.0, z: 2.0 });
+    model.supports.insert("4".to_string(), SolverSupport {
+        id: 4, node_id: 4, support_type: "fixed".to_string(),
+        kx: None, ky: None, kz: None,
+        dx: None, dz: None, dry: None, angle: None,
+    });
+    model.connectors.insert("1".to_string(), ConnectorElement {
+        id: 1, node_i: 2, node_j: 4,
+        k_axial: 1.0e6, k_shear: 1.0e6, k_moment: 0.0,
+        k_shear_z: 0.0, k_bend_y: 0.0, k_bend_z: 0.0,
+    });
+
+    let loads = vec![SolverLoad::Nodal(SolverNodalLoad {
+        node_id: 2, fx: 0.0, fz: -10.0, my: 0.0,
+    })];
+
+    // Reference: single-case solve with the connector present.
+    let mut reference_model = model.clone();
+    reference_model.loads = loads.clone();
+    let reference = dedaliano_engine::solver::linear::solve_2d(&reference_model).unwrap();
+    let uz_ref = reference.displacements.iter().find(|d| d.node_id == 2).unwrap().uz;
+
+    // The connector must actually change the answer, or this test pins nothing.
+    let mut bare_model = model.clone();
+    bare_model.connectors = HashMap::new();
+    bare_model.loads = loads.clone();
+    let bare = dedaliano_engine::solver::linear::solve_2d(&bare_model).unwrap();
+    let uz_bare = bare.displacements.iter().find(|d| d.node_id == 2).unwrap().uz;
+    assert!((uz_ref - uz_bare).abs() > 1e-6,
+        "connector should stiffen the model: {} vs {}", uz_ref, uz_bare);
+
+    let input = MultiCaseInput {
+        solver: model,
+        load_cases: vec![LoadCase { name: "D".to_string(), loads }],
+        combinations: vec![CombinationDef {
+            name: "1.0D".to_string(),
+            factors: { let mut m = HashMap::new(); m.insert("D".to_string(), 1.0); m },
+        }],
+    };
+    let result = solve_multi_case_2d(&input).unwrap();
+    let uz_mc = result.case_results[0].results.displacements
+        .iter().find(|d| d.node_id == 2).unwrap().uz;
+    assert!((uz_mc - uz_ref).abs() < 1e-10,
+        "multi-case dropped the connector: {} vs reference {}", uz_mc, uz_ref);
+}
+
+/// Same contract for 3D: connectors survive multi-case preparation.
+#[test]
+fn load_cases_3d_connectors_are_not_dropped() {
+    let mut model = make_beam_3d();
+    model.nodes.insert("4".to_string(), SolverNode3D { id: 4, x: 5.0, y: 2.0, z: 0.0 });
+    model.supports.insert("4".to_string(), SolverSupport3D {
+        node_id: 4,
+        rx: true, ry: true, rz: true, rrx: true, rry: true, rrz: true,
+        kx: None, ky: None, kz: None, krx: None, kry: None, krz: None,
+        dx: None, dy: None, dz: None, drx: None, dry: None, drz: None,
+        rw: None, kw: None,
+        normal_x: None, normal_y: None, normal_z: None, is_inclined: None,
+    });
+    model.connectors.insert("1".to_string(), ConnectorElement {
+        id: 1, node_i: 2, node_j: 4,
+        k_axial: 1.0e6, k_shear: 1.0e6, k_moment: 0.0,
+        k_shear_z: 1.0e6, k_bend_y: 0.0, k_bend_z: 0.0,
+    });
+
+    let loads = vec![SolverLoad3D::Nodal(SolverNodalLoad3D {
+        node_id: 2, fx: 0.0, fy: -10.0, fz: 0.0,
+        mx: 0.0, my: 0.0, mz: 0.0, bw: None,
+    })];
+
+    let mut reference_model = model.clone();
+    reference_model.loads = loads.clone();
+    let reference = dedaliano_engine::solver::linear::solve_3d(&reference_model).unwrap();
+    let uy_ref = reference.displacements.iter().find(|d| d.node_id == 2).unwrap().uy;
+
+    let mut bare_model = model.clone();
+    bare_model.connectors = HashMap::new();
+    bare_model.loads = loads.clone();
+    let bare = dedaliano_engine::solver::linear::solve_3d(&bare_model).unwrap();
+    let uy_bare = bare.displacements.iter().find(|d| d.node_id == 2).unwrap().uy;
+    assert!((uy_ref - uy_bare).abs() > 1e-6,
+        "connector should stiffen the model: {} vs {}", uy_ref, uy_bare);
+
+    let input = MultiCaseInput3D {
+        solver: model,
+        load_cases: vec![LoadCase3D { name: "D".to_string(), loads }],
+        combinations: vec![CombinationDef {
+            name: "1.0D".to_string(),
+            factors: { let mut m = HashMap::new(); m.insert("D".to_string(), 1.0); m },
+        }],
+    };
+    let result = solve_multi_case_3d(&input).unwrap();
+    let uy_mc = result.case_results[0].results.displacements
+        .iter().find(|d| d.node_id == 2).unwrap().uy;
+    assert!((uy_mc - uy_ref).abs() < 1e-9,
+        "multi-case dropped the connector: {} vs reference {}", uy_mc, uy_ref);
+}
+
+/// Constraints in multi-case 2D must delegate to the constrained solver per
+/// case (mirroring 3D) instead of being silently cleared.
+#[test]
+fn load_cases_2d_constraints_delegate_per_case() {
+    let mut model = make_beam_2d();
+    // Tie the rotations of nodes 2 and 3 together.
+    model.constraints.push(Constraint::EqualDOF(EqualDOFConstraint {
+        master_node: 2, slave_node: 3, dofs: vec![2],
+    }));
+
+    let loads = vec![SolverLoad::Nodal(SolverNodalLoad {
+        node_id: 2, fx: 0.0, fz: -10.0, my: 0.0,
+    })];
+
+    let mut reference_model = model.clone();
+    reference_model.loads = loads.clone();
+    let reference = dedaliano_engine::solver::linear::solve_2d(&reference_model).unwrap();
+    let ry_ref = reference.displacements.iter().find(|d| d.node_id == 3).unwrap().ry;
+    // The constraint must bite, or this test pins nothing.
+    let ry2_ref = reference.displacements.iter().find(|d| d.node_id == 2).unwrap().ry;
+    assert!((ry_ref - ry2_ref).abs() < 1e-10,
+        "EqualDOF should couple rotations: {} vs {}", ry_ref, ry2_ref);
+
+    let input = MultiCaseInput {
+        solver: model,
+        load_cases: vec![LoadCase { name: "D".to_string(), loads }],
+        combinations: vec![CombinationDef {
+            name: "1.0D".to_string(),
+            factors: { let mut m = HashMap::new(); m.insert("D".to_string(), 1.0); m },
+        }],
+    };
+    let result = solve_multi_case_2d(&input).unwrap();
+    let ry_mc = result.case_results[0].results.displacements
+        .iter().find(|d| d.node_id == 3).unwrap().ry;
+    assert!((ry_mc - ry_ref).abs() < 1e-10,
+        "multi-case dropped the constraint: {} vs reference {}", ry_mc, ry_ref);
+}
+
+/// A combination that references a non-existent load case must fail loudly
+/// instead of silently producing a combination without that case.
+#[test]
+fn load_cases_unknown_case_name_errors() {
+    let input = MultiCaseInput {
+        solver: make_beam_2d(),
+        load_cases: vec![LoadCase {
+            name: "Dead".to_string(),
+            loads: vec![SolverLoad::Nodal(SolverNodalLoad {
+                node_id: 2, fx: 0.0, fz: -10.0, my: 0.0,
+            })],
+        }],
+        combinations: vec![CombinationDef {
+            name: "TypoCombo".to_string(),
+            factors: { let mut m = HashMap::new(); m.insert("Ded".to_string(), 1.2); m },
+        }],
+    };
+    let err = solve_multi_case_2d(&input).unwrap_err();
+    assert!(err.contains("TypoCombo") && err.contains("Ded"),
+        "error should name the combo and the unknown case: {}", err);
+}
+
+#[test]
+fn load_cases_3d_unknown_case_name_errors() {
+    let input = MultiCaseInput3D {
+        solver: make_beam_3d(),
+        load_cases: vec![LoadCase3D {
+            name: "Dead".to_string(),
+            loads: vec![SolverLoad3D::Nodal(SolverNodalLoad3D {
+                node_id: 2, fx: 0.0, fy: -10.0, fz: 0.0,
+                mx: 0.0, my: 0.0, mz: 0.0, bw: None,
+            })],
+        }],
+        combinations: vec![CombinationDef {
+            name: "TypoCombo".to_string(),
+            factors: { let mut m = HashMap::new(); m.insert("Ded".to_string(), 1.2); m },
+        }],
+    };
+    let err = solve_multi_case_3d(&input).unwrap_err();
+    assert!(err.contains("TypoCombo") && err.contains("Ded"),
+        "error should name the combo and the unknown case: {}", err);
+}

--- a/engine/tests/integration/load_cases.rs
+++ b/engine/tests/integration/load_cases.rs
@@ -632,3 +632,50 @@ fn load_cases_3d_unknown_case_name_errors() {
     assert!(err.contains("TypoCombo") && err.contains("Ded"),
         "error should name the combo and the unknown case: {}", err);
 }
+
+
+#[test]
+fn load_cases_duplicate_case_name_errors() {
+    // Two cases named "Dead": case_map keeps only the LAST one, so a
+    // combination factor on "Dead" silently drops the first case's
+    // contribution. Reject the ambiguous input instead.
+    let case = |fz: f64| LoadCase {
+        name: "Dead".to_string(),
+        loads: vec![SolverLoad::Nodal(SolverNodalLoad {
+            node_id: 2, fx: 0.0, fz, my: 0.0,
+        })],
+    };
+    let input = MultiCaseInput {
+        solver: make_beam_2d(),
+        load_cases: vec![case(-10.0), case(-20.0)],
+        combinations: vec![CombinationDef {
+            name: "Combo".to_string(),
+            factors: { let mut m = HashMap::new(); m.insert("Dead".to_string(), 1.2); m },
+        }],
+    };
+    let err = solve_multi_case_2d(&input).unwrap_err();
+    assert!(err.contains("Dead") && err.contains("Duplicate"),
+        "error should name the duplicated case: {}", err);
+}
+
+#[test]
+fn load_cases_3d_duplicate_case_name_errors() {
+    let case = |fy: f64| LoadCase3D {
+        name: "Dead".to_string(),
+        loads: vec![SolverLoad3D::Nodal(SolverNodalLoad3D {
+            node_id: 2, fx: 0.0, fy, fz: 0.0,
+            mx: 0.0, my: 0.0, mz: 0.0, bw: None,
+        })],
+    };
+    let input = MultiCaseInput3D {
+        solver: make_beam_3d(),
+        load_cases: vec![case(-10.0), case(-20.0)],
+        combinations: vec![CombinationDef {
+            name: "Combo".to_string(),
+            factors: { let mut m = HashMap::new(); m.insert("Dead".to_string(), 1.2); m },
+        }],
+    };
+    let err = solve_multi_case_3d(&input).unwrap_err();
+    assert!(err.contains("Dead") && err.contains("Duplicate"),
+        "error should name the duplicated case: {}", err);
+}

--- a/engine/tests/validation/domains/solver/reduction.rs
+++ b/engine/tests/validation/domains/solver/reduction.rs
@@ -564,3 +564,33 @@ fn test_guyan_reactions_match_linear() {
         );
     }
 }
+
+
+// ---------------------------------------------------------------------------
+// Test 9: Guyan with prescribed support displacements must error, not silently
+// ignore them (u_r is hardcoded to zero in the reduction recovery path)
+// ---------------------------------------------------------------------------
+#[test]
+fn test_guyan_prescribed_displacement_is_rejected() {
+    let mut solver = five_node_cantilever();
+    // Prescribe a support rotation at the fixed end. The linear solver couples
+    // this into the solve via F_f -= K_fr * u_r; Guyan has no such coupling and
+    // used to silently produce results as if the support had not moved.
+    for sup in solver.supports.values_mut() {
+        sup.dry = Some(0.01);
+    }
+
+    // Sanity: the linear solver DOES account for the prescribed rotation.
+    let linear_result = linear::solve_2d(&solver).unwrap();
+    let tip = linear_result.displacements.iter()
+        .find(|d| d.node_id == 5).unwrap();
+    assert!(tip.uz.abs() > 1e-6, "prescribed rotation should move the tip");
+
+    let guyan_input = GuyanInput {
+        solver,
+        boundary_nodes: vec![3],
+    };
+    let err = guyan_reduce_2d(&guyan_input)
+        .expect_err("Guyan with prescribed displacements must be rejected");
+    assert!(err.contains("prescribed"), "error should mention prescribed displacements, got: {}", err);
+}

--- a/engine/tests/validation/three_d/three_d_inclined_supports.rs
+++ b/engine/tests/validation/three_d/three_d_inclined_supports.rs
@@ -437,3 +437,75 @@ fn validation_inclined_support_equilibrium_summary_correct() {
         "Equilibrium imbalance should be near zero, got {:.6e}", eq.max_imbalance
     );
 }
+
+// ================================================================
+// Inclined support with prescribed displacement (settlement)
+// ================================================================
+//
+// Prescribed translations are given in GLOBAL axes (same convention as the
+// 2D inclinedRoller path), but the restrained inclined DOF lives in the
+// rotated frame. prepare_static_3d must project (dx, dy, dz) onto the
+// support normal; before the fix it assigned raw dx to the normal slot.
+
+#[test]
+fn validation_inclined_support_prescribed_global_settlement() {
+    // Beam 1→2 along X. Node 2 fully fixed. Node 1: inclined support with
+    // normal 45° in the XZ plane, rotations restrained, prescribed
+    // dx = dz = δ (global). The normal-direction displacement at node 1
+    // must equal e1·(δ, 0, δ) = δ√2.
+    let sqrt2_inv = std::f64::consts::FRAC_1_SQRT_2;
+    let delta = 0.001;
+
+    let mut nodes_map = HashMap::new();
+    nodes_map.insert("1".to_string(), SolverNode3D { id: 1, x: 0.0, y: 0.0, z: 0.0 });
+    nodes_map.insert("2".to_string(), SolverNode3D { id: 2, x: L, y: 0.0, z: 0.0 });
+
+    let mut materials = HashMap::new();
+    materials.insert("1".to_string(), SolverMaterial { id: 1, e: E, nu: NU });
+
+    let mut sections = HashMap::new();
+    sections.insert("1".to_string(), SolverSection3D {
+        id: 1, name: None, a: A, iy: IY, iz: IZ, j: J,
+        cw: None, as_y: None, as_z: None,
+    });
+
+    let mut elements = HashMap::new();
+    elements.insert("1".to_string(), SolverElement3D {
+        id: 1, elem_type: "frame".to_string(), node_i: 1, node_j: 2,
+        material_id: 1, section_id: 1,
+        release_my_start: false, release_my_end: false,
+        release_mz_start: false, release_mz_end: false,
+        release_t_start: false, release_t_end: false,
+        local_yx: None, local_yy: None, local_yz: None, roll_angle: None,
+    });
+
+    let mut sup1 = make_inclined_support(1, sqrt2_inv, 0.0, sqrt2_inv);
+    sup1.rrx = true; sup1.rry = true; sup1.rrz = true;
+    sup1.dx = Some(delta);
+    sup1.dz = Some(delta);
+
+    let mut supports = HashMap::new();
+    supports.insert("1".to_string(), sup1);
+    supports.insert("2".to_string(), make_fixed_3d(2));
+
+    let input = SolverInput3D {
+        nodes: nodes_map, materials, sections, elements, supports,
+        loads: vec![], constraints: vec![], left_hand: None,
+        plates: HashMap::new(), quads: HashMap::new(), quad9s: HashMap::new(),
+        solid_shells: HashMap::new(), curved_beams: vec![],
+        curved_shells: HashMap::new(), connectors: HashMap::new(),
+    };
+
+    let res = linear::solve_3d(&input).unwrap();
+    let d1 = res.displacements.iter().find(|d| d.node_id == 1).unwrap();
+
+    // The prescribed DOF is the normal-direction displacement.
+    let u_normal = sqrt2_inv * d1.ux + sqrt2_inv * d1.uz;
+    let expected = delta * 2.0 * sqrt2_inv; // e1·(δ, 0, δ)
+    assert!(
+        (u_normal - expected).abs() < 1e-9,
+        "inclined prescribed settlement: normal disp {} expected {} \
+         (raw-dx bug would give {})",
+        u_normal, expected, delta
+    );
+}

--- a/engine/tests/validation/three_d/three_d_supports.rs
+++ b/engine/tests/validation/three_d/three_d_supports.rs
@@ -505,3 +505,53 @@ fn validation_3d_combined_springs() {
         drift_spring, drift_fixed, drift_pinned
     );
 }
+
+// ================================================================
+// 8. Flag + spring on the same DOF: reaction must report the spring force
+// ================================================================
+//
+// DofNumbering gives springs precedence over restraint flags (a DOF with
+// k > 0 is free with added stiffness). build_reactions_3d used to consult
+// the flag on free DOFs, reporting 0 for a real spring force.
+
+#[test]
+fn validation_3d_flag_plus_spring_reaction() {
+    // Beam 1→2 along X. Node 1: all DOFs restrained by flags, but ux ALSO
+    // has a translational spring kx — so ux is an elastic (free) DOF.
+    // Axial load at node 2: the spring force must appear as the reaction.
+    let k_spring = 1.0e4; // kN/m
+    let f_axial = 100.0;  // kN
+
+    let nodes = vec![(1, 0.0, 0.0, 0.0), (2, 5.0, 0.0, 0.0)];
+    let elems = vec![(1, "frame", 1, 2, 1, 1)];
+    let sups = vec![(1, vec![true, true, true, true, true, true])];
+    let loads = vec![SolverLoad3D::Nodal(SolverNodalLoad3D {
+        node_id: 2, fx: f_axial, fy: 0.0, fz: 0.0,
+        mx: 0.0, my: 0.0, mz: 0.0, bw: None,
+    })];
+
+    let mut input = make_3d_input(
+        nodes, vec![(1, E, NU)], vec![(1, A, IY, IZ, J)],
+        elems, sups, loads,
+    );
+    for sup in input.supports.values_mut() {
+        sup.kx = Some(k_spring);
+    }
+
+    let res = linear::solve_3d(&input).unwrap();
+
+    // Sanity: node 1 ux is the spring deflection F/k (series: spring carries
+    // the full axial load), node 2 adds the beam elongation.
+    let ux1 = res.displacements.iter().find(|d| d.node_id == 1).unwrap().ux;
+    assert_close(ux1, f_axial / k_spring, 1e-6, "spring deflection at node 1");
+
+    // The reaction must be the spring force -k·u (≈ -F), not zero.
+    let r1 = res.reactions.iter().find(|r| r.node_id == 1).unwrap();
+    assert!(
+        r1.fx.abs() > 1.0,
+        "flag+spring DOF reported zero reaction (spring force lost): fx={}",
+        r1.fx
+    );
+    assert_close(r1.fx, -k_spring * ux1, 1e-6, "spring reaction at node 1");
+    assert_close(r1.fx, -f_axial, 1e-6, "reaction balances applied load");
+}

--- a/web/src/components/pro/ProAdvancedTab.svelte
+++ b/web/src/components/pro/ProAdvancedTab.svelte
@@ -31,6 +31,10 @@
     solveConstrained3D,
   } from '../../lib/engine/wasm-solver';
   import { buildSolverInput3D } from '../../lib/engine/solver-service';
+  // Every solver below is a WASM export that throws a bare string, which has no
+  // `.message`. Reading it with `e.message` reported "Error" for every engine
+  // refusal and discarded the sentence the solver wrote.
+  import { errorText } from '../../lib/utils/error-text';
   import { cirsoc103Spectrum } from '../../lib/engine/result-types';
   import type { DesignSpectrum } from '../../lib/engine/result-types';
   import { applyRigidDiaphragm, detectFloorLevels } from '../../lib/engine/rigid-diaphragm';
@@ -143,7 +147,7 @@
       }
       advancedResults = { ...advancedResults, pdelta: { converged: res.converged, iterations: res.iterations, b2Factor: res.b2Factor } };
     } catch (e: any) {
-      solveError = `P-Delta: ${e.message ?? 'Error'}`;
+      solveError = `P-Delta: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -190,7 +194,7 @@
         advancedResults = { ...advancedResults, modal: { modes, totalMass: res.totalMass } };
       }
     } catch (e: any) {
-      solveError = `Modal: ${e.message ?? 'Error'}`;
+      solveError = `Modal: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -228,7 +232,7 @@
       spectralResult = res;
       advancedResults = { ...advancedResults, spectral: { baseShearX: res.baseShearX ?? res.baseShear, baseShearY: res.baseShearY, baseShearZ: res.baseShearZ } };
     } catch (e: any) {
-      solveError = `Espectral: ${e.message ?? 'Error'}`;
+      solveError = `Espectral: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -255,7 +259,7 @@
       const factors = res.factors ?? res.eigenvalues ?? (res.modes?.map((m: any) => m.loadFactor ?? m.factor ?? m.eigenvalue) ?? []);
       advancedResults = { ...advancedResults, buckling: { factors } };
     } catch (e: any) {
-      solveError = `Buckling: ${e.message ?? 'Error'}`;
+      solveError = `Buckling: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -318,7 +322,7 @@
       });
       thResult = res;
     } catch (e: any) {
-      solveError = `Time History: ${e.message ?? 'Error'}`;
+      solveError = `Time History: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -357,7 +361,7 @@
       harmonicElapsed = elapsed;
       harmResult = res;
     } catch (e: any) {
-      solveError = `Harmónico: ${e.message ?? 'Error'}`;
+      solveError = `Harmónico: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -425,7 +429,7 @@
         });
       }
     } catch (e: any) {
-      solveError = `No lineal: ${e.message ?? 'Error'}`;
+      solveError = `No lineal: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -450,7 +454,7 @@
         nIncrements: arcIncrements,
       });
     } catch (e: any) {
-      solveError = `Arc-Length: ${e.message ?? 'Error'}`;
+      solveError = `Arc-Length: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -477,7 +481,7 @@
         nIncrements: dcIncrements,
       });
     } catch (e: any) {
-      solveError = `Disp. Control: ${e.message ?? 'Error'}`;
+      solveError = `Disp. Control: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -500,7 +504,7 @@
         amplitude: imperfAmplitude,
       });
     } catch (e: any) {
-      solveError = `Imperfecciones: ${e.message ?? 'Error'}`;
+      solveError = `Imperfecciones: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -538,7 +542,7 @@
       winklerResult = res;
       if (res.results) resultsStore.setResults3D(res.results);
     } catch (e: any) {
-      solveError = `Winkler: ${e.message ?? 'Error'}`;
+      solveError = `Winkler: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -588,7 +592,7 @@
       ssiResult = res;
       if (res.results) resultsStore.setResults3D(res.results);
     } catch (e: any) {
-      solveError = `SSI: ${e.message ?? 'Error'}`;
+      solveError = `SSI: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -628,7 +632,7 @@
       contactResult = res;
       if (res.results) resultsStore.setResults3D(res.results);
     } catch (e: any) {
-      solveError = `Contacto: ${e.message ?? 'Error'}`;
+      solveError = `Contacto: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -658,7 +662,7 @@
       stagedResult = res;
       if (res.results) resultsStore.setResults3D(res.results);
     } catch (e: any) {
-      solveError = `Etapas: ${e.message ?? 'Error'}`;
+      solveError = `Etapas: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -695,7 +699,7 @@
         timeSteps: creepTimeSteps,
       });
     } catch (e: any) {
-      solveError = `Fluencia: ${e.message ?? 'Error'}`;
+      solveError = `Fluencia: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -715,7 +719,7 @@
       if (!input) { solveError = t('advanced.emptyModel'); solving = false; return; }
       cableResult = solveCable2D(input, cableMaxIter, cableTol);
     } catch (e: any) {
-      solveError = `Cable: ${e.message ?? 'Error'}`;
+      solveError = `Cable: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -738,7 +742,7 @@
         responseType: ilResponse,
       });
     } catch (e: any) {
-      solveError = `Influence Line 3D: ${e.message ?? 'Error'}`;
+      solveError = `Influence Line 3D: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -769,7 +773,7 @@
         reductionResult = craigBampton2D({ solver: input, retainedDofs: retained, numModes: numCBModes });
       }
     } catch (e: any) {
-      solveError = `Model Reduction: ${e.message ?? 'Error'}`;
+      solveError = `Model Reduction: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -799,7 +803,7 @@
         multiCaseResult = solveMultiCase2D({ solver: input2D, caseIds: cases.map(c => c.id) });
       }
     } catch (e: any) {
-      solveError = `Multi-Case: ${e.message ?? 'Error'}`;
+      solveError = `Multi-Case: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }
@@ -838,7 +842,7 @@
       }
       secResult = analyzeSection(geometry);
     } catch (e: any) {
-      solveError = `Section: ${e.message ?? 'Error'}`;
+      solveError = `Section: ${errorText(e, 'Error')}`;
     }
   }
 
@@ -877,7 +881,7 @@
         is3DMode ? resultsStore.setResults3D(res.results) : resultsStore.setResults(res.results);
       }
     } catch (e: any) {
-      solveError = `Constrained: ${e.message ?? 'Error'}`;
+      solveError = `Constrained: ${errorText(e, 'Error')}`;
     }
     solving = false;
   }

--- a/web/src/lib/utils/__tests__/error-text.test.ts
+++ b/web/src/lib/utils/__tests__/error-text.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Reading a thrown value, including the ones WASM throws.
+ *
+ * Every `#[wasm_bindgen]` export in this engine returns `Result<String, JsValue>`
+ * and builds its error with `JsValue::from_str`. wasm-bindgen throws that value
+ * as-is, so what reaches a `catch` is a JS STRING PRIMITIVE, not an Error — and a
+ * string has no `.message`. Code written as `e.message ?? 'Error'` therefore
+ * reports the fallback for every engine refusal, discarding the sentence the
+ * solver went to the trouble of writing.
+ *
+ * That is what these tests pin: the string case first, because it is the one the
+ * engine actually produces.
+ */
+import { describe, it, expect } from 'vitest';
+import { errorText } from '../error-text';
+
+describe('the text of a thrown value', () => {
+  it('returns a thrown string verbatim — the shape WASM throws', () => {
+    expect(errorText('Guyan reduction does not support prescribed support displacements (node 3)', 'fallback'))
+      .toBe('Guyan reduction does not support prescribed support displacements (node 3)');
+  });
+
+  it('reads .message from a real Error', () => {
+    expect(errorText(new Error('boom'), 'fallback')).toBe('boom');
+  });
+
+  it('falls back when the thrown value carries no text', () => {
+    expect(errorText(null, 'fallback')).toBe('fallback');
+    expect(errorText(undefined, 'fallback')).toBe('fallback');
+    expect(errorText({}, 'fallback')).toBe('fallback');
+  });
+
+  it('treats blank text as absent rather than reporting an empty line', () => {
+    expect(errorText('   ', 'fallback')).toBe('fallback');
+    expect(errorText(new Error('  '), 'fallback')).toBe('fallback');
+  });
+
+  it('does not invent text for a non-string, non-Error value', () => {
+    // `String(42)` would read as an error message; it is not one.
+    expect(errorText(42, 'fallback')).toBe('fallback');
+  });
+});

--- a/web/src/lib/utils/error-text.ts
+++ b/web/src/lib/utils/error-text.ts
@@ -1,0 +1,24 @@
+/**
+ * The readable text of a thrown value.
+ *
+ * Written for the shape the engine throws. Every `#[wasm_bindgen]` export in
+ * `engine/src/lib.rs` returns `Result<String, JsValue>` and builds its error with
+ * `JsValue::from_str` — 76 exports, 216 such sites. wasm-bindgen throws that value
+ * as-is, so a `catch` receives a JS STRING PRIMITIVE rather than an `Error`, and a
+ * string has no `.message`.
+ *
+ * `e.message ?? fallback` therefore reports the fallback for every refusal the
+ * solver writes, which is how "Guyan reduction does not support prescribed support
+ * displacements (node 3)" reached the user as "Model Reduction: Error". The string
+ * branch is checked FIRST because it is the case that actually occurs.
+ *
+ * A non-string, non-Error value returns the fallback rather than `String(value)`:
+ * stringifying `42` or `[object Object]` into an error panel presents noise as if
+ * it were the engine's explanation.
+ */
+export function errorText(e: unknown, fallback: string): string {
+  if (typeof e === 'string') return e.trim() ? e : fallback;
+  const message = (e as { message?: unknown } | null | undefined)?.message;
+  if (typeof message === 'string' && message.trim()) return message;
+  return fallback;
+}


### PR DESCRIPTION
# Audit E2 — linear solver core: correctness fixes

Section E2 (`engine/src/solver/{linear,assembly,sparse_assembly,dof,load_cases,constraints,reduction,pre_solve_gates}.rs`) audit per `docs/AUDIT_PLAN.md`. Nine commits, each a correctness fix with a failing-before/passing-after test, plus one comment-only hygiene commit.

## Findings and fixes

### High

1. **Guyan reduction silently ignored prescribed support displacements** — `engine/src/solver/reduction.rs:145,595`. `guyan_reduce_2d/3d` hardcode `u_r = 0` in the recovery/reaction paths, so a model with prescribed support displacements solved as if the supports had not moved: wrong displacements, reactions, and element forces, no error or warning. Verified empirically: prescribed fixed-end rotation of 0.01 rad produced results identical to the zero-settlement model (node 1 `ry` reported as 0.0). Both entry points now return an error naming the offending node. Craig-Bampton is unaffected (reduces K/M only). → `1cfc6a82`

2. **Circular constraint chains returned partial results as final** — `engine/src/solver/constraints.rs` (solve_constrained_2d/3d). An EqualDOF cycle (A→B→A) leaves the cycled DOFs with all-zero C rows, silently dropping their stiffness AND loads from the reduced system. Error-severity constraint diagnostics now abort the solve. → `1523da17`

### Medium

3. **Multi-case 2D solve dropped constraints and connectors; unknown combination case names silently dropped** — `engine/src/solver/load_cases.rs`. The prepared multi-case path cleared `constraints` and `connectors` from the model; a combination referencing a nonexistent case name silently omitted that case's contribution from combined results and the envelope. Constraints now delegate to the per-case constrained solver, connectors stay assembled, and unknown case names are a hard error. → `9da18999`

4. **Duplicate load case names silently shadowed** — `engine/src/solver/load_cases.rs:95`. `case_map` keeps only the LAST case with a given name, so two cases named e.g. "Dead" meant every combination on "Dead" used only the last one — the earlier case was solved and displayed but its contribution dropped from combinations and envelope. Now rejected alongside unknown names. → `e2e6af69`

5. **Sparse 2D assemblers ignored Timoshenko shear deformation (`as_y`)** — `engine/src/solver/assembly.rs:1907`, `engine/src/solver/sparse_assembly.rs:153,704`. The sparse/triplet 2D stiffness paths hardcoded `phi = 0` (Euler-Bernoulli) while the fixed-end-force builder in the same function computed phi from `as_y` — pairing EB stiffness with Timoshenko FEFs, ~13% error on the bending diagonal for a typical section. All sparse 2D assemblers now compute phi exactly like the dense path; new test asserts sparse K_ff matches dense bit-for-bit (1e-9 relative) on a Timoshenko cantilever. → `cad9356c`

6. **Instability-risk gate falsely flagged guidedZ supports** — `engine/src/solver/pre_solve_gates.rs:235`. `guidedZ` is a 2D alias of `guidedY` in `dof::is_dof_restrained_2d` (ux+ry restrained), but the gate's rotation-restraint list only matched `fixed|guidedX|guidedY`, so a truss-only node with a guidedZ support was flagged InstabilityRisk despite having rotational restraint. Sibling enumerations in assembly.rs/sparse_assembly.rs (artificial stiffness for all-hinged nodes) also omit guidedZ but are provably unreachable: a guidedZ node's ry DOF is restrained, so its equation index is ≥ n_free and the block skips it regardless. → `5943e410`

### Low

7. **3D reactions reported zero on DOFs with both a restraint flag and spring stiffness** — `engine/src/solver/linear.rs:2519`. `DofNumbering` gives springs precedence (flag+k ⇒ free DOF with added stiffness), but `build_reactions_3d` consulted the flag on the free branch and reported 0 while the spring force was real. The flag check is removed; the free branch reports −k·u. → `ba6b415b`

8. **Prescribed displacements on inclined supports not rotated into the inclined frame** — `engine/src/solver/linear.rs:1300` (3D), `engine/src/solver/constraints.rs:777,1097` (2D+3D constrained). Prescribed translations are given in GLOBAL axes but the restrained inclined DOF lives in the rotated frame; the raw `dx` was assigned to the normal slot instead of the projection onto the normal. Both constrained paths and the 3D prepared path now rotate, mirroring `prepare_static_2d`'s inclinedRoller handling; parity tests pin constrained vs unconstrained results. → `068b4933`

9. **Comment-only:** `dof.rs` multi-support sort comment said "descending" where the code sorts ascending (behavior was already correct and matches the described outcome). → `b7ce1109`

## Deferred / questions (not fixed)

- `dof.rs`: 2D ("highest support ID wins") vs 3D ("OR-merge flags") multi-support semantics diverge. Both are documented and self-consistent; changing 2D would alter solver numbers, so deferred.
- `dof.rs:116`: an inclined support on a node that ALSO has a regular support bypasses the merged-flags path (only the winning support is consulted). Exotic; no failing case constructed.
- `dof.rs:78` vs assemblers: `has_warping` uses `cw.is_some()` while element assembly uses `cw > 0.0`. A section with `cw = Some(0.0)` gives 7 DOFs/node with zero stiffness on DOF 6 → hard singularity error (loud, not silent). Deferred.
- Guyan + constraints where a master/slave pair spans the boundary/interior partition: static condensation is exact regardless of partition; worst case is a singular K_II (loud error). No failing case constructed.

## Out-of-section findings (for other audit sections, NOT fixed here)

- `engine/src/solver/kinematic.rs:41` (`count_support_restraints_2d`) misses `guidedZ` (counts r=0, has_rot=false) and `rollerZ` (counts r=0 instead of 1) — static-degree/kinematic diagnostics wrong for those supports.
- `engine/src/solver/kinematic.rs:231` — same instability-risk-style rotation-restraint list missing `guidedZ` (sibling of finding 6).
- `engine/src/solver/material_nonlinear.rs:462` — same artificial-stiffness support enumeration missing `guidedZ`; likely unreachable by the same argument as finding 6 but not verified.

## Verification

- `cargo test -p dedaliano-engine`: all 28 targets pass, 0 failures (7,068 tests total incl. the 4,730-test validation target), `EXIT=0`.
- WASM rebuilt: `cd web && npm run wasm` (wasm-pack 0.14.0, release profile) — success.
- `cd web && npm test`: **green**. Unit pass: 5,242 passed / 1 failed / 12 skipped / 1 todo (273 files passed); build pass: 8/8. The single failure was the known flake `outline.test.ts` ("every geometry-backed profile stays inside the shared viewBox") timing out at its 5 s budget under CPU contention (the test takes ~1.7 s uncontended; engine suite + wasm build were running concurrently). Re-run standalone: **18/18 pass in 2.35 s**. The test is pure frontend section-geometry code, untouched by this branch.

Every fix has a test that fails before and passes after; no existing test was weakened, widened, or ignored.


---

## Result impact — read before merging

Two of these fixes change the numbers existing models produce. Neither is a
regression; both replace a wrong answer with a right one, but a user comparing
against a previous run will see the difference and should be told why.

- **Finding 5 (sparse `phi`)** is the big one. Every **2D model with `as_y` set
  that solves through the sparse path** changes: the bending diagonal was off by
  roughly **13 %** for a typical section, because Euler-Bernoulli stiffness was
  paired with Timoshenko fixed-end forces inside the same function. Displacements
  and element forces move accordingly. Worth noting that no existing test failed
  when this was corrected — that path had no dense-vs-sparse equivalence test at
  all, which is what the new one adds.
- **Finding 8 (inclined prescribed displacements)** changes results for models
  that prescribe a settlement on an inclined support, which is a much narrower
  set.

Three more fixes turn a silently wrong result into a hard error, so models that
previously "solved" will now refuse:

- Guyan reduction with prescribed support displacements (reachable from the Pro
  Advanced tab).
- A combination naming a load case that does not exist.
- Two load cases sharing a name.

The last one deserves a note: `CombinationDef.factors` is keyed by case NAME, so
two cases called "Dead" are genuinely ambiguous and there is no correct factor to
apply. The web layer sidesteps this by solving per case by ID and combining in
JS — see `solver-service-combos-2d.test.ts`, "duplicate case names stay correct
(id-keyed per-case path)". The two layers therefore now disagree about whether
duplicate names are legal. Nothing breaks today because the paths do not meet,
but anything that routes web combinations through the engine's multi-case entry
point (the batching work, for instance) would hit this.

## Follow-up commit: the Advanced tab was discarding these messages

Adding the Guyan guard exposed something wider. Every `#[wasm_bindgen]` export
returns `Result<String, JsValue>` built with `JsValue::from_str` — 76 exports,
216 sites — and wasm-bindgen throws that value as-is, so a `catch` receives a
string primitive with no `.message`.

`ProAdvancedTab.svelte` read all of them as `e.message ?? 'Error'`, in **21
places**: P-Delta, Modal, Spectral, Buckling, Time History, Harmonic, nonlinear,
Arc-Length, Winkler, SSI, Contact, Staged, Creep, Cable, Influence Line, Model
Reduction, Multi-Case, Section. Every engine refusal in that tab reached the user
as the literal word "Error".

So the new Guyan message arrived as "Model Reduction: Error" — barely better than
the silent wrong answer the guard replaced. Fixed with a shared `errorText`
helper (5 unit tests, string branch checked first because it is the case that
occurs). `ToolbarAdvanced.svelte` already handled this correctly with a local
copy; ProAdvancedTab was the outlier.
