### PR TITLE
fix(warping): measure a channel's sectorial coordinate about its shear centre

### DIFF
--- a/web/src/lib/engine/__tests__/warping.test.ts
+++ b/web/src/lib/engine/__tests__/warping.test.ts
@@ -191,3 +191,69 @@ describe('warping stress — the part that is not conservative to omit', () => {
       .toBeCloseTo(warpingResponse(s, p, 10, 3, 210000)!.sigmaW, 9);
   });
 });
+
+describe('a channel warps about its shear centre, not about its web', () => {
+  /** Mid-line walk: omega(s) = int r_t ds, normalised so int(omega dA) = 0. */
+  function sectorialByIntegration(h: number, b: number, tw: number, tf: number) {
+    const bm = b - tw / 2, h0 = h - tf;
+    const den = 6 * tf * bm + tw * h0;
+    const e = (3 * bm * bm * tf) / den;   // pole, outside the web
+    const N = 4000;
+    // Perpendicular distance from the pole to each wall's line: h0/2 for the
+    // flanges (horizontal), e for the web (vertical).
+    const walls = [
+      { rt: -h0 / 2, ds: bm / N, dA: (tf * bm) / N },  // top flange, tip -> web
+      { rt: e, ds: h0 / N, dA: (tw * h0) / N },        // web, top -> bottom
+      { rt: -h0 / 2, ds: bm / N, dA: (tf * bm) / N },  // bottom flange, web -> tip
+    ];
+    const om: number[] = [], dA: number[] = [];
+    let acc = 0;
+    for (const w of walls) {
+      for (let i = 0; i < N; i++) { acc += w.rt * w.ds; om.push(acc); dA.push(w.dA); }
+    }
+    const area = dA.reduce((s, v) => s + v, 0);
+    const mean = om.reduce((s, v, i) => s + v * dA[i], 0) / area;
+    const omN = om.map((v) => v - mean);
+    return {
+      e,
+      cw: omN.reduce((s, v, i) => s + v * v * dA[i], 0),
+      peak: Math.max(...omN.map(Math.abs)),
+    };
+  }
+
+  it('the integration reproduces the module\'s own Cw, so it is the same omega', () => {
+    const s = UPN200();
+    const ref = sectorialByIntegration(s.h, s.b, s.tw, s.tf);
+    // Relative: Cw is of order 1e-9 m⁶, so an absolute tolerance here would
+    // pass on almost anything of that magnitude and check nothing.
+    expect(Math.abs(ref.cw / warpingProperties(s).cw - 1)).toBeLessThan(1e-4);
+  });
+
+  it('puts the shear centre outside the web, where a channel\'s belongs', () => {
+    const s = UPN200();
+    const ref = sectorialByIntegration(s.h, s.b, s.tw, s.tf);
+    // ~27 mm from the web mid-line for a UPN 200 — a real arm, not a rounding.
+    expect(ref.e).toBeGreaterThan(0.02);
+    expect(ref.e).toBeLessThan(0.035);
+  });
+
+  it('the reported stress follows the integrated peak, not the web-measured one', () => {
+    const s = UPN200();
+    const p = withLambda(warpingProperties(s), 210000);
+    const ref = sectorialByIntegration(s.h, s.b, s.tw, s.tf);
+    const r = warpingResponse(s, p, 10, 2, 210000, 'cantilever')!;
+
+    // sigma_w = B·omega/Cw, in MPa. Compared relatively: the reference is a
+    // midpoint sum over N segments, so its peak carries an O(1/N) sampling
+    // error — around 3e-5 here. A tolerance of 1e-3 is loose against that and
+    // still tight against the error being checked for, which is 60%.
+    const expected = (r.bimoment * ref.peak) / p.cw / 1000;
+    expect(Math.abs(r.sigmaW / expected - 1)).toBeLessThan(1e-3);
+
+    // And the value it used to report, for the record: measuring the tip from
+    // the web gives h0·bm/2, which is 60% larger.
+    const fromWeb = ((s.h - s.tf) * (s.b - s.tw / 2)) / 2;
+    expect(fromWeb / ref.peak).toBeGreaterThan(1.5);
+    expect(r.sigmaW).toBeLessThan((r.bimoment * fromWeb) / p.cw / 1000);
+  });
+});

--- a/web/src/lib/engine/warping.ts
+++ b/web/src/lib/engine/warping.ts
@@ -180,15 +180,32 @@ export function withLambda(
  * For a doubly-symmetric I this is `h0·b/4` — the corner of a flange, which is
  * where the flange's own bending stress is largest too, so the two add at the
  * worst place rather than at different ones.
+ *
+ * A channel needs the shear centre, and this is where it was skipped: the
+ * comment said "measured about the shear centre" and the arithmetic measured
+ * from the WEB. Its pole sits a distance `e` outside the web, so the sectorial
+ * coordinate runs from `h0·e/2` at the web-flange junction to `h0·(bm−e)/2` at
+ * the flange tip, and the peak is whichever is larger. Taking the tip from the
+ * web instead — `h0·bm/2` — is 60% high on a UPN 200, and `sigma_w = B·ω/Cw`
+ * carries that straight into the reported stress. Conservative, but a stress
+ * 60% high is not a usable number either.
+ *
+ * `e = 3·bm²·tf / (6·bm·tf + h0·tw)` is the thin-wall result, and its
+ * denominator is the same one the channel's `Cw` above already computes —
+ * which is the tell that the two belong to the same derivation.
  */
 function peakSectorialCoordinate(rs: ResolvedSection): number {
   switch (rs.shape) {
     case 'I': case 'H':
       return ((rs.h - rs.tf) * rs.b) / 4;
-    case 'U': case 'C':
-      // Approximate: the flange tip, measured about the shear centre. Adequate
-      // for the magnitude, which is what this reports.
-      return ((rs.h - rs.tf) * (rs.b - rs.tw / 2)) / 2;
+    case 'U': case 'C': {
+      const bm = rs.b - rs.tw / 2;
+      const h0 = rs.h - rs.tf;
+      const den = 6 * rs.tf * bm + rs.tw * h0;
+      if (bm <= 0 || h0 <= 0 || den <= 0) return 0;
+      const e = (3 * bm * bm * rs.tf) / den;
+      return (h0 / 2) * Math.max(e, bm - e);
+    }
     default:
       return 0;
   }


### PR DESCRIPTION
Rebased onto 2d3e8ec and cut down to the one finding it does not cover.

You got to **1** and **2** first and your fixes are the same ones — `saintVenantShare` on the half-span parameter, `principalOf` taking both normal components — so I dropped mine rather than have two versions of the same change. Your `principalOf` passes `otherNormal` as the third value where mine passed `strain.zz`; identical here because the two contractions are equal, and yours is the simpler signature. Your `the simple case is the cantilever solution on the half-span` covers the share, so my tests for it went too.

What is left is the channel.

## A channel's sectorial coordinate is measured from the web

Different module from the one you fixed: this is `peakSectorialCoordinate` in `warping.ts`, not the shear centre in `section-teaching.ts`. The comment says "the flange tip, measured about the shear centre" and the arithmetic is `h0·bm/2`, with the offset never subtracted.

The pole sits `e = 3·bm²·tf / (6·bm·tf + h0·tw)` outside the web — the same denominator your `Cw` already computes, which is the tell that both come from one derivation. So ω runs from `h0·e/2` at the web-flange junction to `h0·(bm−e)/2` at the tip, and the peak is the larger. On a UPN 200:

```
shear-centre offset e            26.63 mm from the web mid-line
max|omega|, integrated           41.58 cm2
(h0/2)·max(e, bm−e)              41.58 cm2
h0·bm/2  (what it returned)      66.68 cm2   → 60% high
```

`sigma_w = B·ω/Cw` carries that factor straight through. Conservative, so nothing unsafe shipped — I am fixing it because a stress reported 60 % high is not a usable number either, and this module states the direction of every other approximation it makes.

## How the tests are anchored

They do not restate the closed form and check it against itself. They walk the section mid-line and integrate `ω(s) = ∫ r_t ds`, then require that integration to reproduce **your** `Cw` — a completely different route to the same warping constant. If it lands there, it is the same ω and its peak can be trusted.

It matches to **0.00 %**, which incidentally validates the channel `Cw` formula independently of the published value it had been checked against before.

Reverting the change turns the third test red; I checked.

## Still open from the review, and deliberately not here

The fall-through in `warpingProperties` that labels a degenerate channel — and `rect`, and `generic` — as `closedNegligible`. Right about the magnitude for a solid rectangle, wrong about the reason. A new `WarpingClass` plus a label across 14 locales is your call, not mine.

## Verification

- warping suite: 111 passed.
- `npm run typecheck`: no new errors (479, baseline 479).
