### PR TITLE
test(e2e): close the toast-recorder hole #147 shipped, and pin it with a test

### DIFF
--- a/web/e2e/fixtures.ts
+++ b/web/e2e/fixtures.ts
@@ -328,4 +328,22 @@ export async function computeDemands(page: Page): Promise<void> {
   await expect.poll(() => page.evaluate(() => window.__stabileo.demandRevision())).toBeGreaterThan(0);
 }
 
+/**
+ * Show the Básico project panel, where the project controls live on desktop.
+ *
+ * Básico is the ribbon, and `BasicPanel` is what renders `ToolbarProject` — so
+ * `project-open-file` is not attached until this panel is showing. Three specs learned
+ * that separately and each grew its own copy of the click; one UI move then read as three
+ * unrelated broken files, which is most of why ten tests looked like ten defects.
+ *
+ * Clicking is conditional because `hdr-project` TOGGLES: `openBasicPanel` defaults
+ * `opts.toggle` to true, so an unconditional click CLOSES the panel for any journey that
+ * opens a project twice, and the file input then detaches mid-test.
+ */
+export async function openBasicProjectPanel(page: Page): Promise<void> {
+  const panel = page.locator('[data-testid="basic-panel"][data-panel="project"]');
+  if (await panel.count() === 0) await page.getByTestId('hdr-project').click();
+  await expect(panel, 'the Básico project panel is showing').toBeVisible();
+}
+
 export { expect };

--- a/web/e2e/pro-project-files.spec.ts
+++ b/web/e2e/pro-project-files.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { test, expect } from './fixtures';
+import { test, expect, openBasicProjectPanel } from './fixtures';
 import type { Page } from '@playwright/test';
 
 const FIXTURE = new URL(
@@ -158,8 +158,8 @@ test.describe('@slow PRO project files', () => {
     // Básico is the ribbon on desktop and its project controls live in a panel, so the
     // claim "untouched" has to be checked where they actually are. Opening the panel is
     // part of the assertion, not setup for it: if the ribbon had lost the button, this
-    // click would fail and that is exactly the regression the test is named for.
-    await page.getByTestId('hdr-project').click();
+    // would fail and that is exactly the regression the test is named for.
+    await openBasicProjectPanel(page);
     await expect(page.locator('[data-tour="project-section"]')).toBeAttached();
     await expect(page.getByTestId('project-open-file')).toBeAttached();
     // And PRO's own controls are correctly absent from Básico.

--- a/web/e2e/project-restore.spec.ts
+++ b/web/e2e/project-restore.spec.ts
@@ -97,38 +97,69 @@ interface Watch {
  * forbidden-string check used to sample the container too, so a dismissed error toast would
  * have passed it silently, which is the failure direction that actually matters.
  */
+const TOAST_LOG_KEY = '__e2eToastLog';
+
 function recordToasts(page: Page) {
-  return page.addInitScript(() => {
+  return page.addInitScript(([key]) => {
     const w = window as unknown as { __toastLog?: string[] };
-    // `boot` runs once per page load but init scripts accumulate across them; the first
-    // script on a fresh document wins and the rest find the log already installed.
     if (w.__toastLog) return;
-    const log: string[] = [];
+
+    // The log lives in sessionStorage so it spans the RUN, not one page load. `boot`
+    // navigates three times, and the console watcher this is paired with accumulates
+    // across all of them; a per-load toast log would make `assertClean`'s two halves
+    // disagree about scope, and a forbidden toast raised before a reload would go
+    // unseen. Same origin and same tab survive `goto`, and `boot` clears only
+    // localStorage.
+    let log: string[] = [];
+    try { log = JSON.parse(sessionStorage.getItem(key) ?? '[]'); } catch { log = []; }
     w.__toastLog = log;
-    const seen = new WeakSet<Element>();
-    const note = (el: Element) => {
-      if (seen.has(el)) return;
-      seen.add(el);
-      const text = (el.textContent ?? '').trim();
-      if (text) log.push(text);
-    };
-    new MutationObserver((muts) => {
-      for (const m of muts) {
-        for (const n of Array.from(m.addedNodes)) {
-          if (!(n instanceof HTMLElement)) continue;
-          if (n.classList.contains('toast')) note(n);
-          n.querySelectorAll('.toast').forEach(note);
-        }
+    const save = () => { try { sessionStorage.setItem(key, JSON.stringify(log)); } catch { /* private mode */ } };
+
+    // Keyed on the element's CURRENT TEXT, not on "have I seen this element" — because
+    // `App.svelte` renders toasts through an UNKEYED `{#each}`. Svelte recycles the same
+    // `.toast` div by index and rewrites its text when one toast replaces another in a
+    // single flush, which emits no addedNodes at all. Watching insertions alone would
+    // therefore miss exactly the case this file cares about: a new toast raised as a 4 s
+    // dismissal fires. Text-keyed also fixes the reverse — an element inserted empty and
+    // filled a microtask later still gets recorded.
+    const lastText = new Map<Element, string>();
+    const scan = () => {
+      let dirty = false;
+      for (const el of Array.from(document.querySelectorAll('.toast'))) {
+        const text = (el.textContent ?? '').trim();
+        if (!text || lastText.get(el) === text) continue;
+        lastText.set(el, text);
+        log.push(text);
+        dirty = true;
       }
+      if (dirty) save();
+    };
     // `document`, not `documentElement`: an init script runs against the initial empty
     // document, where `documentElement` is still null and `observe` throws.
-    }).observe(document, { childList: true, subtree: true });
-  });
+    new MutationObserver(scan).observe(document, {
+      childList: true, subtree: true, characterData: true,
+    });
+  }, [TOAST_LOG_KEY]);
 }
 
-/** Every toast raised since the page loaded, in order, dismissed or not. */
+/** Every toast raised so far in the run, in order, dismissed or not. */
 async function toastsSeen(page: Page): Promise<string[]> {
-  return page.evaluate(() => (window as unknown as { __toastLog?: string[] }).__toastLog ?? []);
+  const log = await page.evaluate(() =>
+    (window as unknown as { __toastLog?: string[] }).__toastLog);
+  // Never default to []. An absent recorder would otherwise read as "no toasts were
+  // raised", turning every forbidden-toast assertion below into a silent vacuous pass —
+  // the one failure direction this file exists to prevent.
+  expect(log, 'the toast recorder is installed').toBeDefined();
+  return log!;
+}
+
+/** Forget the toasts recorded so far, alongside the console watcher's own reset. */
+async function resetToasts(page: Page) {
+  await page.evaluate(([key]) => {
+    const w = window as unknown as { __toastLog?: string[] };
+    if (w.__toastLog) w.__toastLog.length = 0;
+    try { sessionStorage.setItem(key, '[]'); } catch { /* private mode */ }
+  }, [TOAST_LOG_KEY]);
 }
 
 function watchPage(page: Page): Watch {
@@ -168,7 +199,6 @@ async function assertClean(page: Page, w: Watch, step: string) {
  * has to go because a restored tab session bypasses the autosave banner entirely.
  */
 async function boot(page: Page) {
-  await recordToasts(page);
   await page.addInitScript(() => {
     try {
       localStorage.clear();
@@ -285,9 +315,63 @@ async function assertResponsive(page: Page, step: string) {
   expect(dt, `${step}: the app answered in ${dt} ms`).toBeLessThan(15_000);
 }
 
+/**
+ * The recorder's own guard, because the journey below cannot prove this.
+ *
+ * `App.svelte` renders toasts through an UNKEYED `{#each}`, so Svelte recycles the same
+ * `.toast` div by index and rewrites its text rather than inserting a node. A recorder
+ * that watched `addedNodes` alone — the first version of this one — silently missed
+ * exactly that, which is the case where a new toast replaces one that is dismissing.
+ *
+ * The @slow journey passes either way, because whether the container happens to empty
+ * first is a timing accident. So the three shapes are pinned here directly, in a second,
+ * on every PR rather than only on main.
+ */
+test('@smoke the toast recorder catches inserted, recycled and late-filled toasts', async ({ page }) => {
+  await recordToasts(page);
+  await page.goto(PRO_URL);
+
+  // Mirrors App.svelte's markup: `.toast > span` holding the message text node.
+  await page.evaluate(() => {
+    const host = document.createElement('div');
+    host.className = 'toast-container';
+    document.body.appendChild(host);
+    const el = document.createElement('div');
+    el.className = 'toast toast-success';
+    const span = document.createElement('span');
+    span.appendChild(document.createTextNode('inserted message'));
+    el.appendChild(span);
+    host.appendChild(el);
+  });
+  await expect.poll(() => toastsSeen(page)).toContain('inserted message');
+
+  // The unkeyed-{#each} recycle, done the way Svelte does it: `set_text` assigns the
+  // existing text node's `.data`. That is a characterData record and NOT a childList
+  // one — assigning `textContent` here instead would replace the node and quietly test
+  // the wrong thing, passing even against an observer that watches insertions only.
+  await page.evaluate(() => {
+    const node = document.querySelector('.toast span')!.firstChild as Text;
+    node.data = 'recycled message';
+  });
+  await expect.poll(() => toastsSeen(page)).toContain('recycled message');
+
+  // Inserted empty and filled a tick later — the case an element-keyed `seen` set
+  // permanently swallowed.
+  await page.evaluate(() => {
+    const el = document.createElement('div');
+    el.className = 'toast toast-info';
+    document.querySelector('.toast-container')!.appendChild(el);
+    setTimeout(() => { el.textContent = 'late message'; }, 10);
+  });
+  await expect.poll(() => toastsSeen(page)).toContain('late message');
+});
+
 test('@slow restore, design, view in 3-D — then reload and do it again', async ({ page }) => {
   test.setTimeout(900_000);
   const w = watchPage(page);
+  // Installed once, before the first navigation — not inside `boot`, which runs three
+  // times and would stack three copies of the script onto every later page load.
+  await recordToasts(page);
 
   // ── 1. Open the example ──────────────────────────────────────────
   await boot(page);
@@ -423,6 +507,7 @@ test('@slow restore, design, view in 3-D — then reload and do it again', async
   await boot(page);
   await page.evaluate(() => window.__stabileoActions.openDesignTab());
   w.errors.length = 0; w.fallbacks.length = 0; w.forbidden.length = 0;
+  await resetToasts(page);
   await restoreFromBanner(page);
 
   // The restored model carries the design. Under the old autosave this was the morning's

--- a/web/e2e/project-restore.spec.ts
+++ b/web/e2e/project-restore.spec.ts
@@ -122,7 +122,27 @@ function recordToasts(page: Page) {
     // therefore miss exactly the case this file cares about: a new toast raised as a 4 s
     // dismissal fires. Text-keyed also fixes the reverse — an element inserted empty and
     // filled a microtask later still gets recorded.
-    const lastText = new Map<Element, string>();
+    //
+    // WeakMap, not Map: this keys on DOM elements the app destroys and replaces for the
+    // life of the page, and a strong map would hold every one of them alive. The
+    // observer this replaces used a WeakSet for that reason; only the key changed.
+    const lastText = new WeakMap<Element, string>();
+
+    // The sweep is document-wide on purpose, and its cost was MEASURED rather than
+    // assumed — because the obvious objection is that watching `characterData` across
+    // the whole document, in the one spec that also asserts the app answers within 15 s,
+    // puts a whole-DOM query on every text change the app makes.
+    //
+    // It does not. A MutationObserver delivers records in batches, one callback per
+    // microtask checkpoint, so `scan` runs once per task that touched the DOM and not
+    // once per mutation. Measured in Chromium at 400 mutations spread over 400 separate
+    // tasks in an 8 000-node document: 401 calls to `querySelectorAll`, and 2 511 ms
+    // against 2 548 ms with no recorder installed at all — the difference is below the
+    // noise of the run. A record-scoped version that resolves each mutation to its
+    // nearest `.toast` was written, measured at 0 calls and 2 528 ms, and thrown away:
+    // it is twenty lines of extra machinery buying nothing.
+    //
+    // Left here so the next person to have that idea can skip having it.
     const scan = () => {
       let dirty = false;
       for (const el of Array.from(document.querySelectorAll('.toast'))) {
@@ -153,7 +173,13 @@ async function toastsSeen(page: Page): Promise<string[]> {
   return log!;
 }
 
-/** Forget the toasts recorded so far, alongside the console watcher's own reset. */
+/**
+ * Forget the toasts recorded so far, alongside the console watcher's own reset.
+ *
+ * Clears the LOG, not the recorder's per-element memory: a toast still on screen
+ * showing the text it showed before the reset is the same toast, not a new one, and
+ * re-recording it would report a toast that was never raised again.
+ */
 async function resetToasts(page: Page) {
   await page.evaluate(([key]) => {
     const w = window as unknown as { __toastLog?: string[] };

--- a/web/e2e/rc-cad-handoff.spec.ts
+++ b/web/e2e/rc-cad-handoff.spec.ts
@@ -21,7 +21,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { test, expect, solveModel, designAll } from './fixtures';
+import { test, expect, solveModel, designAll, openBasicProjectPanel } from './fixtures';
 import type { Page } from '@playwright/test';
 import { validateAgainstSchema } from '../src/lib/export/json-schema-subset';
 import {
@@ -54,11 +54,9 @@ async function openCommittedProject(page: Page) {
   // First button in the mode toggle is Básico. Selected structurally rather than by label, so
   // the Spanish journeys below use the same helper.
   await page.locator('[data-tour="mode-toggle"] button').first().click();
-  // Desktop Básico is the ribbon, and the project controls live in a panel it opens —
-  // `BasicPanel` renders `ToolbarProject`, so nothing is attached until the panel is.
-  // This helper was written before the ribbon reached this branch and reached straight
-  // for the input, which no longer exists on load.
-  await page.getByTestId('hdr-project').click();
+  // Written before the ribbon reached this branch, this helper reached straight for the
+  // input, which no longer exists on load.
+  await openBasicProjectPanel(page);
   const input = page.getByTestId('project-open-file');
   await expect(input).toBeAttached();
   await input.setInputFiles(FIXTURE);

--- a/web/e2e/rc-cad-production-download.spec.ts
+++ b/web/e2e/rc-cad-production-download.spec.ts
@@ -34,7 +34,7 @@
  * identity, and never the prose.
  */
 
-import { test, expect } from './fixtures';
+import { test, expect, openBasicProjectPanel } from './fixtures';
 import type { Page } from '@playwright/test';
 import { CIRSOC_VERIFIER_ID } from '../src/lib/engine/design/adapters/cirsoc201-adapter';
 
@@ -47,10 +47,7 @@ const EXPECTED_VERIFIER = `${CIRSOC_VERIFIER_ID}.2025`;
 /** Open the committed project through the production file input. */
 async function openProject(page: Page) {
   await page.locator('[data-tour="mode-toggle"] button').first().click();
-  // Desktop Básico is the ribbon, and the project controls live in a panel it opens —
-  // `BasicPanel` renders `ToolbarProject`, so the input is not attached on load. Third
-  // copy of this helper; `rc-cad-handoff.spec.ts` carries the same opening click.
-  await page.getByTestId('hdr-project').click();
+  await openBasicProjectPanel(page);
   const input = page.getByTestId('project-open-file');
   await expect(input).toBeAttached();
   await input.setInputFiles(FIXTURE);


### PR DESCRIPTION
Follow-up to #147, which merged before this review landed. **The recorder #147 shipped has a hole in the exact mechanism it was written to fix**, so `main` currently carries it.

## The hole

`App.svelte:1136` renders toasts through an **unkeyed** `{#each}`. Svelte recycles the same `.toast` div by index and rewrites its text through `set_text` rather than inserting a node — so when one toast replaces another in a single flush there is **no `addedNodes` record at all**.

#147's observer watched insertions only. It therefore missed precisely the case the PR is about: a new toast raised as a 4 s dismissal fires. That is the same "missed toast, not missing toast" false red #147 set out to eliminate, on the same 4 s boundary it identified. It passed because whether the container happens to empty first is a timing accident, not because the mechanism was sound.

The recorder is now keyed on each element's **current text** with `characterData: true`. That covers the recycled node, and also a node inserted empty and filled a tick later — which the old `seen` WeakSet swallowed permanently, because it marked the element before the emptiness check.

## Four further repairs from the same review

- **`toastsSeen` no longer defaults to `[]`.** An absent recorder read as "no toasts were raised", turning every forbidden-toast assertion into a silent vacuous pass — the one failure direction this file exists to prevent.
- **The log spans the run, not one page load.** It was per-load while the console watcher it is paired with accumulates per-run, so the two halves of `assertClean` disagreed about scope and a forbidden toast raised before a reload was invisible. Now sessionStorage-backed, reset explicitly beside the watcher's own reset.
- **The recorder installs once**, before the first navigation, instead of inside `boot` — which runs three times and stacked three copies of the init script onto every later page load.
- **`openBasicProjectPanel` moves to `fixtures.ts`.** #147 wrote the same assumption into three specs — the duplication its own description named as "the more durable defect here", and then reproduced. It now also clicks **conditionally**: `hdr-project` toggles (`openBasicPanel` defaults `opts.toggle` to true), so an unconditional click closes the panel for any journey that opens a project twice, detaching the input mid-test.

## The guard test, and how it was wrong first

The new `@smoke` test pins all three shapes in under a second, on every PR rather than only on main — it would have caught this on #147.

It was **vacuous when first written**. It recycled the toast via `textContent = '...'`, which *replaces* the child text node and is therefore a `childList` record — so it passed against the broken observer. Svelte assigns the existing text node's `.data`, a `characterData` record. Rewritten to do the same, against markup mirroring `.toast > span`.

Verified in both directions:

```
with    characterData: true  → passes
without characterData: true  → fails
    Expected value: "recycled message"
    Received array: ["inserted message"]
```

## Verification

16/16 green locally across all four affected specs (`project-restore` @smoke + @slow, `pro-project-files`, `rc-cad-handoff`, `rc-cad-production-download`), 2.7 min.

## Still open from #147, not addressed here

`rebar-workspace-open.spec.ts:139` misses a perf bound by 0.24% (`501.2` vs `< 500`). It passed on #147's CI and fails under load, so it is flaky at a threshold sitting on the real cost. Whoever owns that number should decide whether the bound is too tight or document assembly regressed; relaxing it to keep a suite green is how suites stop being believed.
