### PR TITLE
fix(engine): E5 audit — dynamics: Rayleigh anchoring, integration-parameter stability

### DIFF
--- a/engine/src/solver/damping.rs
+++ b/engine/src/solver/damping.rs
@@ -8,6 +8,52 @@ pub fn rayleigh_coefficients(omega1: f64, omega2: f64, xi: f64) -> (f64, f64) {
     (a0, a1)
 }
 
+/// Rayleigh coefficients anchored on the structure's OWN first two natural
+/// frequencies, solved for rather than guessed at.
+///
+/// `ξ(ω) = a₀/2ω + a₁ω/2` is a U-shaped curve, so the pair only means anything
+/// relative to the frequencies it was anchored on, and anchoring above the real
+/// spectrum sends the `a₀/2ω` branch through the roof exactly where a building
+/// responds. `time_integration` used to anchor on `√(Σ|K_ii| / Σ|M_ii|)`, which is
+/// a mass-weighted average of diagonal ratios and not a fundamental frequency at
+/// all: on the repo's 10-storey frame it returns 1027 rad/s against a true 1.15,
+/// and hands the fundamental mode ~669× the requested damping. A mode damped that
+/// hard does not respond, and a seismic run that suppresses the dominant mode
+/// under-predicts demand.
+///
+/// Rigid-body modes are filtered out — they are not what Rayleigh should anchor
+/// on — and the diagonal estimate survives only as the last resort when the
+/// eigensolve finds nothing usable, where being crude beats returning nothing.
+pub fn rayleigh_from_modes(k: &[f64], m: &[f64], n: usize, xi: f64) -> (f64, f64) {
+    if let Some(result) = crate::linalg::lanczos_generalized_eigen(k, m, n, 2, 0.0) {
+        let positive: Vec<f64> = result.values.iter().copied().filter(|&v| v > 1e-10).collect();
+        if positive.len() >= 2 {
+            return rayleigh_coefficients(positive[0].sqrt(), positive[1].sqrt(), xi);
+        } else if positive.len() == 1 {
+            let omega1 = positive[0].sqrt();
+            // One usable mode: bracket it rather than anchoring twice on the same
+            // frequency, which would leave the curve unconstrained on one side.
+            return rayleigh_coefficients(omega1, 3.0 * omega1, xi);
+        }
+    }
+
+    // Last resort: the smallest diagonal ratio, which at least tracks the softest
+    // DOF rather than the average of all of them.
+    let mut omega1_sq = f64::INFINITY;
+    for i in 0..n {
+        let kii = k[i * n + i];
+        let mii = m[i * n + i];
+        if mii > 1e-20 && kii > 1e-20 {
+            omega1_sq = omega1_sq.min(kii / mii);
+        }
+    }
+    if !omega1_sq.is_finite() || omega1_sq < 1e-20 {
+        return (0.0, 0.0);
+    }
+    let omega1 = omega1_sq.sqrt();
+    rayleigh_coefficients(omega1, 3.0 * omega1, xi)
+}
+
 /// Assemble Rayleigh damping matrix C = a0*M + a1*K.
 /// m, k: mass and stiffness matrices (n x n, row-major dense)
 pub fn rayleigh_damping_matrix(m: &[f64], k: &[f64], n: usize, a0: f64, a1: f64) -> Vec<f64> {

--- a/engine/src/solver/harmonic.rs
+++ b/engine/src/solver/harmonic.rs
@@ -504,52 +504,15 @@ pub fn solve_complex_system(
     Ok((u_real, u_imag))
 }
 
-/// Estimate first two natural frequencies from K and M for Rayleigh damping.
-/// Uses the Lanczos eigenvalue solver for accurate natural frequencies.
+/// Estimate the first two natural frequencies from K and M for Rayleigh damping.
+///
+/// Delegates: this logic used to live here in full while `time_integration` carried
+/// its own, much cruder, copy. Two modules doing the same job with different
+/// accuracy is how the seismic path ended up anchoring its damping 892× high.
 fn compute_rayleigh_from_stiffness_mass(
     k: &[f64], m: &[f64], n: usize, xi: f64,
 ) -> (f64, f64) {
-    // Use Lanczos to find the first two eigenvalues (omega^2)
-    if let Some(result) = lanczos_generalized_eigen(k, m, n, 2, 0.0) {
-        // Filter out near-zero eigenvalues (rigid-body modes)
-        let positive: Vec<f64> = result.values.iter()
-            .copied()
-            .filter(|&v| v > 1e-10)
-            .collect();
-
-        if positive.len() >= 2 {
-            let omega1 = positive[0].sqrt();
-            let omega2 = positive[1].sqrt();
-            return rayleigh_coefficients(omega1, omega2, xi);
-        } else if positive.len() == 1 {
-            let omega1 = positive[0].sqrt();
-            let omega2 = 3.0 * omega1; // fallback ratio for second mode
-            return rayleigh_coefficients(omega1, omega2, xi);
-        }
-    }
-
-    // Fallback: diagonal ratio estimate
-    let mut omega1_sq: f64 = 0.0;
-    let mut count: usize = 0;
-    for i in 0..n {
-        let kii = k[i * n + i];
-        let mii = m[i * n + i];
-        if mii > 1e-20 && kii > 1e-20 {
-            let ratio = kii / mii;
-            if count == 0 || ratio < omega1_sq {
-                omega1_sq = ratio;
-            }
-            count += 1;
-        }
-    }
-
-    if omega1_sq < 1e-20 {
-        return (0.0, 0.0);
-    }
-
-    let omega1 = omega1_sq.sqrt();
-    let omega2 = 3.0 * omega1;
-    rayleigh_coefficients(omega1, omega2, xi)
+    rayleigh_from_modes(k, m, n, xi)
 }
 
 fn get_target_dof_2d(dof_num: &DofNumbering, node_id: usize, dof: &str) -> Result<usize, String> {

--- a/engine/src/solver/time_integration.rs
+++ b/engine/src/solver/time_integration.rs
@@ -274,37 +274,12 @@ fn compute_damping_matrix(
         _ => return vec![0.0; nf * nf],
     };
 
-    // Estimate omega1 via Rayleigh quotient: omega1^2 ~ (phi^T K phi) / (phi^T M phi)
-    // Use a unit vector as initial guess, then one step of inverse iteration
-    let omega1 = estimate_fundamental_frequency(k_ff, m_ff, nf);
-    let omega2 = 3.0 * omega1; // Bracket a range of frequencies
-
-    let (a0, a1) = damping::rayleigh_coefficients(omega1, omega2, xi);
+    // Anchored on the structure's real first two modes. This used to call
+    // `estimate_fundamental_frequency` — √(Σ|K_ii|/Σ|M_ii|), a mass-weighted average
+    // of diagonal ratios, not a fundamental frequency — which on a 10-storey frame
+    // read 1027 rad/s against a true 1.15 and over-damped the dominant mode ~669×.
+    let (a0, a1) = damping::rayleigh_from_modes(k_ff, m_ff, nf, xi);
     damping::rayleigh_damping_matrix(m_ff, k_ff, nf, a0, a1)
-}
-
-/// Estimate the fundamental circular frequency from K and M using the Rayleigh quotient.
-fn estimate_fundamental_frequency(k: &[f64], m: &[f64], n: usize) -> f64 {
-    // Use the diagonal Rayleigh quotient as a quick estimate:
-    // omega^2 ~ sum(K_ii) / sum(M_ii) for translational DOFs
-    let mut k_sum = 0.0;
-    let mut m_sum = 0.0;
-    for i in 0..n {
-        k_sum += k[i * n + i].abs();
-        m_sum += m[i * n + i].abs();
-    }
-
-    if m_sum < 1e-30 {
-        // Fallback: assume 1 Hz
-        return 2.0 * std::f64::consts::PI;
-    }
-
-    let omega2 = k_sum / m_sum;
-    if omega2 <= 0.0 {
-        return 2.0 * std::f64::consts::PI;
-    }
-
-    omega2.sqrt()
 }
 
 /// Compute initial acceleration: M * a0 = F0 - C*v0 - K*u0.

--- a/engine/src/solver/time_integration.rs
+++ b/engine/src/solver/time_integration.rs
@@ -20,19 +20,7 @@ pub fn solve_time_history_2d(
     let referenced_material_ids = super::dynamic_validation::referenced_material_ids_2d(&input.solver);
     super::dynamic_validation::validate_densities(&input.densities, &referenced_material_ids)?;
     super::dynamic_validation::validate_time_params(input.time_step, input.n_steps)?;
-    if !input.beta.is_finite() || !input.gamma.is_finite() {
-        return Err("Newmark beta/gamma parameters must be finite".to_string());
-    }
-    if let Some(alpha) = input.alpha {
-        if !alpha.is_finite() {
-            return Err("HHT alpha parameter must be finite".to_string());
-        }
-    }
-    if let Some(damping_xi) = input.damping_xi {
-        if !damping_xi.is_finite() {
-            return Err("damping_xi must be finite".to_string());
-        }
-    }
+    validate_integration_params(input.beta, input.gamma, input.alpha, input.damping_xi)?;
     if let Some(ga) = &input.ground_accel {
         if ga.iter().any(|v| !v.is_finite()) {
             return Err("Ground acceleration history contains non-finite values".to_string());
@@ -263,6 +251,60 @@ pub fn solve_time_history_2d(
 // ============================================================================
 // Internal helpers
 // ============================================================================
+
+/// Reject integration parameters that make the scheme amplify.
+///
+/// These were checked for finiteness only, so a provably unstable scheme ran to
+/// completion and returned numbers. Nothing downstream re-checks, and a diverging
+/// history is not distinguishable from a resonant one by looking at it.
+///
+/// * `γ < ½` gives Newmark NEGATIVE numerical damping — energy grows every step.
+///   γ = ½ is the neutral value; above it the scheme merely damps.
+/// * HHT-α sets `γ = ½ − α`, so `α > 0` is the same defect wearing another name,
+///   and below −1/3 the method loses second-order accuracy. The range was already
+///   written in the comment beside the formula; this makes it hold.
+/// * A negative `damping_xi` was accepted and then silently dropped by
+///   `compute_damping_matrix`'s `x > 0.0` guard, so the run reported a damped
+///   method in `result.method` while assembling no damping at all.
+///
+/// NOT checked here: `β < γ/2` is conditionally stable rather than unstable —
+/// linear acceleration (β = 1/6, γ = ½) is a legitimate scheme — and its stability
+/// depends on Δt against the model's highest frequency, which this solver does not
+/// compute. Refusing it would remove a valid capability and accepting it silently
+/// is what this function exists to stop, so it needs a warning channel
+/// `TimeHistoryResult` does not have. Left for the E5 write-up.
+fn validate_integration_params(
+    beta: f64, gamma: f64, alpha: Option<f64>, damping_xi: Option<f64>,
+) -> Result<(), String> {
+    if !beta.is_finite() || !gamma.is_finite() {
+        return Err("Newmark beta/gamma parameters must be finite".to_string());
+    }
+    if let Some(alpha) = alpha {
+        if !alpha.is_finite() {
+            return Err("HHT alpha parameter must be finite".to_string());
+        }
+        if !(-1.0 / 3.0..=0.0).contains(&alpha) {
+            return Err(format!(
+                "HHT alpha must be in [-1/3, 0] (got {alpha}). Above 0 it gives \
+                 gamma = 0.5 - alpha < 0.5, which amplifies instead of damping."
+            ));
+        }
+    } else if gamma < 0.5 {
+        return Err(format!(
+            "Newmark gamma must be >= 0.5 (got {gamma}). Below 0.5 the scheme has \
+             negative numerical damping and the response grows without bound."
+        ));
+    }
+    if let Some(xi) = damping_xi {
+        if !xi.is_finite() {
+            return Err("damping_xi must be finite".to_string());
+        }
+        if xi < 0.0 {
+            return Err(format!("damping_xi must be >= 0 (got {xi})"));
+        }
+    }
+    Ok(())
+}
 
 /// Compute the Rayleigh damping matrix for free DOFs.
 /// If damping_xi is None, returns a zero matrix.
@@ -804,19 +846,7 @@ pub fn solve_time_history_3d(
     let referenced_material_ids = super::dynamic_validation::referenced_material_ids_3d(&input.solver);
     super::dynamic_validation::validate_densities(&input.densities, &referenced_material_ids)?;
     super::dynamic_validation::validate_time_params(input.time_step, input.n_steps)?;
-    if !input.beta.is_finite() || !input.gamma.is_finite() {
-        return Err("Newmark beta/gamma parameters must be finite".to_string());
-    }
-    if let Some(alpha) = input.alpha {
-        if !alpha.is_finite() {
-            return Err("HHT alpha parameter must be finite".to_string());
-        }
-    }
-    if let Some(damping_xi) = input.damping_xi {
-        if !damping_xi.is_finite() {
-            return Err("damping_xi must be finite".to_string());
-        }
-    }
+    validate_integration_params(input.beta, input.gamma, input.alpha, input.damping_xi)?;
     for ga in [&input.ground_accel_x, &input.ground_accel_y, &input.ground_accel_z] {
         if let Some(ga) = ga {
             if ga.iter().any(|v| !v.is_finite()) {

--- a/engine/tests/core/modal.rs
+++ b/engine/tests/core/modal.rs
@@ -214,3 +214,57 @@ fn modal_no_density_fails() {
     let result = modal::solve_modal_2d(&input, &densities, 2);
     assert!(result.is_err(), "should fail with no mass");
 }
+
+// ─── Rayleigh damping anchoring ─────────────────────────────
+
+/// Rayleigh damping must deliver the ratio the user ASKED FOR at the structure's
+/// own fundamental frequency.
+///
+/// ξ(ω) = a₀/2ω + a₁ω/2 is a U-shaped curve, so the pair (a₀, a₁) is only
+/// meaningful relative to the frequencies it was anchored on. Anchoring above the
+/// real spectrum sends the a₀/2ω branch through the roof exactly where the
+/// building responds: `time_integration` estimated ω₁ as √(Σ|K_ii|/Σ|M_ii|), which
+/// on a 10-storey frame returns 1027 rad/s against a true 1.15 — and hands the
+/// fundamental mode ~669× the requested damping. A mode damped 669× too hard does
+/// not respond, and a seismic run that suppresses the dominant mode under-predicts
+/// demand. Hence a test on the delivered ratio rather than on the estimate.
+#[test]
+fn rayleigh_delivers_the_requested_ratio_at_the_real_fundamental() {
+    use dedaliano_engine::solver::{assembly, damping, dof::DofNumbering};
+    use dedaliano_engine::solver::mass_matrix::assemble_mass_matrix_2d;
+
+    let n_elem = 8;
+    let mut input = make_ss_beam_udl(n_elem, L, E, A, IZ, 0.0);
+    input.loads.clear();
+    let densities = make_densities();
+
+    let dof_num = DofNumbering::build_2d(&input);
+    let nf = dof_num.n_free;
+    let asm = assembly::assemble_2d(&input, &dof_num);
+    let m = assemble_mass_matrix_2d(&input, &dof_num, &densities);
+
+    // Extract the free-free blocks.
+    let n = dof_num.n_total;
+    let mut k_ff = vec![0.0; nf * nf];
+    let mut m_ff = vec![0.0; nf * nf];
+    for i in 0..nf {
+        for j in 0..nf {
+            k_ff[i * nf + j] = asm.k[i * n + j];
+            m_ff[i * nf + j] = m[i * n + j];
+        }
+    }
+
+    let xi = 0.05;
+    let (a0, a1) = damping::rayleigh_from_modes(&k_ff, &m_ff, nf, xi);
+
+    let rho_a_solver = DENSITY * A / 1000.0;
+    let omega1 = (std::f64::consts::PI / L).powi(2) * (EI / rho_a_solver).sqrt();
+
+    let xi_eff = a0 / (2.0 * omega1) + a1 * omega1 / 2.0;
+    let ratio = xi_eff / xi;
+    assert!(
+        (0.5..=2.0).contains(&ratio),
+        "asked for xi={xi}, the fundamental (omega={omega1:.1}) actually gets \
+         xi_eff={xi_eff:.4} ({ratio:.1}x). a0={a0:.4e} a1={a1:.4e}"
+    );
+}

--- a/engine/tests/input_validation_gates.rs
+++ b/engine/tests/input_validation_gates.rs
@@ -339,3 +339,49 @@ fn linear_3d_rejects_dangling_shell_node() {
     let input = tiny_3d_input_with_dangling_quad();
     expect_clean_err("linear 3D dangling shell node", || linear::solve_3d(&input));
 }
+
+// ─── Newmark / HHT stability parameters ─────────────────────
+//
+// These were validated for finiteness only, so a scheme that provably amplifies
+// was accepted and ran to completion, returning numbers. Newmark carries negative
+// numerical damping for γ < ½ — energy grows every step — and HHT-α reduces to
+// exactly that through γ = ½ − α whenever α > 0. Nothing downstream re-checks, and
+// a diverging run is not distinguishable from a resonant one by looking at it.
+
+#[test]
+fn newmark_gamma_below_one_half_is_refused() {
+    let mut input = th_input(tiny_beam_2d());
+    input.gamma = 0.4; // negative numerical damping
+    expect_clean_err("gamma < 1/2", || time_integration::solve_time_history_2d(&input));
+}
+
+#[test]
+fn hht_alpha_outside_its_documented_range_is_refused() {
+    for bad in [0.1_f64, -0.5] {
+        let mut input = th_input(tiny_beam_2d());
+        input.alpha = Some(bad);
+        expect_clean_err("alpha outside [-1/3, 0]", || time_integration::solve_time_history_2d(&input));
+    }
+}
+
+#[test]
+fn negative_damping_is_refused_rather_than_ignored() {
+    // Silently dropping it is worse than refusing: the run reports a damped
+    // method in `result.method` while having assembled no damping at all.
+    let mut input = th_input(tiny_beam_2d());
+    input.damping_xi = Some(-0.05);
+    expect_clean_err("negative damping_xi", || time_integration::solve_time_history_2d(&input));
+}
+
+#[test]
+fn the_stable_defaults_still_run() {
+    // The guard must not cost the schemes that are correct: average acceleration
+    // (β=¼, γ=½) and the HHT endpoints.
+    let input = th_input(tiny_beam_2d());
+    assert!(time_integration::solve_time_history_2d(&input).is_ok(), "beta=1/4 gamma=1/2");
+    for good in [0.0_f64, -1.0 / 3.0, -0.05] {
+        let mut i2 = th_input(tiny_beam_2d());
+        i2.alpha = Some(good);
+        assert!(time_integration::solve_time_history_2d(&i2).is_ok(), "alpha={good}");
+    }
+}


### PR DESCRIPTION
Section E5 of the audit queue: `engine/src/solver/{modal,spectral,harmonic,time_integration,mass_matrix,damping,dynamic_validation}.rs`, ~4.1k lines.

**Based on #143, not on `main`.** E5's subject is the callers of the eigensolver #143 fixes. Auditing modal and buckling against a solver that returns non-eigenvectors would make every number measured here meaningless, and the damping fix below is measured through a modal solve. Merge #143 first; this retargets to `main` after.

## Fixed

### 1. Rayleigh damping was anchored ~892× above the real spectrum

`time_integration.rs` estimated the fundamental frequency as `√(Σ|K_ii| / Σ|M_ii|)` — a mass-weighted average of diagonal ratios, which is not a fundamental frequency and is not near one:

| model | true ω₁ | estimate | error |
|---|---|---|---|
| 10-storey frame (nf=300) | 1.15 | 1027 | **892×** |
| simply-supported beam (8 el) | 199.3 | 11259 | 56× |

`ξ(ω) = a₀/2ω + a₁ω/2` is U-shaped, so the coefficient pair only means anything relative to the frequencies it was anchored on. Anchoring above the spectrum sends the `a₀/2ω` branch through the roof exactly where the structure responds: the fundamental mode receives **~669×** the requested ratio on the frame, 42× on the beam. Asking for 5 % hands the dominant mode several thousand percent of critical — which does not damp it so much as delete it. **A seismic time-history that suppresses the mode carrying the demand under-predicts that demand.**

`harmonic.rs` already did this correctly, with Lanczos and a diagonal fallback. Two modules doing one job at different accuracy is how the seismic path ended up with the bad copy. The good version now lives in `damping.rs` as `rayleigh_from_modes`; `harmonic` delegates, `time_integration` calls it, and its own estimator is deleted — along with the comment above it promising "one step of inverse iteration", an algorithm the function did not contain.

The last-resort diagonal path is kept for when the eigensolve finds nothing usable, but takes the **minimum** diagonal ratio rather than the ratio of sums: the softest DOF is at least in the neighbourhood of the fundamental, whereas the average of all of them is what produced the table above.

### 2. Integration parameters that make the scheme amplify were accepted

Checked for finiteness only. Now refused: `gamma < 0.5` (negative numerical damping — energy grows every step), `alpha` outside [-1/3, 0] (HHT sets `gamma = 0.5 - alpha`, so `alpha > 0` is the same defect renamed), and `damping_xi < 0` (accepted, then silently dropped downstream, so the result reported a damped method with no damping assembled).

Validation was duplicated verbatim across the 2D and 3D entry points; both now call one function.

## Deferred, with reasons

- **`beta < gamma/2` is not refused.** Conditionally stable, not unstable — linear acceleration (β=1/6, γ=½) is legitimate — and stability there depends on Δt against the model's highest frequency, which this solver never computes. Refusing removes a valid capability; accepting silently is what the new guard exists to stop. It needs a warning channel, and `TimeHistoryResult` has no diagnostics field, so adding one reaches the WASM boundary and the web.
- **No participating-mass sufficiency check in the response-spectrum path.** `spectral.rs` consumes participation and effective mass per mode but never checks they reach the ≥90 % the codes require, and there is no missing-mass or residual-rigid correction. Compounds with the repeated-eigenvalue mode drop left open in #143.
- **Buckling has no participating-mass analogue at all.** `BucklingResult` carries only modes, `n_dof` and element data, so a dropped buckling mode has no detection path the way a dropped modal one does.

## A coverage gap this exposed

Nothing else in the suite moved when the damping fix landed — and that is a finding, not a relief. **Nine test files pass `damping_xi: Some(0.05)`, and a 42–892× error in the damping they receive breaks none of them.** They assert that amplitude does not grow, never what the response actually is. There is no damped time-history test on a realistic multi-storey structure, which is exactly where the error is largest.

## Verified sound (no action)

- Rayleigh coefficient algebra in `damping.rs` — derived independently; `ξ` is delivered exactly at both anchor frequencies.
- `dynamic_validation.rs` — including the subtle case it documents, where a density keyed to a material no element references contributes nothing.
- Modal participation arithmetic — the standard scale-invariant form, normalised against physical total mass (`compute_total_mass`, not the sum of modes found), so a missing mode does show as a shortfall.
- **CQC** — checked against Der Kiureghian; `ρ_ii = 16ξ²/16ξ² = 1`. SRSS standard.
- Mass conservation in **both** assembler branches: consistent gives (140+70+70+140)·m = ρAL, the hinged lumped branch gives ρAL/2 + ρAL/2. A hinge does silently switch the element's mass model and zero its rotational inertia, which is documented as "Simplified" but is a modelling change the user never sees.

## Coverage

Complete: `damping.rs`, `dynamic_validation.rs`, `modal.rs`, `spectral.rs` (combination rules), `mass_matrix.rs` (mass representation). Partial: `time_integration.rs` (validation, Rayleigh, the Newmark loop — not the record interpolation or the 3D path in detail) and `harmonic.rs` (Rayleigh only). Stated so the next pass knows where to start rather than assuming the section is closed.

## Verification

`cargo test -p dedaliano-engine --no-fail-fast`: **7,061 passed, 0 failed, 28 binaries.**

Each fix has a test that fails before and passes after. Worth recording that the Rayleigh test's red was only a compile error — the function did not exist yet — which proves nothing about the value; measuring afterwards showed the beam case would have failed it at 42.4× against a bound of 2.0, so it does discriminate.