### PR TITLE
fix(web): say which thickness the quoted fy belongs to, and whose table says so

### DIFF
--- a/web/src/components/MaterialPresetSelector.svelte
+++ b/web/src/components/MaterialPresetSelector.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { MATERIAL_CATEGORIES, searchPresets, categoryFamily, type MaterialPreset } from '../lib/data/material-presets';
+  import { MATERIAL_CATEGORIES, searchPresets, categoryFamily, bandSummary, type MaterialPreset } from '../lib/data/material-presets';
   import {
     MATERIAL_DESIGN_CODES, codesForFamily, codesForMode, defaultCodeFor,
   } from '../lib/data/structural-grades';
@@ -152,6 +152,7 @@
 
       <div class="preset-list">
         {#each filtered as p}
+          {@const bands = bandSummary(p)}
           <button class="preset-item" onclick={() => onselect(p)}>
             <span class="preset-name">
               {p.name}
@@ -168,17 +169,21 @@
             </span>
             <span class="preset-props">
               E={p.e >= 1000 ? `${(p.e/1000).toFixed(0)}GPa` : `${p.e}MPa`}
-              <!-- The quoted fy is the THIN-PLATE value. Hot-rolled yield falls
-                   with thickness — S355 is 355 MPa to 40 mm and 335 beyond it —
-                   so a picker that shows one number lets someone size a thick
-                   plate 6 % unconservative without ever being told. The band is
-                   named where the number is, not in a tooltip nobody opens. -->
+              <!-- The quoted fy applies to the first thickness band only.
+                   Hot-rolled yield falls with thickness — S355 is 355 MPa to
+                   40 mm and 335 beyond it — so a picker that shows one number
+                   lets someone size a thick plate 6 % unconservative without
+                   ever being told.
+
+                   Both numbers go on screen, not just the bound: `title` is
+                   mouse-only and never reaches the button's accessible name,
+                   so anything left there is unreachable by touch or keyboard.
+                   What stays in the tooltip is the full table and the standard
+                   the bands come from — which is the DESIGN code, not the
+                   product standard shown beside the grade name. -->
               {#if p.fy}
-                fy={p.fy}MPa{#if p.thicknessBands?.length}<span
-                  class="preset-band"
-                  title={p.thicknessBands.map((b) =>
-                    `${b.overMm}–${b.upToMm} mm: fy ${b.fy} MPa`).join(' · ')}
-                >≤{p.thicknessBands[0].upToMm}mm</span>{/if}
+                fy={p.fy}MPa{#if bands}<span class="preset-band" title={bands.full}
+                >{bands.tail}</span>{/if}
               {/if}
               {#if p.fu} fu={p.fu}MPa{/if}
               ρ={p.rho}kN/m³
@@ -399,12 +404,15 @@
     font-size: 0.72rem;
     color: var(--st-text-3);
   }
-  /* Attached to the fy it qualifies, with no gap, so it reads as part of the
-     value rather than as a separate property. */
+  /* Sits on the baseline beside the fy it qualifies, not raised: this carries
+     a second number now, and ten superscript characters are a footnote mark,
+     not a value anyone reads. The parentheses do the grouping the raise used
+     to, so it still attaches to fy rather than reading as a property of its
+     own. */
   .preset-band {
+    margin-left: 3px;
     font-size: 0.68rem;
     color: var(--st-text-3);
-    vertical-align: super;
   }
   .preset-unver {
     margin-left: 5px;

--- a/web/src/components/MaterialPresetSelector.svelte
+++ b/web/src/components/MaterialPresetSelector.svelte
@@ -168,7 +168,18 @@
             </span>
             <span class="preset-props">
               E={p.e >= 1000 ? `${(p.e/1000).toFixed(0)}GPa` : `${p.e}MPa`}
-              {#if p.fy} fy={p.fy}MPa{/if}
+              <!-- The quoted fy is the THIN-PLATE value. Hot-rolled yield falls
+                   with thickness — S355 is 355 MPa to 40 mm and 335 beyond it —
+                   so a picker that shows one number lets someone size a thick
+                   plate 6 % unconservative without ever being told. The band is
+                   named where the number is, not in a tooltip nobody opens. -->
+              {#if p.fy}
+                fy={p.fy}MPa{#if p.thicknessBands?.length}<span
+                  class="preset-band"
+                  title={p.thicknessBands.map((b) =>
+                    `${b.overMm}–${b.upToMm} mm: fy ${b.fy} MPa`).join(' · ')}
+                >≤{p.thicknessBands[0].upToMm}mm</span>{/if}
+              {/if}
               {#if p.fu} fu={p.fu}MPa{/if}
               ρ={p.rho}kN/m³
             </span>
@@ -387,6 +398,13 @@
     font-weight: 400;
     font-size: 0.72rem;
     color: var(--st-text-3);
+  }
+  /* Attached to the fy it qualifies, with no gap, so it reads as part of the
+     value rather than as a separate property. */
+  .preset-band {
+    font-size: 0.68rem;
+    color: var(--st-text-3);
+    vertical-align: super;
   }
   .preset-unver {
     margin-left: 5px;

--- a/web/src/lib/data/__tests__/material-presets-thickness.test.ts
+++ b/web/src/lib/data/__tests__/material-presets-thickness.test.ts
@@ -7,7 +7,7 @@
  *
  * Every production caller ignored it. `fromGrade` copied `g.fy` and dropped the
  * bands, so the picker offered S355 as a flat 355 MPa and a user sizing a 60 mm
- * plate got a yield stress 6 % above what EN 10025-2 gives them (335). The error
+ * plate got a yield stress 6 % above the 335 MPa that governs there. The error
  * runs in the unsafe direction, which is why it is worth carrying rather than
  * documenting.
  *
@@ -16,29 +16,37 @@
  * stops the picker claiming a certainty the standard does not give.
  */
 import { describe, it, expect } from 'vitest';
-import { getMaterialPresets } from '../material-presets';
+import { bandSummary, getMaterialPresets } from '../material-presets';
 import { ALL_GRADES } from '../structural-grades';
 
 const PRESETS = getMaterialPresets();
+const BANDED = ALL_GRADES.filter((g) => g.byThickness && g.byThickness.length > 0);
 
 describe('a preset carries its grade thickness bands', () => {
   it('keeps the bands for every grade that has them', () => {
-    const banded = ALL_GRADES.filter((g) => g.byThickness && g.byThickness.length > 0);
-    expect(banded.length, 'the fixture for this test is the data itself').toBeGreaterThan(0);
+    expect(BANDED.length, 'the fixture for this test is the data itself').toBeGreaterThan(0);
 
-    for (const g of banded) {
+    // Counted rather than only looped: `continue` on a missing preset would
+    // let this pass while checking nothing at all, the day the grade-to-preset
+    // projection stops emitting one of these.
+    let checked = 0;
+    for (const g of BANDED) {
       const preset = PRESETS.find((p) => p.gradeId === g.id);
       if (!preset) continue; // not every grade is offered in every picker
       expect(preset.thicknessBands, `${g.designation} lost its bands`).toBeDefined();
       expect(preset.thicknessBands!.length).toBe(g.byThickness!.length);
+      checked++;
     }
+    expect(checked, 'every banded grade reaches a preset today').toBe(BANDED.length);
   });
 
   it('leaves a grade with a single tabulated value alone', () => {
     const flat = ALL_GRADES.find((g) => !g.byThickness);
     expect(flat, 'some grade is tabulated as one value').toBeDefined();
     const preset = PRESETS.find((p) => p.gradeId === flat!.id);
-    if (preset) expect(preset.thicknessBands).toBeUndefined();
+    expect(preset, 'the unbanded grade reaches a preset, so this checks something').toBeDefined();
+    expect(preset!.thicknessBands).toBeUndefined();
+    expect(bandSummary(preset!)).toBeNull();
   });
 
   it('the quoted fy is the FIRST band, so the bands explain the headline number', () => {
@@ -49,11 +57,91 @@ describe('a preset carries its grade thickness bands', () => {
     }
   });
 
-  it('S355 specifically drops to 335 MPa over 40 mm, per EN 10025-2', () => {
+  it('S355 drops to 335 MPa over 40 mm, per EN 1993-1-1 table 3.1', () => {
     // The grade the module's own docstring uses to explain the hazard.
     const s355 = PRESETS.find((p) => p.gradeId === 'en-s355');
     expect(s355?.fy).toBe(355);
     const thick = s355?.thicknessBands?.find((b) => b.overMm === 40);
     expect(thick?.fy, 'the 40–80 mm band').toBe(335);
+  });
+});
+
+/**
+ * Where a band comes from is not where the grade comes from.
+ *
+ * Every band in the catalogue is a DESIGN code's table while `standard` names
+ * the PRODUCT standard, and the picker prints them side by side. Left unsaid,
+ * the 40 mm step reads as EN 10025-2's — which it is not: that standard steps
+ * at 16 mm and gives S355 as 345 MPa above it. Conflating the two axes is the
+ * error `structural-grades.ts` exists to prevent, so it must not be reintroduced
+ * by the thing that displays them.
+ */
+describe('a band says which standard tabulated it', () => {
+  it('names a source for every banded grade', () => {
+    for (const g of BANDED) {
+      expect(g.bandStandard, `${g.designation} has bands from nowhere`).toBeTruthy();
+    }
+  });
+
+  it('never claims the bands came from the product standard', () => {
+    for (const g of BANDED) {
+      expect(g.bandStandard, `${g.designation}`).not.toBe(g.productStandard);
+    }
+  });
+
+  it('carries the source onto the preset, next to the bands it qualifies', () => {
+    for (const g of BANDED) {
+      const preset = PRESETS.find((p) => p.gradeId === g.id);
+      expect(preset?.bandStandard, `${g.designation}`).toBe(g.bandStandard);
+    }
+  });
+
+  it('puts the source in the tooltip text', () => {
+    const s355 = PRESETS.find((p) => p.gradeId === 'en-s355')!;
+    expect(bandSummary(s355)!.full).toBe(
+      'EN 1993-1-1 t.3.1 · 0–40 mm: fy 355 MPa · 40–80 mm: fy 335 MPa',
+    );
+  });
+});
+
+/**
+ * The one line the picker shows, which is the whole point of the change.
+ *
+ * These assert the rendered strings because the markup itself has no test:
+ * there is no component-test setup in this repo and the material picker has no
+ * e2e coverage, so pinning the text the template interpolates is as close to
+ * the user-visible result as this suite reaches.
+ */
+describe('the summary the picker shows', () => {
+  it('states the far value, not only the bound, so nothing needs a hover', () => {
+    const s355 = PRESETS.find((p) => p.gradeId === 'en-s355')!;
+    expect(bandSummary(s355)!.tail).toBe('(>40mm: 335)');
+  });
+
+  it('reads as a rise for the one grade that gets stronger with thickness', () => {
+    // 6082-T6 runs the other way and EN 1999-1-1 flags it as not a misprint.
+    // Quoting the far value states that without asserting a direction; wording
+    // it as a fall would have been wrong here and nowhere else.
+    const alu = PRESETS.find((p) => p.gradeId === 'alu-6082-t6')!;
+    expect(alu.fy).toBe(250);
+    expect(bandSummary(alu)!.tail).toBe('(>5mm: 260)');
+  });
+
+  it('says nothing for a grade with no bands', () => {
+    expect(bandSummary({ thicknessBands: undefined })).toBeNull();
+    expect(bandSummary({ thicknessBands: [] })).toBeNull();
+  });
+
+  /**
+   * The summary quotes the FIRST band's bound and the LAST band's value, which
+   * is exact for two bands and would skip the middle of three. Every banded
+   * grade has exactly two today. Pinning that means a three-band grade fails
+   * here — where the decision is — instead of silently rendering a step that
+   * does not exist.
+   */
+  it('assumes two bands, and every catalogued grade has exactly two', () => {
+    for (const g of BANDED) {
+      expect(g.byThickness!.length, `${g.designation} — bandSummary would skip a step`).toBe(2);
+    }
   });
 });

--- a/web/src/lib/data/__tests__/material-presets-thickness.test.ts
+++ b/web/src/lib/data/__tests__/material-presets-thickness.test.ts
@@ -1,0 +1,59 @@
+/**
+ * A preset must not present a thickness-dependent `fy` as if it were one number.
+ *
+ * `structural-grades.ts` says so itself: "`fy` for hot-rolled steel FALLS with
+ * thickness … `byThickness` carries it and `fy` is the thin-plate value — so a
+ * caller that ignores thickness is unconservative, by about 6%, silently."
+ *
+ * Every production caller ignored it. `fromGrade` copied `g.fy` and dropped the
+ * bands, so the picker offered S355 as a flat 355 MPa and a user sizing a 60 mm
+ * plate got a yield stress 6 % above what EN 10025-2 gives them (335). The error
+ * runs in the unsafe direction, which is why it is worth carrying rather than
+ * documenting.
+ *
+ * This does NOT change the number the model uses — plumbing the member's real
+ * thickness into the design check is a larger change with its own decisions. It
+ * stops the picker claiming a certainty the standard does not give.
+ */
+import { describe, it, expect } from 'vitest';
+import { getMaterialPresets } from '../material-presets';
+import { ALL_GRADES } from '../structural-grades';
+
+const PRESETS = getMaterialPresets();
+
+describe('a preset carries its grade thickness bands', () => {
+  it('keeps the bands for every grade that has them', () => {
+    const banded = ALL_GRADES.filter((g) => g.byThickness && g.byThickness.length > 0);
+    expect(banded.length, 'the fixture for this test is the data itself').toBeGreaterThan(0);
+
+    for (const g of banded) {
+      const preset = PRESETS.find((p) => p.gradeId === g.id);
+      if (!preset) continue; // not every grade is offered in every picker
+      expect(preset.thicknessBands, `${g.designation} lost its bands`).toBeDefined();
+      expect(preset.thicknessBands!.length).toBe(g.byThickness!.length);
+    }
+  });
+
+  it('leaves a grade with a single tabulated value alone', () => {
+    const flat = ALL_GRADES.find((g) => !g.byThickness);
+    expect(flat, 'some grade is tabulated as one value').toBeDefined();
+    const preset = PRESETS.find((p) => p.gradeId === flat!.id);
+    if (preset) expect(preset.thicknessBands).toBeUndefined();
+  });
+
+  it('the quoted fy is the FIRST band, so the bands explain the headline number', () => {
+    // If these ever disagree the picker would show one number and caveat another.
+    for (const p of PRESETS) {
+      if (!p.thicknessBands?.length) continue;
+      expect(p.fy, `${p.name}`).toBe(p.thicknessBands[0].fy);
+    }
+  });
+
+  it('S355 specifically drops to 335 MPa over 40 mm, per EN 10025-2', () => {
+    // The grade the module's own docstring uses to explain the hazard.
+    const s355 = PRESETS.find((p) => p.gradeId === 'en-s355');
+    expect(s355?.fy).toBe(355);
+    const thick = s355?.thicknessBands?.find((b) => b.overMm === 40);
+    expect(thick?.fy, 'the 40–80 mm band').toBe(335);
+  });
+});

--- a/web/src/lib/data/material-presets.ts
+++ b/web/src/lib/data/material-presets.ts
@@ -37,19 +37,61 @@ export interface MaterialPreset {
    */
   verification?: 'standard' | 'typical';
   /**
-   * The grade's thickness bands, where the product standard tabulates them.
+   * The grade's thickness bands, where they are tabulated.
    *
-   * `fy` above is the THIN-PLATE value, which is what `structural-grades.ts`
-   * warns about in its own header: hot-rolled yield falls with thickness, and a
-   * caller that quotes the headline number for a 60 mm plate is unconservative
-   * by about 6 %. Carrying the bands lets the picker say so instead of
-   * presenting one number as if the standard gave only one.
+   * `fy` above is the value for the FIRST band, which is what
+   * `structural-grades.ts` warns about in its own header: hot-rolled yield
+   * falls with thickness, and a caller that quotes the headline number for a
+   * 60 mm plate is unconservative by about 6 %. Carrying the bands lets the
+   * picker say so instead of presenting one number as if only one existed.
    *
    * This is disclosure, not selection: nothing here picks a band, because the
    * member's governing thickness is not known at this point. Choosing by
    * thickness is a larger change with its own decisions.
    */
   thicknessBands?: ThicknessBand[];
+  /**
+   * Which standard tabulates those bands — never the one in `standard`.
+   *
+   * Carried alongside them because the picker shows `standard` beside the
+   * grade name, so a band shown without its own source reads as coming from
+   * the product standard. It does not: see `bandStandard` in
+   * `structural-grades.ts`.
+   */
+  bandStandard?: string;
+}
+
+/**
+ * The thickness caveat as one short line, for a picker with no member in hand.
+ *
+ * Returns the headline value's upper bound and where the strength ends up
+ * beyond it — "(>40mm: 335)" — rather than only the bound. Naming just the
+ * bound would put the number that matters behind a hover, and `title` is
+ * mouse-only: absent on touch, and a child span's title never reaches the
+ * button's accessible name. The safety-relevant fact belongs on screen; the
+ * full table and its source can stay in the tooltip.
+ *
+ * Quoting the LAST band's value states the far end without asserting a
+ * direction, which matters because one grade here runs the other way: 6082-T6
+ * gets stronger with thickness, so it renders "(>5mm: 260)" and reads as the
+ * rise it is. A wording like "falls to" would have been wrong for it.
+ *
+ * Exact for two bands, which every banded grade currently has — a test pins
+ * that, so a three-band grade fails loudly here instead of silently skipping
+ * an intermediate step.
+ */
+export function bandSummary(
+  p: Pick<MaterialPreset, 'thicknessBands' | 'bandStandard'>,
+): { tail: string; full: string } | null {
+  const bands = p.thicknessBands;
+  if (!bands || bands.length === 0) return null;
+  const first = bands[0];
+  const last = bands[bands.length - 1];
+  const table = bands.map((b) => `${b.overMm}–${b.upToMm} mm: fy ${b.fy} MPa`).join(' · ');
+  return {
+    tail: `(>${first.upToMm}mm: ${last.fy})`,
+    full: p.bandStandard ? `${p.bandStandard} · ${table}` : table,
+  };
 }
 
 /**
@@ -72,6 +114,7 @@ function fromGrade(g: StructuralGrade, category: MaterialPreset['category']): Ma
     region: g.region,
     verification: g.verification,
     thicknessBands: g.byThickness,
+    bandStandard: g.bandStandard,
   };
 }
 

--- a/web/src/lib/data/material-presets.ts
+++ b/web/src/lib/data/material-presets.ts
@@ -5,7 +5,7 @@ import { t } from '../i18n';
 import {
   HOT_ROLLED, COLD_FORMED, ALUMINIUM, STAINLESS,
   BASIC_REGIONS, MATERIAL_DESIGN_CODES, gradesForCode,
-  type StructuralGrade, type GradeFamily, type GradeRegion,
+  type StructuralGrade, type GradeFamily, type GradeRegion, type ThicknessBand,
 } from './structural-grades';
 import { CONCRETE, TIMBER } from './non-metal-grades';
 
@@ -36,6 +36,20 @@ export interface MaterialPreset {
    * choosing a grade for a calculation deserves to know which they are getting.
    */
   verification?: 'standard' | 'typical';
+  /**
+   * The grade's thickness bands, where the product standard tabulates them.
+   *
+   * `fy` above is the THIN-PLATE value, which is what `structural-grades.ts`
+   * warns about in its own header: hot-rolled yield falls with thickness, and a
+   * caller that quotes the headline number for a 60 mm plate is unconservative
+   * by about 6 %. Carrying the bands lets the picker say so instead of
+   * presenting one number as if the standard gave only one.
+   *
+   * This is disclosure, not selection: nothing here picks a band, because the
+   * member's governing thickness is not known at this point. Choosing by
+   * thickness is a larger change with its own decisions.
+   */
+  thicknessBands?: ThicknessBand[];
 }
 
 /**
@@ -57,6 +71,7 @@ function fromGrade(g: StructuralGrade, category: MaterialPreset['category']): Ma
     gradeId: g.id,
     region: g.region,
     verification: g.verification,
+    thicknessBands: g.byThickness,
   };
 }
 

--- a/web/src/lib/data/structural-grades.ts
+++ b/web/src/lib/data/structural-grades.ts
@@ -96,11 +96,33 @@ export interface StructuralGrade {
   /** Ultimate tensile strength, MPa. */
   fu: number;
   /**
-   * Thickness dependence, where the product standard tabulates it. Absent
-   * means the standard quotes a single value for the usual range, not that
-   * thickness has no effect.
+   * Thickness dependence, where it is tabulated. Absent means the source
+   * quotes a single value for the usual range, not that thickness has no
+   * effect.
+   *
+   * Read `bandStandard` before quoting these anywhere: they do NOT come from
+   * `productStandard`.
    */
   byThickness?: ThicknessBand[];
+  /**
+   * Which standard tabulates `byThickness` — and it is never `productStandard`.
+   *
+   * Every band in this file is a DESIGN code's table, not a product standard's:
+   * EN 1993-1-1 table 3.1 for the EN steels, CIRSOC 301 for the IRAM ones,
+   * EN 1999-1-1 table 3.2b for 6082-T6. The product standards do tabulate
+   * thickness dependence, but more finely and with different numbers — EN
+   * 10025-2 steps at 16/40/63/80 mm and gives S355 as 345 MPa above 16 mm,
+   * where EN 1993-1-1 §3.2.1(1) permits the two-band simplification carried
+   * here. Both are legitimate; they are not interchangeable.
+   *
+   * Recorded per grade because separating the product standard from the design
+   * code is the entire point of this file, and a band displayed beside
+   * `productStandard` without naming its own source quietly implies the
+   * product standard tabulated it. A test requires this wherever `byThickness`
+   * is present, so a banded grade cannot be added without saying where its
+   * bands came from.
+   */
+  bandStandard?: string;
   /** Anything a user would otherwise have to know from outside the table. */
   note?: string;
   /**
@@ -179,16 +201,16 @@ export const HOT_ROLLED: StructuralGrade[] = [
   // rather than filled in with a plausible number.
   {
     id: 'iram-f24', designation: 'F-24', productStandard: 'IRAM-IAS U 500-503', region: 'AR', family: 'hot-rolled', ...IRAM_STEEL, fy: 240, fu: 370, verification: 'standard',
-    byThickness: [{ overMm: 0, upToMm: 30, fy: 240, fu: 370 }, { overMm: 30, upToMm: 100, fy: 220, fu: 370 }],
+    byThickness: [{ overMm: 0, upToMm: 30, fy: 240, fu: 370 }, { overMm: 30, upToMm: 100, fy: 220, fu: 370 }], bandStandard: 'CIRSOC 301',
     note: 'El grado más usado en perfiles argentinos (IPN, UPN, IPE, IPB, ángulos).',
   },
   {
     id: 'iram-f26', designation: 'F-26', productStandard: 'IRAM-IAS U 500-503', region: 'AR', family: 'hot-rolled', ...IRAM_STEEL, fy: 260, fu: 420, verification: 'standard',
-    byThickness: [{ overMm: 0, upToMm: 30, fy: 260, fu: 420 }, { overMm: 30, upToMm: 100, fy: 240, fu: 420 }],
+    byThickness: [{ overMm: 0, upToMm: 30, fy: 260, fu: 420 }, { overMm: 30, upToMm: 100, fy: 240, fu: 420 }], bandStandard: 'CIRSOC 301',
   },
   {
     id: 'iram-f36', designation: 'F-36', productStandard: 'IRAM-IAS U 500-503', region: 'AR', family: 'hot-rolled', ...IRAM_STEEL, fy: 360, fu: 520, verification: 'standard',
-    byThickness: [{ overMm: 0, upToMm: 30, fy: 360, fu: 520 }, { overMm: 30, upToMm: 100, fy: 340, fu: 520 }],
+    byThickness: [{ overMm: 0, upToMm: 30, fy: 360, fu: 520 }, { overMm: 30, upToMm: 100, fy: 340, fu: 520 }], bandStandard: 'CIRSOC 301',
     note: 'Perfiles W laminados y estructuras de alta solicitación.',
   },
 
@@ -210,21 +232,30 @@ export const HOT_ROLLED: StructuralGrade[] = [
   { id: 'astm-a913-65', designation: 'A913 Gr.65', productStandard: 'ASTM A913', region: 'US', family: 'hot-rolled', ...US_STEEL, fy: 450, fu: 550, verification: 'typical' },
 
   // ── EN 10025-2, with the thickness bands of EN 1993-1-1 table 3.1 ──
+  //
+  // The bands below are the DESIGN code's, not the product standard's, and the
+  // `fu` values are the tell: EN 10025-2 quotes Rm as a range (470–630 MPa for
+  // S355), never the single 490 that EN 1993-1-1 table 3.1 gives. EN 10025-2's
+  // own ReH table steps at 16/40/63/80 mm — S355 is 355 MPa only to 16 mm and
+  // 345 above it — while §3.2.1(1) permits the two-band simplification used
+  // here. `bandStandard` says so per grade so nothing downstream can show a
+  // 40 mm step beside the label "EN 10025-2" and imply that is where it came
+  // from.
   {
     id: 'en-s235', designation: 'S235', productStandard: 'EN 10025-2', region: 'EU', family: 'hot-rolled', ...EN_STEEL, fy: 235, fu: 360, verification: 'standard',
-    byThickness: [{ overMm: 0, upToMm: 40, fy: 235, fu: 360 }, { overMm: 40, upToMm: 80, fy: 215, fu: 360 }],
+    byThickness: [{ overMm: 0, upToMm: 40, fy: 235, fu: 360 }, { overMm: 40, upToMm: 80, fy: 215, fu: 360 }], bandStandard: 'EN 1993-1-1 t.3.1',
   },
   {
     id: 'en-s275', designation: 'S275', productStandard: 'EN 10025-2', region: 'EU', family: 'hot-rolled', ...EN_STEEL, fy: 275, fu: 430, verification: 'standard',
-    byThickness: [{ overMm: 0, upToMm: 40, fy: 275, fu: 430 }, { overMm: 40, upToMm: 80, fy: 255, fu: 410 }],
+    byThickness: [{ overMm: 0, upToMm: 40, fy: 275, fu: 430 }, { overMm: 40, upToMm: 80, fy: 255, fu: 410 }], bandStandard: 'EN 1993-1-1 t.3.1',
   },
   {
     id: 'en-s355', designation: 'S355', productStandard: 'EN 10025-2', region: 'EU', family: 'hot-rolled', ...EN_STEEL, fy: 355, fu: 490, verification: 'standard',
-    byThickness: [{ overMm: 0, upToMm: 40, fy: 355, fu: 490 }, { overMm: 40, upToMm: 80, fy: 335, fu: 470 }],
+    byThickness: [{ overMm: 0, upToMm: 40, fy: 355, fu: 490 }, { overMm: 40, upToMm: 80, fy: 335, fu: 470 }], bandStandard: 'EN 1993-1-1 t.3.1',
   },
   {
     id: 'en-s450', designation: 'S450', productStandard: 'EN 10025-2', region: 'EU', family: 'hot-rolled', ...EN_STEEL, fy: 440, fu: 550, verification: 'standard',
-    byThickness: [{ overMm: 0, upToMm: 40, fy: 440, fu: 550 }, { overMm: 40, upToMm: 80, fy: 410, fu: 550 }],
+    byThickness: [{ overMm: 0, upToMm: 40, fy: 440, fu: 550 }, { overMm: 40, upToMm: 80, fy: 410, fu: 550 }], bandStandard: 'EN 1993-1-1 t.3.1',
   },
   // EN 10025-3, normalised fine-grain — the grades used where toughness governs.
   { id: 'en-s275n', designation: 'S275N', productStandard: 'EN 10025-3', region: 'EU', family: 'hot-rolled', ...EN_STEEL, fy: 275, fu: 390, verification: 'typical' },
@@ -330,6 +361,7 @@ export const ALUMINIUM: StructuralGrade[] = [
       { overMm: 0, upToMm: 5, fy: 250, fu: 290 },
       { overMm: 5, upToMm: 15, fy: 260, fu: 310 },
     ],
+    bandStandard: 'EN 1999-1-1 t.3.2b',
     note: 'Extrusión. La resistencia SUBE con el espesor, al revés que las demás.',
   },
   { id: 'alu-7020-t6', designation: '7020-T6', productStandard: 'EN AW-7020', region: 'EU', family: 'aluminium', ...EN_ALU, fy: 280, fu: 350, verification: 'typical' },


### PR DESCRIPTION
Found reviewing #132. Small, and it closes the one gap I could find in the grades work — which is otherwise very solid; see the note at the bottom.

## The gap

`structural-grades.ts` names the hazard in its own header:

> `fy` for hot-rolled steel FALLS with thickness. A grade quoted as "S355" is 355 MPa up to 40 mm and 335 MPa beyond it. Where the standard tabulates that, `byThickness` carries it and `fy` is the thin-plate value — **so a caller that ignores thickness is unconservative, by about 6%, silently.**

Every production caller ignores it. `byThickness` is read only by `strengthAtThickness`, which nothing in production calls; `fromGrade` copies `g.fy` and drops the bands. So the picker offers S355 as a flat 355 MPa, and someone sizing a 60 mm plate gets a yield stress 6 % above the 335 that governs there, with nothing on screen to say so.

Documenting a hazard in a docstring does not mitigate it — the engineer sizing the member never reads it. And the error runs in the **unsafe** direction, which is what makes it worth carrying rather than noting. If it were 6 % conservative I would have left it as a comment.

## What this does

Carries the bands to the preset and prints, beside the quoted value, where it stops applying and what it becomes — `fy=355MPa (>40mm: 335)` — with the full table and its source on hover.

**8 of the 68 grades in `ALL_GRADES` have bands**, and they are not one region's: three are Argentine (F-24, F-26, F-36), four European hot-rolled (S235, S275, S355, S450) and one European aluminium (6082-T6). The Argentine three matter most here — F-24 is the one this file calls *"el grado más usado en perfiles argentinos"*.

## What it deliberately does NOT do

**It does not select a band.** Nothing here changes the number the model uses. Choosing by thickness needs decisions that are yours, not mine:

- which of a section's thicknesses governs (EN 10025 says the element's — flange for an I, and the picker has no section in hand at all);
- what to do when the thickness is unknown, where the conservative answer is the thickest band and the convenient one is today's;
- whether the material or the design check carries the choice.

So this is disclosure, and the fuller fix stays open for you to shape. One thing to know before shaping it: `MaterialsTable.handleMaterialPresetSelect` does not copy `gradeId` (`ElementDetails` does), so a material chosen from the materials table has no link back to the grade whose bands a thickness-aware check would need.

## On the data itself — and a correction

The numbers are right, but **they are not EN 10025-2's, and my first version of this description said they were.** They are **EN 1993-1-1 table 3.1**, which the file's own comment says one line above the data I claimed to have checked.

The `fu` values are the tell: EN 10025-2 quotes Rm as a *range* (470–630 MPa for S355), never the single 490 the file carries, and table 3.1 gives exactly 490/470 for S355, 430/410 for S275, 360/360 for S235, 550/550 for S450 — four for four. EN 10025-2's own ReH table steps at 16/40/63/80 mm, where S355 is 355 MPa only to 16 mm and 345 above it; EN 1993-1-1 §3.2.1(1) permits the two-band simplification used here. Both are legitimate. They are not interchangeable.

That mattered for this change rather than being a pedantic aside: the picker prints `productStandard` beside the grade name, so a bare "40 mm" shown there reads as EN 10025-2's step. That is the grade-versus-code conflation this module exists to prevent, reintroduced by the thing that displays it. The second commit adds `bandStandard` per grade — every band in the catalogue turns out to come from a design code, never from the product standard — and a test asserts they are never equal.

The same check on the rest holds up: S275 275/255, S355 355/335, S450 440/410, and the S450 entry is correct in the way that matters — the designation says 450 and `fy` is **440**, which is exactly where a careless table puts 450. The ASTM values check out too (A36 250, A572 Gr50 345, A992 345, A500 Gr C 317 — the round-HSS value).

The grade/design-code separation is the right model and is the confusion worth preventing. I have no other findings in `structural-grades.ts`.

## Verification

- New tests fail before the change they cover (`F-24 lost its bands`, S355 band undefined) and pass after; the two-band assumption `bandSummary` makes is pinned so a three-band grade fails loudly rather than silently skipping a step.
- The markup itself has **no** test: there is no component-test setup in this repo and the material picker has no e2e coverage at all, so the suite asserts the strings the template interpolates and stops there.
- `npm run typecheck`: no new errors (479, baseline 479). `npm run build`: clean.
- `src/lib/data` suite: 247 passed.
- Note unrelated to this PR: `npm run check:gate` exits 1 on this branch and on its base alike — 7 pre-existing errors in `CrossSectionDrawing.svelte` and `SectionStressPanel.svelte`. CI's lint job does not appear to run it.

## Unrelated, while I was in there

`torsion-flow.ts` is the best thing I read in this PR and I have nothing to fix in it. I checked the three theories against their limits: Bredt takes `Am` from the mid-line (`b−t`, `h−t`) and uses `4Am²/(perimeter/t)`; the solid rectangle gives 0.1408·a⁴ against the tabulated 0.1406 and `τ=4.8T/a³` against the exact 4.81, and tends to the thin-strip limit correctly. Its 19 tests pin the physics rather than the implementation — including one that asserts using the outside dimensions would under-report the stress, which is the classic error the module avoids.
