### PR TITLE
fix(engine): E4 audit — nonlinear solving correctness fixes

### DIFF
--- a/engine/src/solver/arc_length.rs
+++ b/engine/src/solver/arc_length.rs
@@ -269,17 +269,21 @@ pub fn solve_arc_length(input: &ArcLengthInput) -> Result<ArcLengthResult, Strin
         }
 
         if !step_converged {
+            // Restore the last converged state FIRST, so that if the retry
+            // budget runs out the final results are built from the last
+            // converged equilibrium state — not from the failed step's
+            // unconverged iterate.
+            for i in 0..nf {
+                u_full[i] -= delta_u[i];
+            }
+            lambda -= delta_lambda;
+
             // Halve arc-length and retry (don't consume step budget)
             ds *= 0.5;
             if ds < input.min_ds {
                 overall_converged = false;
                 break;
             }
-            // Restore state
-            for i in 0..nf {
-                u_full[i] -= delta_u[i];
-            }
-            lambda -= delta_lambda;
             continue;
         }
 
@@ -712,6 +716,41 @@ mod tests {
         // Load factor should be positive after the first step
         if let Some(last) = result.steps.last() {
             assert!(last.load_factor > 0.0, "Load factor should be positive");
+        }
+    }
+
+    #[test]
+    fn test_arc_length_abort_returns_last_converged_state() {
+        // Force the abort path: max_iter = 1 cannot converge a genuinely
+        // nonlinear large-load step, and ds halves below min_ds quickly.
+        // The final results must reflect the last converged state (here:
+        // no converged step -> zero displacements, zero load factor), not
+        // the failed step's unconverged iterate.
+        let solver = make_cantilever();
+        let input = ArcLengthInput {
+            solver,
+            max_steps: 10,
+            max_iter: 1,
+            tolerance: 1e-6,
+            initial_ds: 0.5,
+            min_ds: 0.1,
+            max_ds: 2.0,
+            target_iter: 5,
+        };
+        let result = solve_arc_length(&input).unwrap();
+        assert!(!result.converged, "Should report non-convergence");
+        assert!(result.steps.is_empty(), "No step should have converged");
+        assert!(
+            result.final_load_factor == 0.0,
+            "Load factor should be restored to 0.0, got {}",
+            result.final_load_factor
+        );
+        for d in &result.results.displacements {
+            assert!(
+                d.ux.abs() < 1e-15 && d.uz.abs() < 1e-15 && d.ry.abs() < 1e-15,
+                "Displacements should be the last converged (zero) state, got ux={} uz={} ry={} at node {}",
+                d.ux, d.uz, d.ry, d.node_id
+            );
         }
     }
 }

--- a/engine/src/solver/corotational.rs
+++ b/engine/src/solver/corotational.rs
@@ -395,14 +395,19 @@ fn assemble_frame_corotational(
 
     // Natural stiffness K_nat (3x3) = P^T * K_local * P
     // where P maps natural to full local: d_local = P * d_natural
-    // P = [[1,0,0],[0,0,0],[0,1,0],[-1,0,0],[0,0,0],[0,0,1]]
+    // Natural deformations are the total elongation d_axial = l_n - l0 and the
+    // corotated end rotations theta_i, theta_j. In the corotated local frame
+    // node i is at the origin and node j carries the full elongation, so
+    // d_local = [0, 0, theta_i, d_axial, 0, theta_j]. (Mapping d_axial as
+    // [+d_axial at i, -d_axial at j] instead would make the local elongation
+    // u_j - u_i = -2*d_axial and quadruple the effective axial stiffness.)
     let k_local = frame_local_stiffness_2d(e, a, iz, l0, elem.hinge_start, elem.hinge_end, 0.0);
 
     let p_mat: [[f64; 3]; 6] = [
-        [1.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0],
         [0.0, 0.0, 0.0],
         [0.0, 1.0, 0.0],
-        [-1.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
         [0.0, 0.0, 0.0],
         [0.0, 0.0, 1.0],
     ];
@@ -2016,5 +2021,62 @@ mod tests {
         let corot = solve_corotational_2d(&input, 100, 1e-6, 5, false).unwrap();
         assert!(corot.converged, "Two-element frame should converge");
         assert_eq!(corot.results.element_forces.len(), 2);
+    }
+
+    #[test]
+    fn test_corotational_frame_axial_stiffness() {
+        // A frame element under pure axial load must reproduce the truss
+        // result: N = P and ux = P*L/(E*A). The natural-deformation map
+        // d_local = P * d_natural must place the full elongation at node j
+        // (u_j = d_axial, u_i = 0) — splitting it as [+d_axial, -d_axial]
+        // would quadruple the effective axial stiffness (K_nat = 4EA/L).
+        let mut nodes = HashMap::new();
+        nodes.insert("1".into(), SolverNode { id: 1, x: 0.0, z: 0.0 });
+        nodes.insert("2".into(), SolverNode { id: 2, x: 5.0, z: 0.0 });
+
+        let mut materials = HashMap::new();
+        materials.insert("1".into(), SolverMaterial { id: 1, e: 200.0, nu: 0.3 });
+
+        let mut sections = HashMap::new();
+        sections.insert("1".into(), SolverSection { id: 1, a: 0.01, iz: 1e-4, as_y: None });
+
+        let mut elements = HashMap::new();
+        elements.insert("1".into(), SolverElement {
+            id: 1, elem_type: "frame".into(),
+            node_i: 1, node_j: 2, material_id: 1, section_id: 1,
+            hinge_start: false, hinge_end: false,
+        });
+
+        let mut supports = HashMap::new();
+        supports.insert("1".into(), SolverSupport {
+            id: 1, node_id: 1, support_type: "fixed".into(),
+            kx: None, ky: None, kz: None,
+            dx: None, dz: None, dry: None, angle: None,
+        });
+
+        let loads = vec![
+            SolverLoad::Nodal(SolverNodalLoad {
+                node_id: 2, fx: 100.0, fz: 0.0, my: 0.0,
+            }),
+        ];
+
+        let input = SolverInput { nodes, materials, sections, elements, supports, loads, constraints: vec![] , connectors: HashMap::new() };
+        let corot = solve_corotational_2d(&input, 50, 1e-8, 1, false).unwrap();
+        assert!(corot.converged);
+
+        // E_eff = 200_000 kN/m^2, A = 0.01 m^2, L = 5 m → ux = PL/(EA) = 0.25 m
+        let d2 = corot.results.displacements.iter().find(|d| d.node_id == 2).unwrap();
+        assert!(
+            (d2.ux - 0.25).abs() < 0.005,
+            "Axial displacement should be PL/(EA) = 0.25 m, got {}",
+            d2.ux
+        );
+
+        let ef = &corot.results.element_forces[0];
+        assert!(
+            (ef.n_start - 100.0).abs() < 0.1,
+            "Axial force should be ~100 kN, got {}",
+            ef.n_start
+        );
     }
 }

--- a/engine/src/solver/geometric_stiffness.rs
+++ b/engine/src/solver/geometric_stiffness.rs
@@ -326,10 +326,10 @@ pub fn build_kg_from_forces_3d(
             }
         }
     }
-    // Add quad shell geometric stiffness (from membrane stress resultants)
-    // Requires displacement vector to compute stresses
-    // Note: quad_stresses are computed from linear solution displacements
-    // For buckling, we recompute stresses here from the linear solution
+    // Note: shell geometric stiffness (quads, plates, quad9s, solid shells,
+    // curved shells) is NOT built here — it needs the displacement vector to
+    // compute membrane stresses. Callers add it separately via
+    // add_*_geometric_stiffness_3d (see buckling.rs).
     k_g
 }
 

--- a/engine/src/solver/material_nonlinear.rs
+++ b/engine/src/solver/material_nonlinear.rs
@@ -119,6 +119,15 @@ pub fn solve_nonlinear_material_2d(
         // F_ext_free norm for convergence check.
         let f_ext_norm = vec_norm_l2(&f_ext_free);
 
+        // Apply this increment's prescribed displacements to the restrained
+        // DOFs BEFORE the first residual evaluation: f_int then includes the
+        // K_fr * u_r coupling, so the residual is the true out-of-balance and
+        // no separate RHS correction is needed (a pure-settlement increment
+        // with zero external load must still iterate).
+        for i in 0..nr {
+            u_full[nf + i] = load_factor * u_r[i];
+        }
+
         // Newton-Raphson inner loop.
         let mut converged_increment = false;
 
@@ -166,20 +175,15 @@ pub fn solve_nonlinear_material_2d(
             }
 
             // Solve K_T * delta_u = R for free DOFs.
+            // The prescribed-displacement coupling K_fr * u_r is already in
+            // the residual via f_int (u_full carries the restrained values),
+            // so the RHS is the residual itself.
             let k_ff = extract_submatrix(&k_t, n, &free_idx, &free_idx);
 
-            // Modify residual for prescribed displacement coupling: R_f -= K_fr * u_r
-            let k_fr = extract_submatrix(&k_t, n, &free_idx, &rest_idx);
-            let k_fr_ur = mat_vec_rect(&k_fr, &u_r, nf, nr);
-            let mut rhs = r_free.clone();
-            for i in 0..nf {
-                rhs[i] -= k_fr_ur[i];
-            }
-
             let (k_s, rhs_s) = if let Some(ref cs) = cs {
-                (cs.reduce_matrix(&k_ff), cs.reduce_vector(&rhs))
+                (cs.reduce_matrix(&k_ff), cs.reduce_vector(&r_free))
             } else {
-                (k_ff, rhs)
+                (k_ff, r_free)
             };
 
             let delta_u_indep = solve_system(k_s, rhs_s, ns)?;
@@ -189,12 +193,10 @@ pub fn solve_nonlinear_material_2d(
                 delta_u_indep
             };
 
-            // Update displacements.
+            // Update displacements (free DOFs; restrained stay at this
+            // increment's prescribed values set before the loop).
             for i in 0..nf {
                 u_full[i] += delta_u_f[i];
-            }
-            for i in 0..nr {
-                u_full[nf + i] = load_factor * u_r[i];
             }
 
             // Update element yield states from current internal forces.
@@ -903,6 +905,14 @@ pub fn solve_nonlinear_material_3d(
         let f_ext_free = extract_subvec(&f_ext, &free_idx);
         let f_ext_norm = vec_norm_l2(&f_ext_free);
 
+        // Apply this increment's prescribed displacements to the restrained
+        // DOFs BEFORE the first residual evaluation — see the 2D solver for
+        // why (f_int then carries the K_fr * u_r coupling and a
+        // pure-settlement increment still iterates).
+        for i in 0..nr {
+            u_full[nf + i] = load_factor * u_r[i];
+        }
+
         let mut converged_increment = false;
 
         for _nr_iter in 0..max_iter {
@@ -937,21 +947,17 @@ pub fn solve_nonlinear_material_3d(
                 break;
             }
 
+            // The prescribed-displacement coupling K_fr * u_r is already in
+            // the residual via f_int (u_full carries the restrained values),
+            // so the RHS is the residual itself.
             let k_ff = extract_submatrix(&k_t, n, &free_idx, &free_idx);
-            let k_fr = extract_submatrix(&k_t, n, &free_idx, &rest_idx);
-            let k_fr_ur = mat_vec_rect(&k_fr, &u_r, nf, nr);
-            let mut rhs = r_free.clone();
-            for i in 0..nf {
-                rhs[i] -= k_fr_ur[i];
-            }
 
-            let delta_u_f = solve_system(k_ff, rhs, nf)?;
+            let delta_u_f = solve_system(k_ff, r_free, nf)?;
 
+            // Update displacements (free DOFs; restrained stay at this
+            // increment's prescribed values set before the loop).
             for i in 0..nf {
                 u_full[i] += delta_u_f[i];
-            }
-            for i in 0..nr {
-                u_full[nf + i] = load_factor * u_r[i];
             }
 
             // See the 2D solver's identical comment: update_element_states_3d

--- a/engine/src/solver/material_nonlinear.rs
+++ b/engine/src/solver/material_nonlinear.rs
@@ -461,7 +461,12 @@ fn assemble_tangent_stiffness(
         let mut rot_restrained: std::collections::HashSet<usize> =
             std::collections::HashSet::new();
         for sup in solver.supports.values() {
-            if sup.support_type == "fixed" || sup.support_type == "guidedX" || sup.support_type == "guidedY" {
+            // guidedY/guidedZ restrain ux+ry (dof.rs), so they belong here
+            // like guidedX. (The `idx < n_free` guard below already makes
+            // this set redundant for any rotation-restraining support — a
+            // restrained ry is numbered at index >= n_free — but keep the
+            // enumeration complete for clarity.)
+            if sup.support_type == "fixed" || sup.support_type == "guidedX" || sup.support_type == "guidedY" || sup.support_type == "guidedZ" {
                 rot_restrained.insert(sup.node_id);
             }
             if sup.support_type == "spring" && sup.kz.unwrap_or(0.0) > 0.0 {

--- a/engine/src/solver/material_nonlinear.rs
+++ b/engine/src/solver/material_nonlinear.rs
@@ -108,6 +108,9 @@ pub fn solve_nonlinear_material_2d(
     let mut load_displacement: Vec<[f64; 2]> = Vec::with_capacity(n_increments);
     let mut total_nr_iterations: usize = 0;
     let mut converged_global = true;
+    // Last increment that actually converged — reported as load_factor so a
+    // failed run does not claim the full load was applied.
+    let mut last_converged_factor = 0.0f64;
 
     for inc in 1..=n_increments {
         let load_factor = inc as f64 / n_increments as f64;
@@ -217,6 +220,8 @@ pub fn solve_nonlinear_material_2d(
 
         if !converged_increment {
             converged_global = false;
+        } else {
+            last_converged_factor = load_factor;
         }
 
         // Record load-displacement point.
@@ -269,7 +274,7 @@ pub fn solve_nonlinear_material_2d(
     // Build element plastic status.
     let element_status = build_element_status(solver, input, &dof_num, &u_geom, &states);
 
-    let final_load_factor = if n_increments > 0 { 1.0 } else { 0.0 };
+    let final_load_factor = last_converged_factor;
 
     // Compute constraint forces if constraints are active
     let constraint_forces = if let Some(ref fcs) = cs {
@@ -902,6 +907,8 @@ pub fn solve_nonlinear_material_3d(
     let mut load_displacement: Vec<[f64; 2]> = Vec::with_capacity(n_increments);
     let mut total_nr_iterations: usize = 0;
     let mut converged_global = true;
+    // Last increment that actually converged — see the 2D solver.
+    let mut last_converged_factor = 0.0f64;
 
     for inc in 1..=n_increments {
         let load_factor = inc as f64 / n_increments as f64;
@@ -978,6 +985,8 @@ pub fn solve_nonlinear_material_3d(
 
         if !converged_increment {
             converged_global = false;
+        } else {
+            last_converged_factor = load_factor;
         }
 
         let max_disp = compute_max_displacement_3d_nl(&dof_num, &u_full);
@@ -1057,7 +1066,7 @@ pub fn solve_nonlinear_material_3d(
         },
         converged: converged_global,
         iterations: total_nr_iterations,
-        load_factor: if n_increments > 0 { 1.0 } else { 0.0 },
+        load_factor: last_converged_factor,
         element_status,
         load_displacement,
     })

--- a/engine/tests/integration/material_nonlinear_3d.rs
+++ b/engine/tests/integration/material_nonlinear_3d.rs
@@ -371,3 +371,34 @@ fn nonlinear_material_3d_l_frame() {
     assert_eq!(result.element_status.len(), 2);
     assert_eq!(result.results.element_forces.len(), 2);
 }
+
+/// Cantilever with a settled fixed support (dz = 0.005) under tip load.
+/// Elastic (huge capacities) — must converge and match the linear solver.
+/// Regression for the prescribed-displacement RHS double-count (K_fr*u_r
+/// was subtracted although f_int already contained the coupling).
+#[test]
+fn nonlinear_material_3d_support_settlement_matches_linear() {
+    let mut input = cantilever_3d_nl(
+        4.0, 0.0, 0.0, -5.0,
+        200.0, 0.3,
+        0.01, 1e-4, 1e-4, 1e-4,
+        1e9, 1e9, 1e9,
+        2,
+    );
+    input.tolerance = 1e-8;
+    for sup in input.solver.supports.values_mut() {
+        sup.dz = Some(0.005);
+    }
+
+    let lin = solve_3d(&input.solver).unwrap();
+    let lin_tip = lin.displacements.iter().find(|d| d.node_id == 2).unwrap();
+
+    let res = solve_nonlinear_material_3d(&input).unwrap();
+    assert!(res.converged, "3D settlement analysis should converge");
+    let nl_tip = res.results.displacements.iter().find(|d| d.node_id == 2).unwrap();
+    assert!(
+        (nl_tip.uz - lin_tip.uz).abs() < 1e-6,
+        "Tip uz: nonlinear={:.6e}, linear={:.6e}",
+        nl_tip.uz, lin_tip.uz
+    );
+}

--- a/engine/tests/validation/benchmarks/ansys_vm_benchmarks.rs
+++ b/engine/tests/validation/benchmarks/ansys_vm_benchmarks.rs
@@ -892,9 +892,13 @@ fn validation_ansys_vm40_large_deflection_cantilever() {
     let l = 1.0;
     // Choose E and section so EI_eff = 1000:
     // E_mpa = 12 -> E_eff = 12000, I = 1/12 -> EI = 1000
+    // A = 100 gives EA*L^2/EI = 1200, i.e. a nearly inextensible beam, so the
+    // (inextensible) Mattiasson elastica reference applies. With A = 1
+    // (EA*L^2/EI = 12) axial extensibility shifts u_tip/v_tip by tens of
+    // percent and the reference is not applicable.
     let e_mpa = 12.0;
     let e_eff = e_mpa * 1000.0;
-    let a_sec = 1.0;
+    let a_sec = 100.0;
     let iz = 1.0 / 12.0;
     let ei = e_eff * iz; // = 1000
 

--- a/engine/tests/validation/domains/nonlinear/material_nonlinear.rs
+++ b/engine/tests/validation/domains/nonlinear/material_nonlinear.rs
@@ -360,3 +360,31 @@ fn validation_material_nonlinear_pure_settlement() {
         nl_tip.ry
     );
 }
+
+// ================================================================
+// 5. Reported load_factor must reflect the last CONVERGED increment
+// ================================================================
+//
+// With max_iter = 1 no increment can converge; the run must report
+// converged = false AND load_factor = 0.0 — not 1.0 (full load).
+
+#[test]
+fn validation_material_nonlinear_failed_run_reports_partial_load_factor() {
+    let l = 4.0;
+    let n = 8;
+    let mid_node = n / 2 + 1;
+    let loads = vec![SolverLoad::Nodal(SolverNodalLoad {
+        node_id: mid_node, fx: 0.0, fz: -100.0, my: 0.0,
+    })];
+    let mut input = make_nonlinear_beam(n, l, "fixed", Some("fixed"), loads);
+    input.max_iter = 1;
+    input.n_increments = 4;
+
+    let res = material_nonlinear::solve_nonlinear_material_2d(&input).unwrap();
+    assert!(!res.converged, "max_iter=1 cannot converge");
+    assert!(
+        res.load_factor == 0.0,
+        "No increment converged: load_factor should be 0.0, got {:.3}",
+        res.load_factor
+    );
+}

--- a/engine/tests/validation/domains/nonlinear/material_nonlinear.rs
+++ b/engine/tests/validation/domains/nonlinear/material_nonlinear.rs
@@ -4,7 +4,7 @@
 ///   1. Fixed-fixed beam — below Pc elastic, at 1.2×Pc shows yielding (Pc=8Mp/L)
 ///   2. Propped cantilever — same approach (Pc=6Mp/L)
 ///   3. Cantilever elastic phase — matches linear solution within 5%
-use dedaliano_engine::solver::material_nonlinear;
+use dedaliano_engine::solver::{linear, material_nonlinear};
 use dedaliano_engine::types::*;
 use crate::common::*;
 use std::collections::HashMap;
@@ -223,4 +223,140 @@ fn validation_material_nonlinear_cantilever_elastic_phase() {
             status.element_id, status.utilization
         );
     }
+}
+
+// ================================================================
+// 4. Support Settlement — Prescribed Displacement Consistency
+// ================================================================
+//
+// A cantilever whose fixed support settles dz = 0.01 m while carrying a
+// tip load. With no section capacities the analysis stays elastic, so the
+// nonlinear solver must (a) converge and (b) reproduce the linear
+// solution exactly (rigid-body settlement + elastic deflection).
+//
+// Regression: the NR loop used to subtract K_fr*u_r from the RHS even
+// though f_int already contained that coupling through u_full, and only
+// applied u_r after the first solve — so settlement-only increments
+// converged instantly to u = 0, and load+settlement increments stagnated
+// at residual ||K_fr*u_r|| and reported non-convergence.
+
+#[test]
+fn validation_material_nonlinear_support_settlement_matches_linear() {
+    let mut nodes = HashMap::new();
+    nodes.insert("1".to_string(), SolverNode { id: 1, x: 0.0, z: 0.0 });
+    nodes.insert("2".to_string(), SolverNode { id: 2, x: 5.0, z: 0.0 });
+
+    let mut materials = HashMap::new();
+    materials.insert("1".to_string(), SolverMaterial { id: 1, e: E, nu: 0.3 });
+
+    let mut sections = HashMap::new();
+    sections.insert("1".to_string(), SolverSection { id: 1, a: A_SEC, iz: IZ_SEC, as_y: None });
+
+    let mut elements = HashMap::new();
+    elements.insert("1".to_string(), SolverElement {
+        id: 1, elem_type: "frame".to_string(),
+        node_i: 1, node_j: 2, material_id: 1, section_id: 1,
+        hinge_start: false, hinge_end: false,
+    });
+
+    let mut supports = HashMap::new();
+    supports.insert("1".to_string(), SolverSupport {
+        id: 1, node_id: 1, support_type: "fixed".to_string(),
+        kx: None, ky: None, kz: None,
+        dx: None, dz: Some(0.01), dry: None, angle: None,
+    });
+
+    let loads = vec![SolverLoad::Nodal(SolverNodalLoad {
+        node_id: 2, fx: 0.0, fz: -10.0, my: 0.0,
+    })];
+
+    let solver = SolverInput {
+        nodes, materials, sections, elements, supports, loads,
+        constraints: vec![], connectors: HashMap::new(),
+    };
+
+    let lin = linear::solve_2d(&solver).unwrap();
+    let lin_tip = lin.displacements.iter().find(|d| d.node_id == 2).unwrap();
+
+    let input = NonlinearMaterialInput {
+        solver,
+        material_models: HashMap::new(),
+        section_capacities: HashMap::new(),
+        max_iter: 50,
+        tolerance: 1e-8,
+        n_increments: 2,
+    };
+    let res = material_nonlinear::solve_nonlinear_material_2d(&input).unwrap();
+
+    assert!(res.converged, "Settlement analysis should converge");
+    let nl_tip = res.results.displacements.iter().find(|d| d.node_id == 2).unwrap();
+    assert!(
+        (nl_tip.uz - lin_tip.uz).abs() < 1e-6,
+        "Tip uz: nonlinear={:.6e}, linear={:.6e}",
+        nl_tip.uz, lin_tip.uz
+    );
+    assert!(
+        (nl_tip.ry - lin_tip.ry).abs() < 1e-8,
+        "Tip ry: nonlinear={:.6e}, linear={:.6e}",
+        nl_tip.ry, lin_tip.ry
+    );
+}
+
+// Pure settlement, no external load: the increment must still iterate and
+// produce the rigid-body motion (previously it "converged" at u = 0).
+#[test]
+fn validation_material_nonlinear_pure_settlement() {
+    let mut nodes = HashMap::new();
+    nodes.insert("1".to_string(), SolverNode { id: 1, x: 0.0, z: 0.0 });
+    nodes.insert("2".to_string(), SolverNode { id: 2, x: 5.0, z: 0.0 });
+
+    let mut materials = HashMap::new();
+    materials.insert("1".to_string(), SolverMaterial { id: 1, e: E, nu: 0.3 });
+
+    let mut sections = HashMap::new();
+    sections.insert("1".to_string(), SolverSection { id: 1, a: A_SEC, iz: IZ_SEC, as_y: None });
+
+    let mut elements = HashMap::new();
+    elements.insert("1".to_string(), SolverElement {
+        id: 1, elem_type: "frame".to_string(),
+        node_i: 1, node_j: 2, material_id: 1, section_id: 1,
+        hinge_start: false, hinge_end: false,
+    });
+
+    let mut supports = HashMap::new();
+    supports.insert("1".to_string(), SolverSupport {
+        id: 1, node_id: 1, support_type: "fixed".to_string(),
+        kx: None, ky: None, kz: None,
+        dx: None, dz: Some(0.01), dry: None, angle: None,
+    });
+
+    let solver = SolverInput {
+        nodes, materials, sections, elements, supports,
+        loads: vec![],
+        constraints: vec![], connectors: HashMap::new(),
+    };
+
+    let input = NonlinearMaterialInput {
+        solver,
+        material_models: HashMap::new(),
+        section_capacities: HashMap::new(),
+        max_iter: 50,
+        tolerance: 1e-8,
+        n_increments: 2,
+    };
+    let res = material_nonlinear::solve_nonlinear_material_2d(&input).unwrap();
+
+    assert!(res.converged, "Pure settlement should converge");
+    let nl_tip = res.results.displacements.iter().find(|d| d.node_id == 2).unwrap();
+    // Rigid-body translation: the free end follows the settled support.
+    assert!(
+        (nl_tip.uz - 0.01).abs() < 1e-9,
+        "Tip uz should follow the 0.01 m settlement, got {:.6e}",
+        nl_tip.uz
+    );
+    assert!(
+        nl_tip.ry.abs() < 1e-12,
+        "Cantilever settlement is rigid-body: ry should be ~0, got {:.6e}",
+        nl_tip.ry
+    );
 }

--- a/engine/tests/validation/domains/nonlinear/nonlinear_extended.rs
+++ b/engine/tests/validation/domains/nonlinear/nonlinear_extended.rs
@@ -47,8 +47,15 @@ fn validation_nonlin_ext_1_williams_toggle_snap() {
 
     let l_bar: f64 = (l_half * l_half + rise * rise).sqrt();
     let sin_alpha: f64 = rise / l_bar;
-    // Analytical limit load for truss toggle: P_lim = 2*EA*sin^3(alpha)
-    let p_limit_analytical: f64 = 2.0 * E_EFF * a * sin_alpha.powi(3);
+    // Analytical limit load for the Williams toggle (engineering-strain bars,
+    // matching the solver's N = EA*(L'-L0)/L0): maximizing the exact
+    // equilibrium path P(h') = 2*EA*(1 - L'/L0)*(h'/L') over the deformed
+    // rise h' gives P_lim = 2*EA*sin^3(alpha)/(3*sqrt(3)) in the shallow
+    // limit (the limit point is at h' = rise/sqrt(3)).
+    // (The often-quoted 2*EA*sin^3(alpha) overestimates the limit load by
+    // 3*sqrt(3) ~ 5.2x; using it here would put the "sub-limit" load above
+    // the true limit point.)
+    let p_limit_analytical: f64 = 2.0 * E_EFF * a * sin_alpha.powi(3) / (3.0 * 3.0f64.sqrt());
 
     // Sub-limit load: 20% of the analytical limit
     let p_sub = 0.20 * p_limit_analytical;
@@ -280,7 +287,9 @@ fn validation_nonlin_ext_3_shallow_arch_buckling() {
 // Source: von Mises (1923), Structural stability textbooks
 // Two symmetric bars with initial inclination angle theta,
 // pinned at supports and at the apex.
-// Critical load: P_cr = 2*E*A*sin^2(theta)*cos(theta)
+// Limit load: maximum of the exact engineering-strain equilibrium path
+//   P(h') = 2*EA*(1 - L'/L0)*(h'/L'),  L' = sqrt(s^2 + h'^2)
+// over the deformed rise h' (found by scanning below).
 //
 // We verify that:
 // (a) below P_cr the solver converges,
@@ -294,11 +303,20 @@ fn validation_nonlin_ext_4_two_bar_truss_instability() {
     let iz: f64 = 1e-8; // very small, truss-like
 
     let l_bar: f64 = (half_span * half_span + rise * rise).sqrt();
-    let sin_theta: f64 = rise / l_bar;
-    let cos_theta: f64 = half_span / l_bar;
 
-    // Von Mises critical load
-    let p_cr = 2.0 * E_EFF * a * sin_theta * sin_theta * cos_theta;
+    // Von Mises limit load: maximize P(h') over the deformed rise.
+    // The closed-form P = 2*EA*sin^2(theta)*cos(theta) is NOT the limit load
+    // for this formulation (it overestimates it ~6.6x at this steep angle);
+    // at 30% of that value the structure is already past snap-through.
+    let mut p_cr = 0.0f64;
+    for k in 1..=1000 {
+        let h_def = rise * k as f64 / 1000.0;
+        let l_def = (half_span * half_span + h_def * h_def).sqrt();
+        let p = 2.0 * E_EFF * a * (1.0 - l_def / l_bar) * (h_def / l_def);
+        if p > p_cr {
+            p_cr = p;
+        }
+    }
 
     let nodes = vec![
         (1, 0.0, 0.0),
@@ -346,9 +364,9 @@ fn validation_nonlin_ext_4_two_bar_truss_instability() {
         ratio, apex.uz, apex_lin.uz
     );
 
-    // Verify the analytical P_cr is positive and reasonable
-    assert_close(p_cr, 2.0 * E_EFF * a * sin_theta * sin_theta * cos_theta, 0.01,
-        "Von Mises P_cr formula consistency");
+    // Verify the scanned P_cr is positive and finite
+    assert!(p_cr > 0.0 && p_cr.is_finite(),
+        "Von Mises P_cr should be positive and finite: {:.4e}", p_cr);
 }
 
 // ================================================================

--- a/engine/tests/validation/domains/solver/capability_upgrades.rs
+++ b/engine/tests/validation/domains/solver/capability_upgrades.rs
@@ -127,7 +127,10 @@ fn capability_vm14a_mattiasson_elastica() {
     let l = 1.0;
     let e_mpa = 12.0;
     let e_eff = e_mpa * 1000.0; // 12000 kN/m^2
-    let a_sec = 1.0;
+    // A = 100 gives EA*L^2/EI = 1200 (nearly inextensible), so the
+    // inextensible-elastica Mattiasson reference applies; with A = 1
+    // (EA*L^2/EI = 12) axial extensibility shifts the tip by several percent.
+    let a_sec = 100.0;
     let iz = 1.0 / 12.0;
     let ei = e_eff * iz; // = 1000
 


### PR DESCRIPTION
# Audit E4 — nonlinear solving

Section audit per `docs/AUDIT_PLAN.md`: `corotational.rs`, `arc_length.rs`, `adaptive_stepping.rs`, `line_search.rs`, `pdelta.rs`, `geometric_stiffness.rs`, `material_nonlinear.rs`, `fiber_nonlinear.rs`, `plastic.rs`.

## Findings and fixes

### 1. HIGH — corotational 2D frame: 4× axial stiffness — `corotational.rs:401` (fixed, `6c4c6bf3`)

The natural-deformation map `P` in `assemble_frame_corotational` placed the elongation as `[+d_axial, −d_axial]` at nodes i/j, so the local elongation became `u_j − u_i = −2·d_axial` and `K_nat[0][0] = PᵀKP = 4EA/L` instead of `EA/L`. Internal force, tangent, and the `N` entering the geometric stiffness were all 4× too stiff axially. Inextensible-bending benchmarks never noticed; anything with real axial deformation did. Proof: fixed-free frame bar under 100 kN axial gave `ux = 0.0625 m = PL/(4EA)` before, `PL/(EA) = 0.25 m` and `N = 100 kN` after (new test `test_corotational_frame_axial_stiffness`, fails before / passes after). Fixed to `d_local = [0, 0, θi, d_axial, 0, θj]`, matching `compute_corotational_forces` and the corotational truss path.

Four validation tests were (unknowingly) calibrated to the bug and are repaired with justification, references and tolerances unchanged:

- `nonlinear_extended.rs` Williams toggle: the "analytical" limit `2EA·sin³α` overestimates the true engineering-strain limit `2EA·sin³α/(3√3)` by 5.2×, so the "20% sub-limit" load was actually ~104% of the true limit once axial stiffness is correct. Formula corrected (derivation in comment).
- `nonlinear_extended.rs` two-bar truss: same story — `2EA·sin²θ·cosθ` is ~6.6× the true limit at this steep angle; the limit is now found by maximizing the exact equilibrium path `P(h') = 2EA(1−L'/L0)(h'/L')`. The old final assertion was tautological (`assert_close(p_cr, <formula that defines p_cr>)`); replaced by a sanity check.
- `ansys_vm40` / `capability_vm14a` (Mattiasson elastica): the reference is *inextensible*, but the test section had `EA·L²/EI = 12`, so the now-correct axial compliance legitimately shifts the tip by tens of percent. Section area raised 1.0 → 100.0 (`EA·L²/EI = 1200`) so the inextensible reference applies; tolerances unchanged (5%/10%/15%).

### 2. HIGH — material nonlinear: support settlements broken — `material_nonlinear.rs:171-177,196-198` and 3D twins (fixed, `ca764a42`)

Two defects in the prescribed-displacement path of `solve_nonlinear_material_2d/3d`:

1. `u_r` was applied to `u_full` only *after* the first NR solve of each increment → a settlement-only increment (zero external load) "converged" on the first residual check with `u = 0`, silently ignoring the settlement.
2. The RHS subtracted `K_fr·u_r` although `f_int` already contains that coupling through `u_full`. The iteration's fixed point solved `K_ff·u = λF − (λ+1)·K_fr·u_r` (doubling the settlement response at full load) and the true residual stagnated at `‖K_fr·u_r‖`, so any load+settlement analysis exhausted `max_iter` and reported `converged=false`.

Fix: apply the increment's prescribed displacements before the NR loop; solve with the plain residual. Tests (fail before / pass after): 2D settlement+load vs `linear::solve_2d` (before: `converged=false`), 2D pure settlement (before: tip `uz = 0` instead of `0.01`), 3D settlement+load (before: `converged=false`).

### 3. MEDIUM — arc-length abort returned the failed step's state — `arc_length.rs:271-284` (fixed, `48ce8b7a`)

When a step failed to converge and `ds` fell below `min_ds`, `solve_arc_length` broke out *before* restoring `u_full`/`lambda` (the restore ran only on the retry path). The returned result carried displacements, element forces, and `final_load_factor` from the failed step's unconverged iterate. Fix: restore first, then check `min_ds`. Test `test_arc_length_abort_returns_last_converged_state` forces the abort path; before: `final_load_factor = 0.0125` (garbage); after: restored to the last converged state.

### 4. MEDIUM — nonlinear material reported `load_factor = 1.0` on failure — `material_nonlinear.rs:270,1049` (fixed, `678f7ab2`)

`load_factor` was hardcoded to 1.0 whenever `n_increments > 0`, even with `converged=false` and zero converged increments — partial results presented as full. Now reports the last converged increment's factor (marching-on behavior itself unchanged). Test: `max_iter=1` run reports `load_factor == 0.0` (was 1.000).

### 5. LOW — E2 filed item triage: `material_nonlinear.rs:462` missing `"guidedZ"` (fixed, `022cb1b6`)

Same shape as the E2 `pre_solve_gates` bug. **Unreachable here**, same proof as the E2 sibling sites: `guidedZ` restrains `ry` (`dof.rs:260`), so a guidedZ node's rotational DOF is numbered at index ≥ `n_free` (`dof.rs:61-63`), and the artificial-stiffness add is guarded by `idx < dof_num.n_free` (`material_nonlinear.rs:473`). Added `"guidedZ"` anyway for consistency/robustness; no behavior change. Grep of the section's files found no other support-type enumerations missing aliases.

### 6. LOW — stale comment — `geometric_stiffness.rs:329-333` (fixed, `022cb1b6`)

Trailing comment in `build_kg_from_forces_3d` claimed quad shell Kg was recomputed and added there; nothing was (buckling.rs adds shell Kg separately via `add_*_geometric_stiffness_3d`). Comment corrected.

## Deferred (real, not fixed here)

- **`pdelta.rs` reactions miss the K_G contribution** (`compute_reactions_from_u`, `pdelta.rs:209-257`, and 3D twin): reactions are computed as `K·u − F` from the *elastic* stiffness, while the converged state satisfies `(K+K_G)·u = F`. Reported reactions therefore violate global equilibrium by `K_G·u` at restrained DOFs — measured: portal frame at B2 ≈ 1.04 gives ΣRx = −31.25 vs applied +30 (4% off); the imbalance grows without bound near buckling. Not fixed: whether reactions should be `(K+K_G)u − F` is a convention decision that also interacts with element-force recovery (`k·u`), and changing reported reactions is user-visible. Recommend a dedicated decision + reference check.
- **`solve_pdelta_3d` never adds shell geometric stiffness** (`pdelta.rs:321`): only frame/truss K_G is included; quads/plates/quad9s/solid/curved shells contribute nothing to P-Δ (buckling.rs:253-285 shows the intended pattern via `add_*_geometric_stiffness_3d`). P-Δ on shell models silently ignores their second-order effect. Not fixed: changes shell P-Δ numbers and needs a shell P-Δ reference benchmark to validate.
- **3D corotational rigid-rotation extraction is small-angle** (`corotational.rs:1306-1309,1690-1692`): `β` is extracted as the axial vector of `skew(R)` = `sin(θ)·axis`, not `θ·axis` — exact for the element chord rotation only to second order, and the same `sin θ` vs `θ` error enters the nodal-rotation subtraction at large rotations (~36% at 90°). A proper fix needs quaternion/rotation-vector extraction (Battini 2002) — formula change, needs reference benchmarks. The 2D formulation is exact (atan2-based).
- **2D plastic event-to-event ignores moment sign** (`plastic.rs:124,140`): `Δλ = (Mp − |M_acc|)/|m_unit|` assumes the incremental moment has the same sign as the accumulated one; after redistribution a section can unload (opposite signs), making the true remaining capacity `(Mp + |M_acc|)/|m_unit|` — the code would form a premature hinge and underestimate the collapse factor. The 3D path does this correctly (quadratic with signed accumulators, `compute_interaction_delta`). Not fixed: I could not construct a minimal failing structure within the section's timebox — flagged as an open question needing a deciding test.
- **`adaptive_stepping.rs` / `line_search.rs` are dead in production**: nothing in `engine/src` calls `AdaptiveStepper`, `armijo_backtrack`, or `simple_line_search` (only their own tests + `tests/validation/domains/solver/line_search.rs`, which re-implements the NR loop around them). `docs/BENCHMARKS.md:295` already lists them as "need broader integration", so this is known — not deleted.
- **`arc_length.rs` corrector convergence floor** (`arc_length.rs:215`): `f_ext_norm = (|λ|·‖f_ref‖).max(1e-15)` becomes unsatisfiable when λ crosses 0 during snap-back (the method's main use case); displacement control uses `.max(1.0)` instead. Likely causes spurious ds-halving/abort near λ = 0. Not fixed: changing convergence criteria needs a snap-back reference case I didn't build in the timebox.

## Out-of-section findings (to file)

- Same missing-`guidedZ` enumeration shape exists at `assembly.rs:410,2017` and `sparse_assembly.rs:230,495,850` (unreachable by the same `idx < n_free` argument). E2 may already cover some of these on its branch — check before filing duplicates. (E2 already filed the `kinematic.rs` ones to E7.)

## Verification

- `cargo test -p dedaliano-engine`: baseline 4727 passed; after changes: all suites green (full run repeated after the final commit).
- `cd web && npm ci && npm run wasm && npm test`: unit 5242 passed / 274 files + build pass, both before (baseline) and after the engine changes (wasm rebuilt).
- Every correctness fix has a fail-before/pass-after test; both directions were run (fail-before via `git stash` of the source change with the test in place).

## Notes

- `docs/AUDIT_PLAN.md` is untracked and lives only in the main checkout — status-table update left to the coordinator.
