### PR TITLE
audit(E6): elements — edge-load outward sign fix, curved-shell thermal gradient 2× fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ It should capture what changed, not what should be built next.
 
 ### Changed
 
+#### Shell edge loads: outward normal sign corrected (E6 audit, 2026-08-14)
+
+**BREAKING (saved models): `quadEdge` and `quad9Edge` loads reverse direction.**
+`quad_edge_load` and `quad9_edge_load` built their in-plane normal as `ez × et`, which
+points INWARD for the CCW node ordering `quad_local_axes` guarantees — the opposite of
+the convention documented on `SolverQuadEdgeLoad` ("positive `qn` = outward from
+element") and of `curved_shell_edge_load`, which has always used `t̂ × d̂`. The three
+shell elements disagreed, and the two quads contradicted their own documented input.
+
+The code now matches the documentation, so **the documentation did not change and the
+results did**. Any existing model carrying a `quadEdge`/`quad9Edge` load now produces
+forces in the opposite direction: a case that read as tension reads as compression.
+There is no version gate and no automatic migration — `qn` is passed through unmodified
+at every call site. Re-check any saved model that uses these load types, and negate `qn`
+where the previous (inward) direction was the intended one.
+
+Unaffected: `curved_shell` edge loads, which were already correct; pressure loads; and
+any model without edge loads.
+
+**Magnitude fix in the same place.** The normal was also unnormalized. `ez` is derived
+from the element diagonals, so it is perpendicular to the edge chord only when the quad
+is planar; on a warped element `|et × ez| = sin θ < 1` and `qn` was applied at that
+fraction of its stated value — correct direction, silently short, and invisible to any
+test built on a flat square. Both quads now normalize, matching `curved_shell`.
+
+#### Curved shell thermal gradient: 2× factor removed (E6 audit, 2026-08-14)
+
+`curved_shell_thermal_load` applied twice the thermal moment it should. The through
+-thickness gradient term now integrates to `M_T = Eα·ΔTg·t²/(12(1−ν))`, matching
+`quad_thermal_load`. Thermal-gradient results on curved shells change by a factor of 2.
+
 #### RC Design workflow rebuild — verified auto-design, honest invalidation (PR15, 2026-07-25)
 
 **BREAKING (verification results): `cirsoc201.provided.v1` → `cirsoc201.provided.v2`.**

--- a/engine/src/element/curved_shell.rs
+++ b/engine/src/element/curved_shell.rs
@@ -1380,8 +1380,11 @@ pub fn curved_shell_thermal_load(
             let b = build_b_matrix_at_point(coords, dirs, h, xi, eta, zeta, &e1, &e2, &e3, &inv_j);
 
             // Thermal stress: σ_th = D · ε_th
-            // ε_th = α*(ΔT + ζ*ΔTg) * [1, 1, 0, 0, 0]
-            let thermal_strain = alpha * (dt_uniform + zeta * dt_gradient);
+            // ε_th = α*(ΔT + ζ*ΔTg/2) * [1, 1, 0, 0, 0]
+            // dt_gradient is the top-to-bottom temperature DIFFERENCE (same
+            // convention as quad_thermal_load: κ_th = α·ΔTg/t). With ζ ∈ [-1,1]
+            // the face temperatures are ΔT ± ΔTg/2.
+            let thermal_strain = alpha * (dt_uniform + zeta * dt_gradient / 2.0);
             let sigma_th = [
                 c * (1.0 + nu) * thermal_strain, // σ11
                 c * (1.0 + nu) * thermal_strain, // σ22
@@ -1499,6 +1502,39 @@ mod tests {
         let n = shape_functions(xi, eta);
         let sum: f64 = n.iter().sum();
         assert!((sum - 1.0).abs() < 1e-14, "Shape functions don't sum to 1: {sum}");
+    }
+
+    /// Thermal-gradient convention parity: dt_gradient is the top-to-bottom
+    /// temperature difference, so on a flat element the curved-shell thermal
+    /// load must match the (benchmark-validated) flat quad thermal load.
+    /// Guards the ζ·ΔTg/2 factor in curved_shell_thermal_load.
+    #[test]
+    fn thermal_gradient_load_matches_flat_quad() {
+        let coords = [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0],
+        ];
+        let dirs = compute_element_directors(&coords);
+        let e = 200e6;
+        let nu = 0.3;
+        let h = 0.02;
+        let alpha = 1.2e-5;
+        let dt_gradient = 15.0;
+
+        let f_curved = curved_shell_thermal_load(&coords, &dirs, e, nu, h, alpha, 0.0, dt_gradient);
+        let f_quad = crate::element::quad::quad_thermal_load(&coords, e, nu, h, alpha, 0.0, dt_gradient);
+
+        let max_abs = f_quad.iter().cloned().fold(0.0f64, f64::max);
+        let tol = 1e-9 * max_abs;
+        for i in 0..24 {
+            assert!(
+                (f_curved[i] - f_quad[i]).abs() < tol,
+                "DOF {}: curved {} vs quad {} (tol {})",
+                i, f_curved[i], f_quad[i], tol
+            );
+        }
     }
 
     #[test]

--- a/engine/src/element/quad.rs
+++ b/engine/src/element/quad.rs
@@ -54,6 +54,16 @@ fn norm3(v: &[f64; 3]) -> f64 {
     (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt()
 }
 
+/// Unit vector, falling back to [0,0,1] on a degenerate input.
+///
+/// Deliberately identical to `curved_shell::normalize3`, including the fallback: the
+/// three shell elements are supposed to agree on the edge-load convention, and the
+/// last time one of them spelled it differently the divergence went unnoticed.
+fn normalize3(v: &[f64; 3]) -> [f64; 3] {
+    let l = norm3(v);
+    if l > 1e-15 { [v[0] / l, v[1] / l, v[2] / l] } else { [0.0, 0.0, 1.0] }
+}
+
 fn sub3(a: &[f64; 3], b: &[f64; 3]) -> [f64; 3] {
     [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
 }
@@ -1159,7 +1169,13 @@ pub fn quad_edge_load(
     // For CCW node ordering (viewed from +ez), et × ez points OUTWARD from the
     // element, matching the documented "positive qn = outward" convention of
     // SolverQuadEdgeLoad and curved_shell_edge_load (which uses t̂ × d̂).
-    let en = cross3(&et, &ez);
+    //
+    // NORMALIZED, because et ⊥ ez holds only on a FLAT quad. `ez` comes from the
+    // diagonals, so on a warped element the chord tangent is not perpendicular to it
+    // and |et × ez| = sin θ < 1 — the direction stays right while qn is applied at
+    // that fraction of its stated magnitude, which is invisible to any test built on
+    // a flat square. curved_shell_edge_load normalizes for exactly this reason.
+    let en = normalize3(&cross3(&et, &ez));
 
     // Distributed load in global = qn * en + qt * et (force per length)
     let qx = qn * en[0] + qt * et[0];
@@ -1519,5 +1535,43 @@ mod tests {
             fx_total
         );
         assert!((fx_total - 2.0).abs() < 1e-10, "total force = qn·L: {}", fx_total);
+    }
+
+    /// The magnitude half of the convention, which a flat quad cannot test.
+    ///
+    /// `ez` is derived from the diagonals, so it is perpendicular to every edge only
+    /// when the element is planar. Warp it and the edge chord tilts out of that plane:
+    /// |et × ez| = sin θ < 1, and an unnormalized normal applies qn at that fraction —
+    /// right direction, silently short. `test_edge_load_normal_points_outward` above
+    /// uses a unit square, where sin θ = 1 exactly, so it passes either way.
+    #[test]
+    fn test_edge_load_normal_is_unit_on_warped_quad() {
+        // Corners alternating off-plane. The diagonals still give ez = +z, but edge
+        // 0's chord rises with them, so et·ez ≠ 0.
+        let coords = [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 1.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0],
+        ];
+        let qn = 2.0;
+        let f = quad_edge_load(&coords, 0, qn, 0.0);
+
+        // Total force delivered to the loaded edge's two nodes.
+        let mut total = [0.0f64; 3];
+        for n in [0usize, 1] {
+            for k in 0..3 {
+                total[k] += f[n * 6 + k];
+            }
+        }
+        let applied = norm3(&total);
+        let expected = qn * norm3(&sub3(&coords[1], &coords[0]));
+
+        assert!(
+            (applied - expected).abs() < 1e-9 * expected,
+            "warped quad applied |F| = {} but qn·L = {} — the edge normal is not a \
+             unit vector (raw |et × ez| = sin θ ≈ 0.707 here)",
+            applied, expected
+        );
     }
 }

--- a/engine/src/element/quad.rs
+++ b/engine/src/element/quad.rs
@@ -1155,8 +1155,11 @@ pub fn quad_edge_load(
 
     // Edge tangent (along edge)
     let et = [edge_vec[0] / l_edge, edge_vec[1] / l_edge, edge_vec[2] / l_edge];
-    // Edge in-plane normal (perpendicular to edge, in shell plane)
-    let en = cross3(&ez, &et);
+    // Edge in-plane normal (perpendicular to edge, in shell plane).
+    // For CCW node ordering (viewed from +ez), et × ez points OUTWARD from the
+    // element, matching the documented "positive qn = outward" convention of
+    // SolverQuadEdgeLoad and curved_shell_edge_load (which uses t̂ × d̂).
+    let en = cross3(&et, &ez);
 
     // Distributed load in global = qn * en + qt * et (force per length)
     let qx = qn * en[0] + qt * et[0];
@@ -1488,5 +1491,33 @@ mod tests {
                 "Distorted quad negative diagonal at {}: {}", i, k_dist[i * 24 + i]
             );
         }
+    }
+
+    #[test]
+    fn test_edge_load_normal_points_outward() {
+        // Unit square, CCW ordering (viewed from +z): interior at y>0 for the
+        // bottom edge, at x<1 for the right edge.
+        // Documented convention (SolverQuadEdgeLoad): positive qn = outward.
+        let coords = make_unit_square();
+
+        // Edge 0 = nodes 0→1 (bottom edge): outward is −y.
+        let f = quad_edge_load(&coords, 0, 2.0, 0.0);
+        let fy_total: f64 = (0..4).map(|i| f[i * 6 + 1]).sum();
+        assert!(
+            fy_total < 0.0,
+            "qn > 0 on bottom edge must push outward (−y), got total fy = {}",
+            fy_total
+        );
+        assert!((fy_total + 2.0).abs() < 1e-10, "total force = qn·L: {}", fy_total);
+
+        // Edge 1 = nodes 1→2 (right edge): outward is +x.
+        let f = quad_edge_load(&coords, 1, 2.0, 0.0);
+        let fx_total: f64 = (0..4).map(|i| f[i * 6]).sum();
+        assert!(
+            fx_total > 0.0,
+            "qn > 0 on right edge must push outward (+x), got total fx = {}",
+            fx_total
+        );
+        assert!((fx_total - 2.0).abs() < 1e-10, "total force = qn·L: {}", fx_total);
     }
 }

--- a/engine/src/element/quad9.rs
+++ b/engine/src/element/quad9.rs
@@ -1056,7 +1056,9 @@ pub fn quad9_edge_load(
     if l_edge < 1e-15 { return f; }
 
     let et = [edge_vec[0] / l_edge, edge_vec[1] / l_edge, edge_vec[2] / l_edge];
-    let en = cross3(&ez, &et);
+    // For CCW node ordering (viewed from +ez), et × ez points OUTWARD from the
+    // element, matching the documented "positive qn = outward" convention.
+    let en = cross3(&et, &ez);
 
     let qx = qn * en[0] + qt * et[0];
     let qy = qn * en[1] + qt * et[1];
@@ -1393,6 +1395,33 @@ mod tests {
             (total_fz - 10.0).abs() < 0.01,
             "Total pressure force: got {}, expected 10.0", total_fz
         );
+    }
+
+    #[test]
+    fn test_edge_load_normal_points_outward() {
+        // Unit square, CCW ordering (viewed from +z).
+        // Documented convention (SolverQuadEdgeLoad): positive qn = outward.
+        let coords = make_unit_square_9();
+
+        // Edge 0 = nodes 0→4→1 (bottom edge): outward is −y.
+        let f = quad9_edge_load(&coords, 0, 2.0, 0.0);
+        let fy_total: f64 = (0..9).map(|i| f[i * 6 + 1]).sum();
+        assert!(
+            fy_total < 0.0,
+            "qn > 0 on bottom edge must push outward (−y), got total fy = {}",
+            fy_total
+        );
+        assert!((fy_total + 2.0).abs() < 1e-10, "total force = qn·L: {}", fy_total);
+
+        // Edge 1 = nodes 1→5→2 (right edge): outward is +x.
+        let f = quad9_edge_load(&coords, 1, 2.0, 0.0);
+        let fx_total: f64 = (0..9).map(|i| f[i * 6]).sum();
+        assert!(
+            fx_total > 0.0,
+            "qn > 0 on right edge must push outward (+x), got total fx = {}",
+            fx_total
+        );
+        assert!((fx_total - 2.0).abs() < 1e-10, "total force = qn·L: {}", fx_total);
     }
 
     /// Helper: n×n matrix-vector multiply

--- a/engine/src/element/quad9.rs
+++ b/engine/src/element/quad9.rs
@@ -39,6 +39,13 @@ fn norm3(v: &[f64; 3]) -> f64 {
     (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt()
 }
 
+/// Unit vector, falling back to [0,0,1] on a degenerate input.
+/// Deliberately identical to `curved_shell::normalize3` — see the note in `quad.rs`.
+fn normalize3(v: &[f64; 3]) -> [f64; 3] {
+    let l = norm3(v);
+    if l > 1e-15 { [v[0] / l, v[1] / l, v[2] / l] } else { [0.0, 0.0, 1.0] }
+}
+
 fn sub3(a: &[f64; 3], b: &[f64; 3]) -> [f64; 3] {
     [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
 }
@@ -1056,7 +1063,11 @@ pub fn quad9_edge_load(
     let et = [edge_vec[0] / l_edge, edge_vec[1] / l_edge, edge_vec[2] / l_edge];
     // For CCW node ordering (viewed from +ez), et × ez points OUTWARD from the
     // element, matching the documented "positive qn = outward" convention.
-    let en = cross3(&et, &ez);
+    // NORMALIZED: et ⊥ ez holds only on a flat quad9. `ez` is diagonal-derived, so a
+    // warped element gives |et × ez| = sin θ < 1 and applies qn at that fraction of
+    // its stated magnitude — correct direction, silently wrong size, and invisible to
+    // a test built on a flat square. Matches curved_shell_edge_load.
+    let en = normalize3(&cross3(&et, &ez));
 
     let qx = qn * en[0] + qt * et[0];
     let qy = qn * en[1] + qt * et[1];

--- a/engine/src/element/quad9.rs
+++ b/engine/src/element/quad9.rs
@@ -750,10 +750,9 @@ pub fn quad9_nodal_von_mises(
         gp_vm[gp] = (sxx * sxx - sxx * syy + syy * syy + 3.0 * txy * txy).sqrt();
     }
 
-    // For 9-node element, 3×3 Gauss points are at the same parametric locations
-    // as a 9-node Lagrange grid, so we can directly interpolate using shape functions.
-    // The 3×3 Gauss point locations match the 9-node pattern, so project to nodes
-    // using shape function evaluation at node locations.
+    // Gauss points sit at ±√(3/5) (and 0), nodes at ±1 (and 0), so project
+    // GP values to nodes by tensor-product Lagrange extrapolation on the
+    // GP grid (see below).
     let node_coords_nat: [(f64, f64); 9] = [
         (-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0),
         (0.0, -1.0), (1.0, 0.0), (0.0, 1.0), (-1.0, 0.0),
@@ -920,8 +919,7 @@ pub fn quad9_stress_at_nodes(
 
 /// Consistent pressure load for quad9 element (54-DOF).
 pub fn quad9_pressure_load(coords: &[[f64; 3]; 9], pressure: f64) -> Vec<f64> {
-    let (_ex, _ey, ez) = quad9_local_axes(coords);
-    let (ex, ey, _) = quad9_local_axes(coords);
+    let (ex, ey, ez) = quad9_local_axes(coords);
     let pts = project_to_2d_9(coords, &ex, &ey);
 
     let mut f = vec![0.0; 54];

--- a/engine/tests/validation/benchmarks/shell_benchmark.rs
+++ b/engine/tests/validation/benchmarks/shell_benchmark.rs
@@ -3522,7 +3522,13 @@ fn benchmark_edge_load_tangential() {
     );
 
     assert!(avg_ux.abs() > 1e-15, "Edge load should produce displacement");
-    // Direction may differ from convention; check magnitude
+    // Positive qn is outward (SolverQuadEdgeLoad doc): on the right edge outward
+    // is +x, so the strip is in tension and avg_ux must be positive.
+    assert!(
+        avg_ux > 0.0,
+        "Positive qn on right edge must produce +x (outward) displacement, got {:.6e}",
+        avg_ux
+    );
     let ratio = avg_ux.abs() / ux_analytical;
     assert!(
         ratio > 0.5 && ratio < 2.0,


### PR DESCRIPTION
# E6 audit: Elements (`engine/src/element/`)

Section 6 of the section-by-section audit queue (`docs/AUDIT_PLAN.md`).

## Findings and fixes

### Fixed

1. **MEDIUM — edge load `qn` sign inverted on quad/quad9** (`engine/src/element/quad.rs:1159`, `engine/src/element/quad9.rs:1059`)
   Both built the in-plane edge normal as `ez × et`, which for CCW-ordered elements points
   **into** the element, while `SolverQuadEdgeLoad` documents "positive = outward" and
   `curved_shell_edge_load` already implements outward (`t̂ × d̂`). The same JSON input
   therefore loaded flat shells inward and curved shells outward. The existing benchmark
   only asserted magnitude (its comment even assumed outward: "in-plane normal = +x
   (outward)" / "Direction may differ from convention").
   Fix: `et × ez`. Tests: new `test_edge_load_normal_points_outward` unit tests in both
   elements (fail before / pass after — verified by flipping the line both ways), plus a
   direction assertion added to `benchmark_edge_load_tangential` (strengthened, not
   weakened: the magnitude assertions are unchanged).
   Commit: `c493a3de`.

2. **MEDIUM — curved-shell thermal gradient was 2× the documented convention**
   (`engine/src/element/curved_shell.rs:1384`)
   `curved_shell_thermal_load` evaluated `α·(ΔT_uniform + ζ·ΔT_gradient)` with ζ ∈ [-1,1],
   i.e. face temperatures ΔT ± ΔTg — a top-to-bottom difference of 2·ΔTg. The flat
   quad/plate/quad9 paths use `κ_th = α·ΔTg/t` (difference = ΔTg), the convention validated
   against the Timoshenko reference in `benchmark_shell_thermal_gradient_convergence`.
   Same input field → twice the thermal curvature in curved shells.
   Fix: `ζ·ΔTg/2`. Test: new `thermal_gradient_load_matches_flat_quad` — flat curved-shell
   thermal load vector must equal `quad_thermal_load` on the same geometry (verified to
   fail 2× without the fix, pass with it).
   Commit: `bf1d3bcf`.

3. **LOW hygiene — quad9** (`engine/src/element/quad9.rs`)
   `quad9_pressure_load` called `quad9_local_axes` twice (identical result); collapsed to
   one call. Fixed a stale comment in `quad9_nodal_von_mises` claiming the 3×3 Gauss points
   coincide with the 9-node Lagrange grid (they are at ±√(3/5); the code correctly does
   Lagrange extrapolation).
   Commit: `c5f7ac10`.

## `erasing_op` per-site verdicts (clippy 1.93, `-D clippy::erasing_op`)

Reproduced 19 deny-level sites in `element/` (plus `identity_op` "no effect" warnings at
`frame.rs:223`, `plate.rs:363`, `plate.rs:1191` — same expressions). **All 19 are
intentional row-0 indexing (`0 * n + m`), same pattern and verdict as the E3
`mass_matrix.rs` triage. No site is a real bug; no code change.** CI's
`-A clippy::erasing_op` stays as-is.

| Site | Expression | Verdict |
|---|---|---|
| transform.rs:6,7 | `t[0 * 6 + 0]`, `t[0 * 6 + 1]` | intentional (row 0 of 6×6) |
| frame.rs:26,27,34,35 | `k[0 * 6 + 0]`, `k[0 * 6 + 3]` | intentional |
| frame.rs:221,222 | `k[0 * n + 0]`, `k[0 * n + 6]` | intentional |
| truss.rs:20,21 | `k[0 * 6 + 0]`, `k[0 * 6 + 3]` | intentional |
| connector.rs:46,47,60,61 | `k[0 * 6 + …]` | intentional |
| plate.rs:134 | `b[0 * 6 + 2 * i]` | intentional (CST B row 0) |
| plate.rs:1186–1188 | `bs[0 * 9 + col_*]` | intentional (DKMT B_s row 0) |
| solid_shell.rs:145 | `b[0 * 24 + col]` | intentional (hex B row 0) |

## Deferred (real, not fixed here)

- **Curved-shell stress recovery is membrane-only** (`curved_shell.rs:1146`,
  `linear.rs:3951`): `mx/my/mxy` are always reported 0 and von Mises uses only mid-surface
  strain, under-reporting in bending-dominated shells. Proper fix = recover top/bottom
  surface stresses (ζ = ±1) and combine; that is a feature with result-shape implications
  (QuadStress fields, web rendering) — deferred, overlaps E9 (postprocess).
- **Zero drilling (rz) mass in `quad_consistent_mass` / `quad9_consistent_mass` /
  `curved_shell_consistent_mass`** while `plate_consistent_mass` assigns `I = m·t²/12` to
  rz. Zero-mass DOFs in the generalized eigenproblem are E5 (modal) territory; flagged for
  that section.
- **Dead public API**: `plate_local_stiffness_thick`, `plate_thickness_ratio` (DKMT thick
  plate never selected by assembly), and most of `element/cable.rs` (`catenary_ordinate`,
  `parabolic_ordinate`, `cable_sag/thrust`, `cable_length_*`, `ernst_tangent_modulus`,
  `cable_global_stiffness_2d/3d`, `cable_self_weight`, `cable_end_tensions`,
  `cable_natural_frequency`, `irvine_parameter` — only `ernst_equivalent_modulus` has a
  caller, in `solver/cable.rs`). Also `fef_distributed_torsion_warping` is never called and
  its triangular-torsion branch computes exact warping shape functions then discards them
  (`n1 * 0.0 + (1.0 - xi)`). Not removed: public API surface, zero user-visible value in
  this pass.

## Out-of-section findings (for filing)

- `linear.rs:3922` pushes `solid_shell_nodal_von_mises` output (8 Gauss-point values in
  GP order (ζ,η,ξ) loops → corner sequence 1,2,4,3) into the `nodal_von_mises` field —
  GP order ≠ node order, unlike quad/quad9 which extrapolate in node order. Owner: E9.
- `fef.rs:152` comment mentions "TS solver has the opposite sign (known divergence)" for
  2D thermal FEF. All current Rust callers use `fef_thermal_2d` consistently; the comment
  refers to a legacy/external path. Owner: W1/E2 follow-up.

## Verified OK (no change)

- `transform.rs` local-axis convention (Z-up canonical) matches `local_axis_convention.rs`
  full-solve tests and has orientation/parity/roll/left-hand unit tests.
- 2D/3D frame Timoshenko hinge condensation factor `12/(4+φ)` re-derived — correct
  (recovers 3EI/L³ for φ=0).
- MITC4 EAS-7 condensation, MITC9 tying, DKT 3-point quadrature area scaling, fiber-beam
  3D tangent symmetry, connector 2D x/z convention (`SolverNode` is x,z).
- Drilling stabilization (Hughes–Brezzi, `G·t·A·1e-3` scale) is PSD by construction and
  standard magnitude; it does add artificial normal-rotation stiffness (inherent to the
  method) — noted, not a defect.

## Verification

- Scoped: new tests fail before / pass after each fix (both directions run).
- `cargo test -p dedaliano-engine --no-fail-fast`: see PR checks — full suite green except
  the known timing-flake `scale_3d_assembly_sub_cubic` under CPU contention (re-run
  standalone on quiet machine passes — see comment below).
- Web gate `npm ci && npm run wasm && npm test`: see comment below.
