### PR TITLE
fix(engine): a circular tube's shear was half its true peak

### DIFF
--- a/engine/src/postprocess/section_stress.rs
+++ b/engine/src/postprocess/section_stress.rs
@@ -162,9 +162,24 @@ fn compute_q_and_b(y: f64, rs: &ResolvedSection) -> (f64, f64) {
             (q_flange + q_web, 2.0 * rs.t)
         }
         "CHS" => {
+            // A horizontal cut at height y severs TWO walls, so `b = 2t` — and
+            // `Q` must then be the first moment of the WHOLE area above the
+            // cut, both sides. With theta measured from the crown
+            // (cos theta = y/R), integrating `t·R dphi` at height `R cos phi`
+            // from the free edge down to theta gives `t·R²·sin theta` per side:
+            //     Q(y) = 2·t·R²·sin theta = 2·t·R·sqrt(R² − y²)
+            //     tau  = V·Q/(I·b) = V·R·sqrt(R² − y²)/I  →  tau_max = 2V/A,
+            // the classic thin-tube result.
+            //
+            // This paired a ONE-sided Q with a two-sided b — half the magnitude
+            // and the wrong (parabolic) shape, reporting V/A where a tube peaks
+            // at 2V/A. The TypeScript closed form was corrected for exactly
+            // that pairing and the engine was not, so the drawn diagram and the
+            // design number disagreed by a factor of two, with the engine — the
+            // one that actually runs in the browser — on the LOW side.
             let r = rs.h / 2.0;
-            if y.abs() >= r { return (0.0, rs.t); }
-            let q = rs.t * (r * r - y * y);
+            if y.abs() >= r { return (0.0, 2.0 * rs.t); }
+            let q = 2.0 * rs.t * r * (r * r - y * y).sqrt();
             (q, 2.0 * rs.t)
         }
         "L" => {

--- a/engine/tests/validation/domains/response/section_stress.rs
+++ b/engine/tests/validation/domains/response/section_stress.rs
@@ -85,6 +85,61 @@ fn validation_stress_pure_shear() {
 }
 
 // ═══════════════════════════════════════════════════════════════
+// 2b. Circular tube: τ_max = 2V/A
+// ═══════════════════════════════════════════════════════════════
+
+/// A thin circular tube peaks at TWICE the mean shear, not once.
+///
+/// Reference: the standard table of shear-shape factors — the thin tube is the
+/// κ = 2 case, beside the solid rectangle's 3/2 above and the solid circle's
+/// 4/3.
+///
+/// This is a regression guard as much as a validation. `compute_q_and_b` paired
+/// a ONE-sided first moment `t(R²−y²)` with a TWO-sided width `2t`, which
+/// reports `V/A` — exactly half. The TypeScript closed form had been corrected
+/// for that pairing and the engine had not, so the drawn diagram and the design
+/// number disagreed by a factor of two, with the engine on the low side and
+/// nothing comparing them.
+#[test]
+fn validation_stress_circular_tube_peaks_at_twice_the_mean() {
+    // CHS 300 x 8, on the mid-line: A = 2πRt, I = πR³t.
+    let d = 0.3_f64;
+    let t = 0.008_f64;
+    let r_mid = (d - t) / 2.0;
+    let a = 2.0 * std::f64::consts::PI * r_mid * t;
+    let i = std::f64::consts::PI * r_mid.powi(3) * t;
+
+    let v = 100.0_f64;
+    let input = SectionStressInput {
+        element_forces: make_ef(0.0, v, 0.0),
+        section: SectionGeometry {
+            shape: "CHS".to_string(),
+            h: d, b: d,
+            tw: None, tf: None, t: Some(t),
+            a, iy: i, iz: i, j: None,
+        },
+        fy: Some(FY),
+        t: 0.0,
+        y_fiber: None,
+    };
+    let result = compute_section_stress_2d(&input);
+
+    let peak = result.distribution.iter()
+        .map(|p| p.tau.abs())
+        .fold(0.0_f64, f64::max);
+    let mean = v / a / 1000.0; // MPa
+    let ratio = peak / mean;
+
+    // Thin-wall theory gives exactly 2; a real wall of t/R ≈ 5.5% lands a few
+    // per cent above, so the band sits above the ideal rather than around it —
+    // and it excludes 1, which is what the one-sided pairing reported.
+    assert!(
+        (1.95..=2.20).contains(&ratio),
+        "circular tube τ_max/(V/A) = {ratio:.4}, expected ≈2 (the bug reported ≈1)"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════
 // 3. Combined N+M: σ(y) = N/A + My/I, Neutral Axis Shift
 // ═══════════════════════════════════════════════════════════════
 

--- a/web/src/lib/engine/__tests__/chs-shear-agreement.test.ts
+++ b/web/src/lib/engine/__tests__/chs-shear-agreement.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The drawn shear diagram and the engine's design number must agree on a tube.
+ *
+ * They did not. `computeQandB`'s TypeScript closed form was corrected to pair a
+ * two-sided first moment with the two-sided width a horizontal cut through a
+ * circular tube actually severs; `engine/src/postprocess/section_stress.rs` kept
+ * the one-sided pairing and so reported half. Nothing compared them, because
+ * `crossCheckShearPeak` measures the drawn peak against the FEM mesh solve and
+ * never against this path.
+ *
+ * A thin tube peaks at 2V/A — the standard shear-shape factor beside the solid
+ * rectangle's 3/2 and the solid circle's 4/3. Pinning the AGREEMENT rather than
+ * only the value is what keeps the two implementations from drifting again: a
+ * fix applied to one language and not the other is exactly what happened here.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { computeSectionProperties } from '../../data/section-shapes';
+import {
+  resolveSectionGeometryLegacy, shearStress, computeShearFlowPaths, analyzeSectionStress,
+} from '../section-stress';
+import { initSolver } from '../wasm-solver';
+
+beforeAll(async () => { await initSolver(); }, 120_000);
+
+const peak = (paths: Array<{ points: Array<{ tau: number }> }>) =>
+  Math.max(...paths.flatMap((p) => p.points.map((q) => Math.abs(q.tau))));
+
+/** CHS 300 x 8, a catalogue-shaped tube: geometry-backed and analysable. */
+function tube() {
+  const built = computeSectionProperties('hollow-circular', { d: 0.3, t: 0.008 } as never);
+  return { id: 1, name: 'CHS 300x8', ...(built as object) } as never;
+}
+
+describe('a circular tube peaks at twice the mean shear, in every path', () => {
+  const V = 100;
+
+  it('the engine agrees with the drawn diagram, not half of it', () => {
+    const sec = tube();
+    const rs = resolveSectionGeometryLegacy(sec);
+    const mean = V / rs.a / 1000;
+
+    const ef = {
+      elementId: 1, length: 4,
+      nStart: 0, nEnd: 0, vStart: V, vEnd: V, mStart: 0, mEnd: 0,
+      qI: 0, qJ: 0, pointLoads: [], distributedLoads: [],
+    } as never;
+
+    const res = analyzeSectionStress(ef, sec, 275, 0, 0) as { distribution?: Array<{ tau: number }> };
+    const enginePeak = Math.max(...(res.distribution ?? []).map((p) => Math.abs(p.tau)));
+    const drawnPeak = peak(computeShearFlowPaths(V, rs));
+
+    // Same physical quantity, so they have to land on the same number. The bug
+    // put a factor of two between them.
+    expect(enginePeak / drawnPeak).toBeCloseTo(1, 1);
+    expect(enginePeak / mean).toBeGreaterThan(1.95);
+  });
+
+  it('lands on the thin-tube factor of 2, not the 1 the one-sided pairing gave', () => {
+    const sec = tube();
+    const rs = resolveSectionGeometryLegacy(sec);
+    const mean = V / rs.a / 1000;
+    // t/R here is ~5.5%, so a real wall sits a few per cent above the thin-wall
+    // ideal. The band is one-sided about 2 for that reason, and it excludes 1.
+    for (const [label, value] of [
+      ['TS design', shearStress(V, 0, rs)],
+      ['TS drawn', peak(computeShearFlowPaths(V, rs))],
+    ] as const) {
+      const ratio = value / mean;
+      expect(ratio, `${label} = ${ratio.toFixed(4)}x`).toBeGreaterThan(1.95);
+      expect(ratio, `${label} = ${ratio.toFixed(4)}x`).toBeLessThan(2.25);
+    }
+  });
+});


### PR DESCRIPTION
A circular tube reports half its true peak shear, and the number that is wrong is the one the panel shows.

## The bug

`engine/src/postprocess/section_stress.rs`, CHS branch:

```rust
let q = rs.t * (r * r - y * y);
(q, 2.0 * rs.t)
```

That is a **one-sided** first moment over a **two-sided** width. A horizontal cut through a tube severs two walls, so `b = 2t` is right — but `Q` must then be the first moment of the whole area above the cut, both sides. Pairing half of one with all of the other halves the answer, and gives a parabola where the real distribution is a semi-ellipse.

The TypeScript closed form in `section-stress.ts` was **corrected for exactly this pairing** and carries a comment saying so. The engine never got the same fix.

## Why it matters more than it looks

`analyzeSectionStress` prefers WASM when it is ready, so in a browser the engine's number is what the panel shows. Measured on a CHS 300×8 at V = 100 kN:

| | τ_max / (V/A) |
|---|---|
| thin-tube exact | 2.000 |
| TS closed form (design + drawn) | 2.109 |
| **engine (what is displayed)** | **1.055** |

Half, and on the **unconservative** side. This is not a corner case: catalogue tubes are geometry-backed and analysable, unlike the solid-circle path, so this is what a user sizing a CHS actually sees.

Nothing caught it because nothing compared the two. `crossCheckShearPeak` measures the DRAWN peak against the FEM mesh solve, never against this path — so a fix landing in one language and not the other was invisible to the suite.

## The fix

Walking the wall from the crown with `cos θ = y/R`, integrating `t·R dφ` at height `R cos φ` from the free edge down to θ gives `t·R²·sin θ` per side:

```
Q(y) = 2·t·R²·sin θ = 2·t·R·√(R² − y²)
τ(y) = V·Q/(I·b) = V·R·√(R² − y²)/I   →   τ_max = 2V/A
```

which is the classic thin-tube result and the same expression the TS side already uses.

## Two tests, deliberately of different kinds

- **Rust validation** against the standard shear-shape factor of 2, sitting beside the solid rectangle's 3/2 and the solid circle's 4/3 that were already in that file. Reverting the fix turns it red — verified.
- **TypeScript** pinning the **agreement** between the engine and the drawn diagram, not either value alone. The divergence is what went unnoticed for as long as it did, so that is what is worth guarding against.

## Verification

- `cargo test --test validation section_stress`: 9 passed.
- Web: the agreement test passes against a rebuilt wasm.
- Full Rust suite: 22 binaries green. Two `perf_regression_*` binaries fail on wall-clock budgets (`assembly_3d_100_elements_under_500ms` at 934 ms, `buckling_3d_5x5_plate_under_5s` at 7.8 s) — debug build with a vitest suite running alongside, unrelated to section stress.
- Full web suite: 6455 passed. `scene-completeness.test.ts` times out in my sandbox because the worker pool cannot `fetch`, falls back to sequential, and one WASM solve alone takes ~46 s against a 120 s hook budget. **It fails identically on `82f48ff8`, without this change** — I checked rather than assumed.

## Not in here

Two things from the same investigation, deliberately separate:

- A **solid** circular section (`concrete-circular` — an ordinary RC round column) cannot be analysed at all: `computeSectionProperties` emits no `t`, and `canonical.ts` requires `t > 0` under `shape: 'CHS'`, so the panel classes it "amorphous" and shows nothing. Adding `t: 0` is NOT the fix — the engine has no solid-circle branch and would return τ = 0, which is worse. The canonical layer needs a way to say "solid circle".
- `section_stress_3d.rs` has its own `t < 1e-12` early return that I have not audited.
