### PR TITLE
fix(engine): E3 audit — sparse linalg: dense fallback for indefinite shift-invert, remove dead perturbation path

### DIFF
--- a/engine/src/linalg/lanczos.rs
+++ b/engine/src/linalg/lanczos.rs
@@ -537,37 +537,40 @@ pub fn lanczos_generalized_eigen(
         return Some(EigenResult { values, vectors });
     }
 
-    // Build shift-invert operator
-    let si_op = ShiftInvertOp::new(a, b, n, sigma)?;
-    let params = LanczosParams {
-        max_iter: 300,
-        tol: 1e-10,
-        subspace_dim: Some((4 * k).max(40).min(n)),
-    };
+    // Build shift-invert operator. Cholesky of (A − σB) fails when the shift
+    // moves past the smallest eigenvalue (A − σB indefinite); fall through to
+    // the dense path in that case, as documented, instead of returning None.
+    if let Some(si_op) = ShiftInvertOp::new(a, b, n, sigma) {
+        let params = LanczosParams {
+            max_iter: 300,
+            tol: 1e-10,
+            subspace_dim: Some((4 * k).max(40).min(n)),
+        };
 
-    if let Some(mut result) = lanczos_irlm(&si_op, k, true, &params) {
-        // Back-transform: λ = 1/θ + σ
-        for val in result.values.iter_mut() {
-            if val.abs() > 1e-30 {
-                *val = 1.0 / *val + sigma;
-            } else {
-                *val = f64::INFINITY;
+        if let Some(mut result) = lanczos_irlm(&si_op, k, true, &params) {
+            // Back-transform: λ = 1/θ + σ
+            for val in result.values.iter_mut() {
+                if val.abs() > 1e-30 {
+                    *val = 1.0 / *val + sigma;
+                } else {
+                    *val = f64::INFINITY;
+                }
             }
-        }
-        // Sort by ascending eigenvalue
-        let nk = result.values.len();
-        let mut pairs: Vec<(f64, usize)> = result.values.iter().copied().enumerate().map(|(i, v)| (v, i)).collect();
-        pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-        let sorted_vals: Vec<f64> = pairs.iter().map(|(v, _)| *v).collect();
-        let mut sorted_vecs = vec![0.0; n * nk];
-        for (new_col, &(_, old_col)) in pairs.iter().enumerate() {
-            for row in 0..n {
-                sorted_vecs[row * nk + new_col] = result.vectors[row * nk + old_col];
+            // Sort by ascending eigenvalue
+            let nk = result.values.len();
+            let mut pairs: Vec<(f64, usize)> = result.values.iter().copied().enumerate().map(|(i, v)| (v, i)).collect();
+            pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+            let sorted_vals: Vec<f64> = pairs.iter().map(|(v, _)| *v).collect();
+            let mut sorted_vecs = vec![0.0; n * nk];
+            for (new_col, &(_, old_col)) in pairs.iter().enumerate() {
+                for row in 0..n {
+                    sorted_vecs[row * nk + new_col] = result.vectors[row * nk + old_col];
+                }
             }
+            result.values = sorted_vals;
+            result.vectors = sorted_vecs;
+            return Some(result);
         }
-        result.values = sorted_vals;
-        result.vectors = sorted_vecs;
-        return Some(result);
     }
 
     // Fallback to dense
@@ -1014,6 +1017,36 @@ mod tests {
         for i in 0..2 {
             assert!((lanczos.values[i] - jacobi.values[i]).abs() < 1e-6,
                 "gen eigenvalue {}: lanczos={}, jacobi={}", i, lanczos.values[i], jacobi.values[i]);
+        }
+    }
+
+    #[test]
+    fn test_lanczos_generalized_indefinite_shift_falls_back_to_dense() {
+        // n > 80 so the shift-invert path is taken. With σ = 1.0 the shifted
+        // matrix A − σB is indefinite (λ_min(A) ≈ 9.7e-4 ≪ σ), so dense
+        // Cholesky of A − σB fails. The function must fall back to the dense
+        // generalized solve (documented behavior) instead of returning None.
+        let n = 100;
+        let mut a = vec![0.0; n * n];
+        let mut b = vec![0.0; n * n];
+        for i in 0..n {
+            a[i * n + i] = 2.0;
+            b[i * n + i] = 1.0;
+            if i > 0 {
+                a[i * n + (i - 1)] = -1.0;
+                a[(i - 1) * n + i] = -1.0;
+            }
+        }
+        let k = 3;
+        let result = lanczos_generalized_eigen(&a, &b, n, k, 1.0)
+            .expect("indefinite shift must fall back to dense solve, not None");
+        assert_eq!(result.values.len(), k);
+        // λ_j of the 1-2-1 tridiagonal (B = I): 2 − 2cos(jπ/(n+1))
+        for j in 0..k {
+            let expected = 2.0 - 2.0 * ((j + 1) as f64 * std::f64::consts::PI / (n as f64 + 1.0)).cos();
+            let rel_err = (result.values[j] - expected).abs() / expected;
+            assert!(rel_err < 1e-6,
+                "eigenvalue {}: got {:.10}, expected {:.10}", j, result.values[j], expected);
         }
     }
 

--- a/engine/src/linalg/mod.rs
+++ b/engine/src/linalg/mod.rs
@@ -16,7 +16,7 @@ pub use sparse::CscMatrix;
 pub use sparse_chol::{
     SymbolicCholesky, NumericCholesky, CholOrdering,
     symbolic_cholesky, symbolic_cholesky_with,
-    numeric_cholesky, numeric_cholesky_perturbed,
+    numeric_cholesky,
     sparse_cholesky_solve, sparse_cholesky_solve_full,
     sparse_condition_estimate,
 };

--- a/engine/src/linalg/sparse_chol.rs
+++ b/engine/src/linalg/sparse_chol.rs
@@ -27,8 +27,6 @@ pub struct SymbolicCholesky {
 pub struct NumericCholesky {
     pub symbolic: Rc<SymbolicCholesky>,
     pub l_values: Vec<f64>,
-    pub pivot_perturbations: usize,   // how many pivots were perturbed
-    pub max_perturbation: f64,        // largest perturbation applied
 }
 
 /// Ordering strategy for symbolic Cholesky factorization.
@@ -137,18 +135,13 @@ pub fn symbolic_cholesky_with(a: &CscMatrix, ordering: CholOrdering) -> Symbolic
 
 /// Compute numeric Cholesky factorization given symbolic structure.
 /// Returns None if matrix is not SPD (strict mode — no perturbation).
+///
+/// There is deliberately no perturbed/regularized variant: a factorization
+/// that silently "succeeds" on an indefinite K_ff turns a genuine mechanism
+/// into a garbage solution. Callers that need drilling-DOF stabilization
+/// apply an explicit diagonal shift to K_ff and verify by iterative
+/// refinement against the original matrix (see `solver::linear`).
 pub fn numeric_cholesky(sym: &Rc<SymbolicCholesky>, a: &CscMatrix) -> Option<NumericCholesky> {
-    numeric_cholesky_inner(sym, a, false)
-}
-
-/// Compute numeric Cholesky factorization with pivot perturbation.
-/// Perturbs small/negative pivots (from shell drilling DOFs) instead of failing.
-/// Always returns Some — caller must verify solution quality via residual check.
-pub fn numeric_cholesky_perturbed(sym: &Rc<SymbolicCholesky>, a: &CscMatrix) -> NumericCholesky {
-    numeric_cholesky_inner(sym, a, true).unwrap()
-}
-
-fn numeric_cholesky_inner(sym: &Rc<SymbolicCholesky>, a: &CscMatrix, perturb: bool) -> Option<NumericCholesky> {
     let n = sym.n;
 
     // Apply permutation to get numeric values
@@ -159,29 +152,11 @@ fn numeric_cholesky_inner(sym: &Rc<SymbolicCholesky>, a: &CscMatrix, perturb: bo
     // Dense column accumulator
     let mut x = vec![0.0f64; n];
 
-    // Compute max diagonal of the ORIGINAL (permuted) matrix for stable thresholds.
-    let mut max_diag = 0.0f64;
-    for j in 0..n {
-        for k in pa.col_ptr[j]..pa.col_ptr[j + 1] {
-            if pa.row_idx[k] == j {
-                if pa.values[k] > max_diag {
-                    max_diag = pa.values[k];
-                }
-                break;
-            }
-        }
-    }
-
-    // Pivot perturbation tracking
-    let mut n_perturbations = 0usize;
-    let mut max_perturbation_val = 0.0f64;
-
-    // Strict mode threshold: use absolute threshold like dense Cholesky.
-    // Previous 1e-12 * max_diag was too aggressive for shell matrices where
-    // drilling DOF pivots are naturally 4+ orders smaller than membrane pivots.
+    // Strict threshold: use absolute threshold like dense Cholesky.
+    // A previous 1e-12 * max_diag relative threshold was too aggressive for
+    // shell matrices where drilling DOF pivots are naturally 4+ orders
+    // smaller than membrane pivots.
     let strict_threshold = 1e-15;
-    // Perturbed mode threshold
-    let soft_threshold = 1e-8 * max_diag;
 
     // Precompute nonzero-column lists: for each row j, which columns k < j have L[j,k] != 0.
     let mut nz_cols_for_row: Vec<Vec<(usize, usize)>> = vec![Vec::new(); n];
@@ -201,13 +176,9 @@ fn numeric_cholesky_inner(sym: &Rc<SymbolicCholesky>, a: &CscMatrix, perturb: bo
             x[sym.l_row_idx[k]] = 0.0;
         }
 
-        // Scatter A[:,j] into accumulator and record original diagonal
-        let mut original_diag = 0.0f64;
+        // Scatter A[:,j] into accumulator
         for k in pa.col_ptr[j]..pa.col_ptr[j + 1] {
             x[pa.row_idx[k]] = pa.values[k];
-            if pa.row_idx[k] == j {
-                original_diag = pa.values[k];
-            }
         }
 
         // Left-looking updates
@@ -225,29 +196,9 @@ fn numeric_cholesky_inner(sym: &Rc<SymbolicCholesky>, a: &CscMatrix, perturb: bo
 
         let diag = x[j];
 
-        if perturb {
-            // Perturbed mode: replace small/negative pivots with a fraction of the
-            // original diagonal. This preserves natural DOF scale and avoids cascading
-            // failures from inflated pivots. Caller must verify via residual check.
-            if diag <= soft_threshold {
-                // Use the full original diagonal: this acts as if the left-looking
-                // updates didn't reduce this pivot, preserving the natural DOF scale.
-                let target = if original_diag > soft_threshold {
-                    original_diag
-                } else {
-                    1e-6 * max_diag
-                };
-                let target = target.max(1e-12 * max_diag);
-                let perturbation = if diag.is_finite() { (target - diag).abs() } else { f64::MAX };
-                x[j] = target;
-                n_perturbations += 1;
-                max_perturbation_val = max_perturbation_val.max(perturbation);
-            }
-        } else {
-            // Strict mode: fail on non-SPD
-            if diag <= strict_threshold {
-                return None;
-            }
+        // Strict mode: fail on non-SPD
+        if diag <= strict_threshold {
+            return None;
         }
 
         let ljj = x[j].sqrt();
@@ -265,8 +216,6 @@ fn numeric_cholesky_inner(sym: &Rc<SymbolicCholesky>, a: &CscMatrix, perturb: bo
     Some(NumericCholesky {
         symbolic: Rc::clone(sym),
         l_values,
-        pivot_perturbations: n_perturbations,
-        max_perturbation: max_perturbation_val,
     })
 }
 

--- a/engine/tests/solver_ci_coverage.rs
+++ b/engine/tests/solver_ci_coverage.rs
@@ -749,19 +749,11 @@ fn plate_10x10_sparse_fill_and_perturbations() {
         "Fill ratio {:.2} exceeds 15x threshold", fill_ratio
     );
 
-    // Numeric Cholesky: verify zero perturbations
+    // Numeric Cholesky: strict factorization must succeed unmodified (there is
+    // no perturbation path — failure returns None instead of a shifted factor)
     let num = numeric_cholesky(&sym, &asm.k_ff)
         .expect("Numeric Cholesky should succeed on 10x10 plate");
-
-    println!(
-        "Cholesky: perturbations={}, max_perturbation={:.2e}",
-        num.pivot_perturbations, num.max_perturbation
-    );
-    assert_eq!(
-        num.pivot_perturbations, 0,
-        "Expected zero Cholesky perturbations, got {}",
-        num.pivot_perturbations
-    );
+    assert!(num.l_values.iter().all(|v| v.is_finite()), "L contains non-finite values");
 
     // Equilibrium should be good
     if let Some(eq) = &result.equilibrium {

--- a/engine/tests/sparse_shell_gates.rs
+++ b/engine/tests/sparse_shell_gates.rs
@@ -298,7 +298,7 @@ fn diagnose_shell_pivots() {
 
     let num = numeric_cholesky(&sym, &asm.k_ff);
     match &num {
-        Some(n) => println!("Cholesky OK: perturbations={}, max_pert={:.2e}", n.pivot_perturbations, n.max_perturbation),
+        Some(_) => println!("Cholesky OK (strict, no shift)"),
         None => println!("Cholesky FAILED (no shift)"),
     }
 


### PR DESCRIPTION
# E3 audit: sparse linear algebra (`engine/src/linalg/`)

Section 3 of the section-by-section audit queue. Branch is off `origin/main` without PR138 (intentional). Scope: `engine/src/linalg/` (10 files, ~3.6k lines) + callers, plus the assigned cross-cutting triage of the clippy 1.93 `erasing_op` DENY errors in `engine/src/solver/mass_matrix.rs`.

## Fixed

1. **`lanczos_generalized_eigen`: no dense fallback when shift-invert Cholesky fails** (medium, latent) — `engine/src/linalg/lanczos.rs:541`. The n>80 path did `ShiftInvertOp::new(a, b, n, sigma)?` — the `?` returned `None` for the whole solve whenever dense Cholesky of (A − σB) failed, which happens for any shift past the smallest eigenvalue (A − σB indefinite). The docstring promises "or falls back to dense solve", the sparse sibling (`lanczos_generalized_eigen_sparse`) does fall back, and the dense generalized path only needs B to be SPD, so it handles this fine. Now falls through to the existing dense fallback. Unreachable from current production callers (all pass σ = 0 with SPD K_ff), so no solver numbers change today — this removes the latent trap for non-zero-shift callers. Commit `570d35c9`. Test `test_lanczos_generalized_indefinite_shift_falls_back_to_dense` (n=100 1-2-1 tridiagonal, B=I, σ=1.0 > λ_min ≈ 9.7e-4): **returns `None` before the fix, analytical eigenvalues after** (both directions verified by running it).

2. **Removed dead, hazardous `numeric_cholesky_perturbed`** (medium, dead-feature-that-looks-alive) — `engine/src/linalg/sparse_chol.rs:147`. Zero callers workspace-wide. It always "succeeds" by replacing small/negative pivots with a fraction of the diagonal, so a genuinely singular/indefinite K_ff (a real mechanism) would factor silently into a garbage solution whose only signal was two bookkeeping fields (`pivot_perturbations`, `max_perturbation`) that no production code read. Production regularization already lives in `solver::linear` (explicit diagonal-shift ladder on K_ff + iterative refinement against the original matrix + user-visible diagnostic) — the honest version of the same idea. Removed the function, the `perturb` branch (folded `numeric_cholesky_inner` back into `numeric_cholesky`), and the vestigial fields. The strict path is arithmetic-identical; only perturbation-only code was deleted. The two test sites that read the removed fields now assert strict success / finite L instead of pinning an always-zero counter. Commit `f42585da`.

## Deferred (real, but the honest fix is a rewrite)

3. **IRLM convergence check is vacuous** (high) — `engine/src/linalg/lanczos.rs:413`. `beta_m` is hardcoded to `0.0` whenever all m Lanczos steps complete (the normal case), so every Ritz residual `β_m·|s_m|` evaluates to 0 and any single m-step run is declared "converged" regardless of `params.tol`. `tol`, `max_iter`, and the entire restart loop are dead code — the loop provably always exits after one run (either `actual_m < m` breaks, or `beta_m = 0` forces `all_converged`). Probe evidence: 200×200 diagonal matrix with clustered spectrum λ_i = 1 + i·1e-3, k=5, m=40, tol=1e-10 → returned eigenvalue errors up to **5.8e-2** with true residuals ~2e-2, reported as converged.

4. **Repeated eigenvalues silently under-resolved** (high, related) — one Lanczos run extracts at most one vector per eigenspace and there is no deflation/locking, so a doubled eigenvalue yields {1, 2, 3, 4, 5} instead of {1, 1, 2, 3, 4} (probe: diag(1,1,2,…,199), k=5) — a mode is silently dropped. Symmetric structures have exactly repeated modes, and the n>80 sparse modal/buckling paths (`solver/modal.rs:105,342`, `solver/buckling.rs:100,324`) go through this.

   Why deferred: I implemented and tested a fix (real β_m + locking/deflation restarts). It converges clustered spectra but the single-vector reseed provably stalls on repeated eigenvalues; a correct fix is thick-restart / Krylov–Schur IRLM — a rewrite that changes solver numbers in cases that are wrong today and needs its own round with reference validation (callers live in E5 sections). An honest half-fix (just enabling the current broken restart) makes hard cases up to 300× slower for the same answers. Probe code/evidence preserved if wanted.

5. **Shift-invert operator is non-symmetric under symmetric Lanczos** (medium, question) — `engine/src/linalg/lanczos.rs:76,608`. `ShiftInvertOp`/`SparseShiftInvertOp` run the symmetric 3-term Lanczos recurrence (Euclidean inner product) on K⁻¹B, which is non-symmetric for non-identity B (mass matrix). The eigenvalues of K⁻¹M are the right targets and structural integration tests pass, but the tridiagonal theory — including the β_m·|s_m| residual estimate — strictly applies only to symmetric operators, and the parity test (`test_sparse_shift_invert_op_csc_vs_dense_parity`) compares two formulations of the *same* operator, so it cannot catch this. Proper formulation: B-inner-product Lanczos or symmetrized M^(1/2)K⁻¹M^(1/2). Deferred with #3/#4 (same rewrite).

## Informational (no action)

- `sparse_condition_estimate` (`sparse_chol.rs:331`) is dead in production (only its own unit test); `lu::condition_estimate` is used by one test only. Both are crude diagonal-ratio heuristics, not rigorous condition estimators — harmless because nothing acts on them.
- `jacobi_eigen` (`jacobi.rs:31,46`): absolute (scale-blind) convergence thresholds (off_norm < 1e-24, |apq| < 1e-30) and silent partial results at max_iter. Fine at structural stiffness scales; 200 sweeps is generous for quadratic Jacobi convergence. Low.
- `tridiag_qr_impl` (`lanczos.rs:194`): silently stops after 30·m QR iterations even if not fully deflated. Low; covered by strong reconstruction/orthogonality tests.

## Verified OK (focus questions)

- **Duplicate triplets**: `CscMatrix::from_triplets` (`sparse.rs:58-71`) sorts by (col,row) and sums duplicates in a single pass; pinned by `test_duplicate_summing`. Correct for element assembly.
- **Ordering quality**: AMD (`amd.rs`) and RCM (`rcm.rs`) produce valid permutations (each index exactly once — heap-based min-degree with stale-entry skipping; disconnected graphs handled); hub-last, bandwidth, and grid-scale tests back this. A wrong-but-valid permutation would only be slow.
- **Dense LU parity**: strict sparse Cholesky falls back to dense LU of the original K_ff (`linear.rs:380-416`); parity covered by `sparse_3d_parity` / drilling-regression tests. LU pivot threshold (1e-14 absolute) is consistent with dense Cholesky's (1e-15).
- **Perturbation masking singular models**: not reachable in production — the 2D sparse path deliberately never regularizes (rationale comment at `linear.rs:337-344`), the 3D path uses the shift ladder + iterative refinement + Info diagnostic.

## Assigned cross-cutting item: clippy 1.93 `erasing_op` in `solver/mass_matrix.rs`

Reproduced with `cargo clippy -p dedaliano-engine` (clippy 0.1.93): 7 DENY-level sites in `mass_matrix.rs` (lines 80, 81, 109, 123, 124, 708, 709). **All 7 are intentional, not bugs.** Each is the row-0 entry of a uniform `row * stride + col` index pattern in the consistent-mass element matrices (`mat[0 * 6 + 0]`, `mat[0 * 4 + 2]`, `mat[0 * 12 + 6]`, …); verified index-by-index against the documented matrices (2D frame 6×6 axial [140, 0, 0, 70, …], 2D truss 4×4 [[2,0,1,0],…]·m, 3D frame 12×12 axial DOFs 0/6). The assigned values are nonzero — only the index arithmetic contains the erasing op. Left unchanged: CI already runs clippy with `-A clippy::erasing_op` (`.github/workflows/ci.yml:30`), so they break no gate, and "fixing" them to bare indices would only hurt the matrix-layout readability. The `element/*` sites remain for E6 as planned.

## Verification

- `cargo test -p dedaliano-engine`: full suite green, exit 0 (7,056 passed, 0 failed across all binaries; includes the two edited integration binaries: solver_ci_coverage 11/11, sparse_shell_gates 15 passed + 2 pre-existing ignored).
- New test for fix 1 fails before / passes after (verified by running it against the pre-fix sources: `expect` panics on `None`).
- Fix 2 is deletion-only on the strict path; the full suite (incl. sparse parity and drilling-regression tests) confirms identical behavior.
- `cargo clippy -p dedaliano-engine --lib -- -W clippy::all -A clippy::erasing_op` (the exact CI invocation): exit 0.
- `cd web && npm run wasm`: rebuilt in this fresh worktree (wasm-pack 0.14.0, release).
- `cd web && npm test` (after `npm ci` — fresh worktree had no `node_modules`): unit + build passes all green.

Note: `docs/AUDIT_PLAN.md` does not exist on `origin/main` (it lives uncommitted in the main checkout), so the section-3 status-table update is left to the plan owner. Suggested entry: E3 ✔ 2026-08 (this PR) — headline: Lanczos IRLM convergence check vacuous + repeated-eigenvalue mode drop (both deferred, need Krylov–Schur rewrite); fixed indefinite-shift fallback; removed dead perturbation path.
