### PR TITLE
test(e2e): repair 11 of the 12 @slow tests red on main since #90

### DIFF
--- a/web/e2e/pro-project-files.spec.ts
+++ b/web/e2e/pro-project-files.spec.ts
@@ -155,6 +155,11 @@ test.describe('@slow PRO project files', () => {
   test('D the Básico project controls are untouched', async ({ pro: page }) => {
     // The correction adds a PRO surface; it must not have moved or removed the Básico one.
     await page.locator('[data-tour="mode-toggle"] button').first().click();
+    // Básico is the ribbon on desktop and its project controls live in a panel, so the
+    // claim "untouched" has to be checked where they actually are. Opening the panel is
+    // part of the assertion, not setup for it: if the ribbon had lost the button, this
+    // click would fail and that is exactly the regression the test is named for.
+    await page.getByTestId('hdr-project').click();
     await expect(page.locator('[data-tour="project-section"]')).toBeAttached();
     await expect(page.getByTestId('project-open-file')).toBeAttached();
     // And PRO's own controls are correctly absent from Básico.

--- a/web/e2e/project-restore.spec.ts
+++ b/web/e2e/project-restore.spec.ts
@@ -79,6 +79,58 @@ interface Watch {
   forbidden: string[];
 }
 
+/**
+ * Toasts have to be RECORDED as they are raised, never sampled off the DOM later.
+ *
+ * A toast removes itself after 4 s (`ui.svelte.ts` `toast()`), and the moment a spec can next
+ * look is not under the spec's control: `__stabileoActions.solve()` resolves when the solve
+ * resolves, but the evaluate cannot RETURN until the main thread is free, and publishing a
+ * restored-and-designed model — 203 reinforced members across 7 combinations — blocks it for
+ * about six seconds after the toast goes up. The assertion window then opens on an empty
+ * container and stays empty, which reads exactly like a solve that reported nothing.
+ *
+ * That is what made this file red on main: not a missing toast, a missed one. The first pass
+ * survived only because an un-designed model publishes fast enough to still be inside the 4 s.
+ *
+ * So a MutationObserver installed before any app code runs appends every toast to a page-side
+ * log that nothing clears on a timer. `assertClean` gains the same soundness for free — its
+ * forbidden-string check used to sample the container too, so a dismissed error toast would
+ * have passed it silently, which is the failure direction that actually matters.
+ */
+function recordToasts(page: Page) {
+  return page.addInitScript(() => {
+    const w = window as unknown as { __toastLog?: string[] };
+    // `boot` runs once per page load but init scripts accumulate across them; the first
+    // script on a fresh document wins and the rest find the log already installed.
+    if (w.__toastLog) return;
+    const log: string[] = [];
+    w.__toastLog = log;
+    const seen = new WeakSet<Element>();
+    const note = (el: Element) => {
+      if (seen.has(el)) return;
+      seen.add(el);
+      const text = (el.textContent ?? '').trim();
+      if (text) log.push(text);
+    };
+    new MutationObserver((muts) => {
+      for (const m of muts) {
+        for (const n of Array.from(m.addedNodes)) {
+          if (!(n instanceof HTMLElement)) continue;
+          if (n.classList.contains('toast')) note(n);
+          n.querySelectorAll('.toast').forEach(note);
+        }
+      }
+    // `document`, not `documentElement`: an init script runs against the initial empty
+    // document, where `documentElement` is still null and `observe` throws.
+    }).observe(document, { childList: true, subtree: true });
+  });
+}
+
+/** Every toast raised since the page loaded, in order, dismissed or not. */
+async function toastsSeen(page: Page): Promise<string[]> {
+  return page.evaluate(() => (window as unknown as { __toastLog?: string[] }).__toastLog ?? []);
+}
+
 function watchPage(page: Page): Watch {
   const w: Watch = { errors: [], fallbacks: [], forbidden: [] };
   const inspect = (text: string, fromError: boolean) => {
@@ -95,7 +147,7 @@ function watchPage(page: Page): Watch {
 
 /** Assert the run is still clean, naming the step that dirtied it. */
 async function assertClean(page: Page, w: Watch, step: string) {
-  const toasts = (await page.locator('[class*=toast]').allTextContents()).join(' | ');
+  const toasts = (await toastsSeen(page)).join(' | ');
   for (const rx of FORBIDDEN) {
     expect(toasts, `${step}: a toast matched ${rx}`).not.toMatch(rx);
   }
@@ -116,6 +168,7 @@ async function assertClean(page: Page, w: Watch, step: string) {
  * has to go because a restored tab session bypasses the autosave banner entirely.
  */
 async function boot(page: Page) {
+  await recordToasts(page);
   await page.addInitScript(() => {
     try {
       localStorage.clear();
@@ -151,13 +204,16 @@ async function restoreFromBanner(page: Page) {
 /** Calculate, and wait for the result rather than for a duration. */
 async function calculate(page: Page) {
   const before = await page.evaluate(() => window.__stabileo.solveCount());
+  // Only the toasts THIS solve raises may satisfy it. The log is cumulative and outlives the
+  // reload it was recorded on, so matching the whole thing would let the second calculate pass
+  // on the first one's success — which is precisely the silence this step exists to catch.
+  const mark = (await toastsSeen(page)).length;
   await page.evaluate(async () => { await window.__stabileoActions.solve(); });
   await expect
     .poll(() => page.evaluate(() => window.__stabileo.solveCount()), { timeout: 120_000 })
     .toBeGreaterThan(before);
   await expect
-    .poll(async () => (await page.locator('[class*=toast]').allTextContents()).join(' | '),
-      { timeout: 120_000 })
+    .poll(async () => (await toastsSeen(page)).slice(mark).join(' | '), { timeout: 120_000 })
     .toContain('Análisis 3D exitoso');
 }
 
@@ -360,7 +416,7 @@ test('@slow restore, design, view in 3-D — then reload and do it again', async
 
   // The over-quota warning belonged to the localStorage autosave. Its appearance now would
   // mean the app had silently fallen back to it.
-  const toastsNow = (await page.locator('[class*=toast]').allTextContents()).join(' | ');
+  const toastsNow = (await toastsSeen(page)).join(' | ');
   expect(toastsNow, 'no over-quota warning, because there is no quota to exceed')
     .not.toMatch(/demasiado grande para el guardado autom/i);
 

--- a/web/e2e/rc-cad-handoff.spec.ts
+++ b/web/e2e/rc-cad-handoff.spec.ts
@@ -54,6 +54,11 @@ async function openCommittedProject(page: Page) {
   // First button in the mode toggle is Básico. Selected structurally rather than by label, so
   // the Spanish journeys below use the same helper.
   await page.locator('[data-tour="mode-toggle"] button').first().click();
+  // Desktop Básico is the ribbon, and the project controls live in a panel it opens —
+  // `BasicPanel` renders `ToolbarProject`, so nothing is attached until the panel is.
+  // This helper was written before the ribbon reached this branch and reached straight
+  // for the input, which no longer exists on load.
+  await page.getByTestId('hdr-project').click();
   const input = page.getByTestId('project-open-file');
   await expect(input).toBeAttached();
   await input.setInputFiles(FIXTURE);

--- a/web/e2e/rc-cad-production-download.spec.ts
+++ b/web/e2e/rc-cad-production-download.spec.ts
@@ -47,6 +47,10 @@ const EXPECTED_VERIFIER = `${CIRSOC_VERIFIER_ID}.2025`;
 /** Open the committed project through the production file input. */
 async function openProject(page: Page) {
   await page.locator('[data-tour="mode-toggle"] button').first().click();
+  // Desktop Básico is the ribbon, and the project controls live in a panel it opens —
+  // `BasicPanel` renders `ToolbarProject`, so the input is not attached on load. Third
+  // copy of this helper; `rc-cad-handoff.spec.ts` carries the same opening click.
+  await page.getByTestId('hdr-project').click();
   const input = page.getByTestId('project-open-file');
   await expect(input).toBeAttached();
   await input.setInputFiles(FIXTURE);


### PR DESCRIPTION
`main` has been red since #90 merged: **12 failing `@slow` tests, 9 passing**. This PR fixes 11 of the 12.

The failures span five files but come from only **two** causes. The count is misleading because one hand-rolled helper is copied into three spec files, and `rc-cad-handoff` alone accounts for eight failures through a single shared copy.

None of these tests had ever executed. The `@slow` job is gated on `main` or the `run-e2e` label, so they first ran after the merge.

## Cause 1 — the Básico project controls moved into a panel (10 tests, 3 files)

`pro-project-files.spec.ts`, `rc-cad-handoff.spec.ts` and `rc-cad-production-download.spec.ts` each reach straight for `project-open-file`. On desktop, Básico is the ribbon and its project controls live in a panel that has to be opened — `BasicPanel` renders `ToolbarProject`, so nothing is attached on load.

Opening the panel is part of the assertion rather than setup for it: had the ribbon lost the button, the click itself would fail, and that is the regression the "untouched" test is named for.

The duplication is the more durable defect here. One assumption about where a control lives is written out three times, so a single UI move reads as three unrelated broken files. Worth collapsing into a shared helper in a follow-up.

## Cause 2 — `project-restore` asserted on a toast that had already dismissed (1 test)

This one looked like the app silently failing to report a solve, and it isn't.

`calculate` asserted on a toast that removes itself after 4 s, through a window it does not control. `__stabileoActions.solve()` resolves when the solve resolves, but the evaluate cannot **return** until the main thread is free — and publishing a restored-and-designed model (203 reinforced members × 7 combinations) blocks it for about 6.6 s.

From the trace of the red `main` run:

| t (s) | event |
|---|---|
| 210.4 | `evaluate(solve())` dispatched |
| 213.6 | combo solve completes, success toast raised |
| ~217.6 | toast self-dismisses (4 s lifetime) |
| 220.2 | evaluate returns, `solveCount` poll runs |
| 220.3 | toast poll first looks — 2.6 s late, then polls `""` for its full 120 s |

The first pass passes only because an un-designed model publishes fast enough to still be inside the 4 s. It is the **second** `calculate`, after the second restore, that fails.

Nothing was wrong with the solve. Measured with a MutationObserver on a reproduction: the toast *is* inserted, with correct text, and `modelVersion` never moves across the solve — so neither silent `return null` in `runComboSolve` (the `isStale()` arm or the `solveEpoch` guard from 53bde992) was ever involved. The console shows the parallel solve completing normally with no fallback.

### The fix

A MutationObserver installed before any app code appends every toast to a page-side log that nothing clears on a timer. `calculate` matches only the toasts its own solve raised — matching the whole log would let the second `calculate` pass on the first one's success, which is the exact silence that step exists to catch.

### Worth a closer look

`assertClean` sampled the toast container the same way, so **an error toast that had already dismissed passed it silently** — the failure direction that actually matters, in a file whose header promises to watch "every toast for the whole run". That is now true rather than aspirational. It is the part of this change most worth a second pair of eyes, because it makes the file strictly stricter and could surface pre-existing noise.

## The 12th failure is NOT fixed here

`rebar-workspace-open.spec.ts:139` fails a perf threshold by 0.24%:

```
reopened: the document is assembled without blocking the click
Expected: < 500    Received: 501.2
```

It fails on CI too, so it is not one machine. It passed when re-run in isolation (1.4 min) and failed under full-suite load, which makes it a threshold set too close to the real cost rather than a clean regression. Untouched deliberately: either the bound is too tight or document assembly genuinely got slower, and that is a call for whoever owns the number, not something to quietly relax to make a suite green.

## Verification

Local, as CI runs it (`--grep "@slow" --grep-invert "visual baselines"`):

| | failed | passed |
|---|---|---|
| `main` (CI run 31826249301) | 12 | 9 |
| this branch, before cause-1 fix #3 | 3 | 18 |
| the 3 remaining, re-run after fix #3 | 0 | 3 |

`project-restore.spec.ts` passes in 2.0 min. This PR carries `run-e2e` so the suite runs here rather than after the merge.

## Follow-up, not in this PR

`@slow` *can* run on a PR — the `run-e2e` label exists. The gap is that nothing prompts you to add it when a PR adds slow tests, which is how ten new e2e files merged unexecuted. A cheap fix is to require the label when the diff touches `web/e2e/**`, rather than running the heavy suite on every PR.
