### PR TITLE
fix(slice): count load by what it carries, not by what survives the cut

### DIFF
--- a/web/src/lib/engine/__tests__/slice-solve-audit.test.ts
+++ b/web/src/lib/engine/__tests__/slice-solve-audit.test.ts
@@ -177,3 +177,73 @@ describe('every cut of every 3D model', { timeout: 120_000 }, () => {
     expect(solved / total).toBeGreaterThan(0.3);
   });
 });
+
+/**
+ * Load accounting, over the same library.
+ *
+ * A cut that keeps its supports fails LOUDLY when it is wrong — the solver
+ * refuses. A cut that keeps no LOAD fails quietly: it solves, every result is
+ * zero, and the utilisation map paints it uniformly safe. The dialog warns
+ * about that, and the warning is only as good as the count it is gated on.
+ *
+ * That count used to be a count of load OBJECTS. A load survives a cut
+ * whenever the thing it acts on survives, but it carries only its in-plane
+ * component into the frame — so a roof load pointing down global Z survived a
+ * horizontal cut and acted on nothing. Seven cuts of this library advertised
+ * between one and forty loads and produced a frame carrying zero, with the
+ * warning silent on every one.
+ */
+describe('load accounting across the library', { timeout: 120_000 }, () => {
+  /** Everything the produced 2D model actually carries, summed. */
+  const magnitude = (loads: Array<{ data: Record<string, unknown> }>): number => {
+    let m = 0;
+    for (const l of loads) {
+      for (const k of ['qI', 'qJ', 'fx', 'fz', 'p', 'my']) {
+        m += Math.abs(Number((l.data as Record<string, unknown>)[k] ?? 0));
+      }
+    }
+    return m;
+  };
+
+  it('no cut advertises load and delivers a frame carrying none', () => {
+    let checked = 0;
+    for (const name of MODELS) {
+      const model = load(name);
+      if (!model.loads.length) continue;
+      for (const plane of ['xy', 'xz', 'yz'] as DrawPlane[]) {
+        for (const cut of planeOffsets(
+          plane, model.nodes.values(), model.elements.values(),
+          model.supports.values(), model.loads,
+        )) {
+          if (cut.elements === 0) continue;
+          const r = sliceModelAtPlane(
+            plane, cut.value, model.nodes.values(), model.elements.values(),
+            model.supports.values(), model.loads, model.materials, model.sections,
+          );
+          if (!r.ok) continue;
+          checked++;
+          const where = `${name} ${plane}=${cut.value}`;
+
+          // The one that matters: if the dialog says there is load, there is.
+          if (cut.loads > 0) {
+            expect(magnitude(r.model.loads), `${where} advertised ${cut.loads} loads`)
+              .toBeGreaterThan(0);
+          }
+
+          /*
+           * The preview is exact about ZERO and approximate above it — it runs
+           * before the projection, so it cannot know which members will
+           * collapse or duplicate away, and a load on one of those goes with
+           * it. Four cuts of this library differ by a few. What has to hold
+           * exactly is the equivalence the warning is gated on, both ways.
+           */
+          expect(cut.loads === 0, `${where}`).toBe(r.slice.loads === 0);
+
+          // And nothing may simply vanish from the accounting.
+          expect(r.slice.loads + r.slice.droppedLoads, `${where}`).toBe(model.loads.length);
+        }
+      }
+    }
+    expect(checked, 'the sweep actually examined cuts').toBeGreaterThan(50);
+  });
+});

--- a/web/src/lib/geometry/__tests__/plane-slice.test.ts
+++ b/web/src/lib/geometry/__tests__/plane-slice.test.ts
@@ -498,4 +498,61 @@ describe('load is counted by what it carries, not by what survives', () => {
       }
     }
   });
+
+  /**
+   * Every KIND, including the ones no shipped fixture exercises at zero.
+   *
+   * The library sweep cannot see this: nothing that ships carries a
+   * zero-magnitude point or thermal load, so a rule applied to the
+   * distributed branch and forgotten on the other two passed it completely.
+   * It did — `pointOnElement` with p = 0 was advertised as nothing by the
+   * preview and counted as carried by the projection, which is the same lie
+   * this count exists to stop, wearing a rarer type.
+   *
+   * Enumerating the kinds is what catches a rule applied unevenly. A sweep
+   * over real models only ever proves things about the loads real models have.
+   */
+  const AT_ZERO: Array<[string, { type: string; data: Record<string, unknown> }]> = [
+    ['distributed', { type: 'distributed', data: { id: 1, elementId: 11, qI: 0, qJ: 0 } }],
+    ['distributed3d', { type: 'distributed3d', data: { id: 1, elementId: 11, qYI: 0, qYJ: 0, qZI: 0, qZJ: 0 } }],
+    ['pointOnElement', { type: 'pointOnElement', data: { id: 1, elementId: 11, a: 2, p: 0 } }],
+    ['thermal', { type: 'thermal', data: { id: 1, elementId: 11, dtUniform: 0, dtGradient: 0 } }],
+    ['nodal', { type: 'nodal', data: { id: 1, nodeId: 1, fx: 0, fz: 0 } }],
+    ['nodal3d', { type: 'nodal3d', data: { id: 1, nodeId: 1, fx: 0, fy: 0, fz: 0, mx: 0, my: 0, mz: 0 } }],
+  ];
+
+  for (const [kind, load] of AT_ZERO) {
+    it(`a ${kind} carrying nothing is dropped and counted, not "kept"`, () => {
+      const cut = planeOffsets('xz', NODES, ELEMENTS, SUPPORTS, [load]).find((o) => o.value === 0)!;
+      expect(cut.loads, 'the preview must not advertise it').toBe(0);
+
+      const r = sliceModelAtPlane('xz', 0, NODES, ELEMENTS, SUPPORTS, [load], MATERIALS, SECTIONS);
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.slice.loads, 'nor may the slice report it as carried').toBe(0);
+      expect(r.slice.droppedLoads, 'and it has to be counted as dropped').toBe(1);
+    });
+  }
+
+  const CARRYING: Array<[string, { type: string; data: Record<string, unknown> }]> = [
+    ['distributed', { type: 'distributed', data: { id: 1, elementId: 11, qI: -10, qJ: -10 } }],
+    ['pointOnElement', { type: 'pointOnElement', data: { id: 1, elementId: 11, a: 2, p: -5 } }],
+    ['thermal', { type: 'thermal', data: { id: 1, elementId: 11, dtUniform: 20, dtGradient: 0 } }],
+    ['nodal', { type: 'nodal', data: { id: 1, nodeId: 1, fx: 3, fz: -7 } }],
+  ];
+
+  for (const [kind, load] of CARRYING) {
+    it(`a ${kind} that does carry something is not dropped`, () => {
+      // The other direction, so the rule cannot be satisfied by dropping
+      // everything — which would silence the warning just as effectively.
+      const cut = planeOffsets('xz', NODES, ELEMENTS, SUPPORTS, [load]).find((o) => o.value === 0)!;
+      expect(cut.loads, `${kind} should be advertised`).toBe(1);
+
+      const r = sliceModelAtPlane('xz', 0, NODES, ELEMENTS, SUPPORTS, [load], MATERIALS, SECTIONS);
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.slice.loads, `${kind} should be carried`).toBe(1);
+      expect(r.slice.droppedLoads).toBe(0);
+    });
+  }
 });

--- a/web/src/lib/geometry/__tests__/plane-slice.test.ts
+++ b/web/src/lib/geometry/__tests__/plane-slice.test.ts
@@ -424,3 +424,78 @@ describe('a released member keeps its hinge through the cut', () => {
     expect(r.model.elements.get(10)!.releaseI).toEqual(rel(false, true));
   });
 });
+
+/**
+ * A load that survives the cut but carries nothing must not count as kept.
+ *
+ * This is the failure the dropped-load count was written to prevent and did
+ * not. A load survives whenever the thing it acts on survives, but it carries
+ * only its IN-PLANE component into the frame: a roof load pointing down the
+ * global Z is nothing at all to a horizontal frame. So a cut could advertise
+ * forty loads, "keep" all forty, and produce a model carrying zero — with the
+ * zero-load warning silent, because it is gated on that same count.
+ *
+ * Counting objects instead of effect is what made it invisible.
+ */
+describe('load is counted by what it carries, not by what survives', () => {
+  /** A vertical (global Z) distributed load on the y = 0 frame's rafter. */
+  const VERTICAL = [
+    { type: 'distributed3d', data: { id: 300, elementId: 11, qYI: 0, qYJ: 0, qZI: -10, qZJ: -10 } },
+  ];
+
+  it('an XZ cut keeps it, because Z lies in that plane', () => {
+    expect(planeOffsets('xz', NODES, ELEMENTS, SUPPORTS, VERTICAL).find((o) => o.value === 0)?.loads)
+      .toBe(1);
+    const r = sliceModelAtPlane('xz', 0, NODES, ELEMENTS, SUPPORTS, VERTICAL, MATERIALS, SECTIONS);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.slice.loads).toBe(1);
+    expect(r.slice.droppedLoads).toBe(0);
+  });
+
+  it('an XY cut does not, because a vertical load is nothing to a horizontal frame', () => {
+    // Same load, same members, a plane that cannot hold it. This has to read
+    // zero, or the warning gated on it never fires.
+    for (const o of planeOffsets('xy', NODES, ELEMENTS, SUPPORTS, VERTICAL)) {
+      expect(o.loads, `offset ${o.value}`).toBe(0);
+    }
+    const r = sliceModelAtPlane('xy', 4, NODES, ELEMENTS, SUPPORTS, VERTICAL, MATERIALS, SECTIONS);
+    if (r.ok) {
+      expect(r.slice.loads).toBe(0);
+      expect(r.slice.droppedLoads).toBe(1);
+    }
+  });
+
+  it('the preview is exact about ZERO, which is what the warning needs', () => {
+    /*
+     * Not "advertised equals kept" — that is false in general and I had
+     * claimed it. The preview runs before the projection, so it cannot know
+     * about members that collapse or duplicate away, and a load on one of
+     * those goes with it. Four cuts of the shipped library disagree by a few.
+     *
+     * What must hold exactly is the equivalence the zero-load warning is
+     * gated on, in both directions: a cut that will carry nothing has to
+     * count zero (or the warning stays silent when it is needed), and a cut
+     * that counts zero has to carry nothing (or it cries wolf).
+     */
+    for (const plane of ['xy', 'xz', 'yz'] as const) {
+      for (const cut of planeOffsets(plane, NODES, ELEMENTS, SUPPORTS, LOADS)) {
+        if (cut.elements === 0) continue;
+        const r = sliceModelAtPlane(plane, cut.value, NODES, ELEMENTS, SUPPORTS, LOADS, MATERIALS, SECTIONS);
+        if (!r.ok) continue;
+        expect(cut.loads === 0, `${plane} = ${cut.value}`).toBe(r.slice.loads === 0);
+      }
+    }
+  });
+
+  it('every load is either carried or counted as dropped — none vanish', () => {
+    for (const plane of ['xy', 'xz', 'yz'] as const) {
+      for (const cut of planeOffsets(plane, NODES, ELEMENTS, SUPPORTS, LOADS)) {
+        if (cut.elements === 0) continue;
+        const r = sliceModelAtPlane(plane, cut.value, NODES, ELEMENTS, SUPPORTS, LOADS, MATERIALS, SECTIONS);
+        if (!r.ok) continue;
+        expect(r.slice.loads + r.slice.droppedLoads, `${plane} = ${cut.value}`).toBe(LOADS.length);
+      }
+    }
+  });
+});

--- a/web/src/lib/geometry/plane-projection.ts
+++ b/web/src/lib/geometry/plane-projection.ts
@@ -55,6 +55,66 @@ export function remapNodalLoad2D(plane: DrawPlane, fx3d: number, fy3d: number, f
 }
 
 /**
+ * Below this, a projected load carries nothing and is not a load.
+ *
+ * Not a tolerance on geometry — a threshold on FORCE. A load whose in-plane
+ * component is this small acts on nothing, and the 2D solver would integrate
+ * it to zero anyway; the only question is whether anyone is told it is gone.
+ */
+export const LOAD_EPS = 1e-12;
+
+/**
+ * What a load still carries once projected onto a plane, as a magnitude.
+ *
+ * Existence is not the same question as effect, and for a slice they come
+ * apart: a roof load pointing down the global Z has no component in a
+ * HORIZONTAL frame, so it survives the cut as an object and acts on nothing.
+ * Counting objects made that invisible — the dialog advertised forty loads,
+ * the frame carried none, and the utilisation map painted it uniformly green.
+ *
+ * Summed componentwise rather than normed: this decides "is there anything
+ * here at all", and for that a sum of absolute values is both cheaper and
+ * strictly safer than a norm — it cannot cancel.
+ *
+ * Kinds with no 2D form (a surface load carries `quadId`, and a quad is not
+ * something a plane frame can hold) return 0, which is what makes them show
+ * up as dropped rather than vanish.
+ */
+export function inPlaneLoadMagnitude(
+  load: { type: string; data: Record<string, unknown> },
+  plane: DrawPlane,
+): number {
+  const d = load.data as Record<string, number | undefined>;
+  const abs = (v: number | undefined) => Math.abs(v ?? 0);
+
+  switch (load.type) {
+    case 'nodal3d': {
+      const f = remapNodalLoad2D(plane, d.fx ?? 0, d.fy ?? 0, d.fz ?? 0);
+      return Math.abs(f.fx) + Math.abs(f.fy)
+        + Math.abs(remapMoment2D(plane, d.mx ?? 0, d.my ?? 0, d.mz ?? 0));
+    }
+    case 'nodal': {
+      // The legacy 2D shape stores the vertical in `fz`, falling back to `fy`.
+      const f = remapNodalLoad2D(plane, d.fx ?? 0, d.fz ?? d.fy ?? 0, 0);
+      return Math.abs(f.fx) + Math.abs(f.fy)
+        + Math.abs(remapMoment2D(plane, 0, 0, d.my ?? d.mz ?? 0));
+    }
+    case 'distributed3d':
+      return plane === 'xy'
+        ? abs(d.qYI) + abs(d.qYJ)
+        : abs(d.qZI) + abs(d.qZJ);
+    case 'distributed':
+      return abs(d.qI) + abs(d.qJ);
+    case 'pointOnElement':
+      return abs(d.p) + abs(d.px) + abs(d.my);
+    case 'thermal':
+      return abs(d.dtUniform) + abs(d.dtGradient);
+    default:
+      return 0;
+  }
+}
+
+/**
  * Remap a 3D moment about each axis to the single 2D rotation (about the
  * out-of-plane axis).
  *   XY plane → rotation about Z
@@ -92,7 +152,20 @@ export interface SimplifiedModel {
   materials: Map<number, any>;
   sections: Map<number, any>;
   /** Stats about the reduction */
-  stats: { mergedNodes: number; removedElements: number; duplicateElements: number; droppedLoads: number };
+  stats: {
+    mergedNodes: number; removedElements: number; duplicateElements: number;
+    droppedLoads: number;
+    /**
+     * How many of the INPUT loads reached the 2D model carrying something.
+     *
+     * Not `loads.length`: the builder sums nodal loads that land on one merged
+     * node, so three loads can leave as one and counting the output would say
+     * two went missing when none did. Counting sources keeps
+     * `carriedLoads + droppedLoads` equal to what came in, which is the
+     * property that makes either number trustworthy.
+     */
+    carriedLoads: number;
+  };
 }
 
 export type SimplifiedResult = { ok: true; model: SimplifiedModel } | { ok: false; error: string };
@@ -298,7 +371,9 @@ export function buildSimplified2DModel(
   }
 
   // 5. Remap loads — sum nodal loads at merged nodes, remap types
-  const nodalSums = new Map<number, { fx: number; fy: number; my: number; caseId?: number }>();
+  // `sources` is how many of the model's loads fed each sum, so a sum that
+  // vanishes can report how many loads went with it rather than counting as one.
+  const nodalSums = new Map<number, { fx: number; fy: number; my: number; caseId?: number; sources: number }>();
   const outLoads: Array<{ type: string; data: Record<string, unknown> }> = [];
   let loadId = 1;
   /*
@@ -308,6 +383,8 @@ export function buildSimplified2DModel(
    * difference between a clean reduction and a quietly weaker structure.
    */
   let droppedLoads = 0;
+  // Counted in SOURCE loads, not emitted ones — see `carriedLoads` on the type.
+  let carriedLoads = 0;
 
   for (const l of loads) {
     if (l.type === 'nodal' || l.type === 'nodal3d') {
@@ -326,9 +403,9 @@ export function buildSimplified2DModel(
       const key = mergedId * 1000 + (d.caseId ?? 1);
       const prev = nodalSums.get(key);
       if (prev) {
-        prev.fx += fx; prev.fy += fy; prev.my += my;
+        prev.fx += fx; prev.fy += fy; prev.my += my; prev.sources++;
       } else {
-        nodalSums.set(key, { fx, fy, my, caseId: d.caseId });
+        nodalSums.set(key, { fx, fy, my, caseId: d.caseId, sources: 1 });
       }
     } else if (l.type === 'distributed' || l.type === 'distributed3d') {
       const d = l.data as any;
@@ -341,14 +418,25 @@ export function buildSimplified2DModel(
       } else {
         qI = d.qI ?? 0; qJ = d.qJ ?? 0;
       }
+      /*
+       * A load whose in-plane component is zero acts on nothing. It used to be
+       * pushed anyway, so a vertical roof load cut onto a HORIZONTAL frame
+       * survived as an object carrying nothing — and every counter said it was
+       * kept. That is the quiet failure this whole count exists to prevent:
+       * the frame solves, every result is zero, and it reads as safe.
+       */
+      if (Math.abs(qI) < LOAD_EPS && Math.abs(qJ) < LOAD_EPS) { droppedLoads++; continue; }
+      carriedLoads++;
       outLoads.push({ type: 'distributed', data: { id: loadId++, elementId: elemId, qI, qJ, angle: d.angle, isGlobal: d.isGlobal, caseId: d.caseId } });
     } else if (l.type === 'pointOnElement') {
       const d = l.data as any;
       if (!outElements.has(d.elementId)) { droppedLoads++; continue; }
+      carriedLoads++;
       outLoads.push({ type: 'pointOnElement', data: { ...d, id: loadId++ } });
     } else if (l.type === 'thermal') {
       const d = l.data as any;
       if (!outElements.has(d.elementId)) { droppedLoads++; continue; }
+      carriedLoads++;
       outLoads.push({ type: 'thermal', data: { ...d, id: loadId++ } });
     } else {
       // 3D-only load types (surface3d, pointOnElement3d, …) have no 2D form.
@@ -359,8 +447,15 @@ export function buildSimplified2DModel(
   // Emit summed nodal loads
   for (const [key, sum] of nodalSums) {
     const nodeId = Math.floor(key / 1000);
-    if (!outNodes.has(nodeId)) continue;
-    if (Math.abs(sum.fx) < 1e-15 && Math.abs(sum.fy) < 1e-15 && Math.abs(sum.my) < 1e-15) continue;
+    // Both of these are losses, and both are counted by how many of the
+    // model's loads went into the sum — a node that merged three loads and
+    // then dropped out took three with it, not one.
+    if (!outNodes.has(nodeId)) { droppedLoads += sum.sources; continue; }
+    if (Math.abs(sum.fx) < LOAD_EPS && Math.abs(sum.fy) < LOAD_EPS && Math.abs(sum.my) < LOAD_EPS) {
+      droppedLoads += sum.sources;
+      continue;
+    }
+    carriedLoads += sum.sources;
     outLoads.push({ type: 'nodal', data: { id: loadId++, nodeId, fx: sum.fx, fz: sum.fy, my: sum.my, caseId: sum.caseId } });
   }
 
@@ -373,7 +468,7 @@ export function buildSimplified2DModel(
       loads: outLoads,
       materials,
       sections,
-      stats: { mergedNodes: totalMergedAway, removedElements, duplicateElements, droppedLoads },
+      stats: { mergedNodes: totalMergedAway, removedElements, duplicateElements, droppedLoads, carriedLoads },
     },
   };
 }

--- a/web/src/lib/geometry/plane-projection.ts
+++ b/web/src/lib/geometry/plane-projection.ts
@@ -386,6 +386,23 @@ export function buildSimplified2DModel(
   // Counted in SOURCE loads, not emitted ones — see `carriedLoads` on the type.
   let carriedLoads = 0;
 
+  /*
+   * ONE rule for "this carries nothing", shared with the preview.
+   *
+   * Applied per type it drifted immediately: the distributed branch got the
+   * check and `pointOnElement` and `thermal` did not, so a point load of 0 kN
+   * was advertised as nothing by the preview and counted as carried here.
+   * That is the same lie this whole count exists to stop, in a rarer type —
+   * and the library sweep could not see it, because no shipped fixture holds
+   * a zero-magnitude load of those kinds.
+   *
+   * Nodal loads are NOT checked here: several can land on one merged node, and
+   * two that individually carry something can still sum to nothing. That is
+   * decided on the sum, below.
+   */
+  const carriesNothing = (l: { type: string; data: Record<string, unknown> }) =>
+    inPlaneLoadMagnitude(l, plane) < LOAD_EPS;
+
   for (const l of loads) {
     if (l.type === 'nodal' || l.type === 'nodal3d') {
       const d = l.data as any;
@@ -418,24 +435,19 @@ export function buildSimplified2DModel(
       } else {
         qI = d.qI ?? 0; qJ = d.qJ ?? 0;
       }
-      /*
-       * A load whose in-plane component is zero acts on nothing. It used to be
-       * pushed anyway, so a vertical roof load cut onto a HORIZONTAL frame
-       * survived as an object carrying nothing — and every counter said it was
-       * kept. That is the quiet failure this whole count exists to prevent:
-       * the frame solves, every result is zero, and it reads as safe.
-       */
-      if (Math.abs(qI) < LOAD_EPS && Math.abs(qJ) < LOAD_EPS) { droppedLoads++; continue; }
+      if (carriesNothing(l)) { droppedLoads++; continue; }
       carriedLoads++;
       outLoads.push({ type: 'distributed', data: { id: loadId++, elementId: elemId, qI, qJ, angle: d.angle, isGlobal: d.isGlobal, caseId: d.caseId } });
     } else if (l.type === 'pointOnElement') {
       const d = l.data as any;
       if (!outElements.has(d.elementId)) { droppedLoads++; continue; }
+      if (carriesNothing(l)) { droppedLoads++; continue; }
       carriedLoads++;
       outLoads.push({ type: 'pointOnElement', data: { ...d, id: loadId++ } });
     } else if (l.type === 'thermal') {
       const d = l.data as any;
       if (!outElements.has(d.elementId)) { droppedLoads++; continue; }
+      if (carriesNothing(l)) { droppedLoads++; continue; }
       carriedLoads++;
       outLoads.push({ type: 'thermal', data: { ...d, id: loadId++ } });
     } else {

--- a/web/src/lib/geometry/plane-slice.ts
+++ b/web/src/lib/geometry/plane-slice.ts
@@ -36,7 +36,8 @@
  */
 
 import {
-  buildSimplified2DModel, type DrawPlane, type SimplifiedResult,
+  buildSimplified2DModel, inPlaneLoadMagnitude, LOAD_EPS,
+  type DrawPlane, type SimplifiedResult,
 } from './plane-projection';
 
 /**
@@ -123,7 +124,9 @@ export function planeOffsets(
   nodes: Iterable<{ id: number; x: number; y: number; z?: number }>,
   elements: Iterable<{ id?: number; nodeI: number; nodeJ: number }>,
   supports: Iterable<{ nodeId: number }> = [],
-  loads: Iterable<{ data: Record<string, unknown> }> = [],
+  // `type` as well as `data`: what a load carries into the plane depends on
+  // its kind, so the count cannot be taken from the payload alone.
+  loads: Iterable<{ type: string; data: Record<string, unknown> }> = [],
   tol = SLICE_TOL,
 ): PlaneOffset[] {
   const byNode = new Map<number, number>();
@@ -162,12 +165,29 @@ export function planeOffsets(
     if (g) sup.set(g.value, (sup.get(g.value) ?? 0) + 1);
   }
 
-  // Counted by the SAME rule `sliceModelAtPlane` keeps them by, so the number the
-  // dialog shows before the cut is the number the cut will honour. A load keyed by
-  // neither a node nor a member — a surface load carries `quadId` — belongs to no
-  // cut and is counted for none, which is what makes it show up as missing.
+  // A load keyed by neither a node nor a member — a surface load carries
+  // `quadId` — belongs to no cut and is counted for none, which is what makes
+  // it show up as missing.
+  //
+  // This is a PREVIEW, and it is exact about zero and approximate above it.
+  // It cannot be exact above zero without running the whole projection for
+  // every candidate offset: the builder also collapses members whose ends
+  // project together and drops duplicates, and a load on one of those goes
+  // with it. What it IS exact about is the only thing the warning depends on —
+  // a cut that will carry nothing counts zero here, and a cut that counts zero
+  // will carry nothing. A test pins that equivalence across the shipped
+  // library; the earlier claim that this equals the final count was wrong, and
+  // four cuts of that library disprove it.
+  //
+  // And counted by EFFECT, not by existence. A load survives the cut as an
+  // object whenever the thing it acts on survives, but what it carries into the
+  // 2D frame is only its in-plane component: a roof load pointing down global Z
+  // is nothing at all to a horizontal frame. Counting objects advertised forty
+  // loads on a cut that carried none, and the zero-load warning — gated on this
+  // number — stayed silent on exactly the cuts that needed it.
   const loadCount = new Map<number, number>();
   for (const l of loads) {
+    if (inPlaneLoadMagnitude(l, plane) < LOAD_EPS) continue;
     const d = l.data as { nodeId?: number; elementId?: number };
     let value: number | undefined;
     if (d.nodeId !== undefined) {
@@ -309,10 +329,24 @@ export function sliceModelAtPlane(
       droppedLoads: (allLoads.length - keptLoads.length) + built.model.stats.droppedLoads,
       nodes: built.model.nodes.size,
       elements: built.model.elements.size,
-      // Counted off what the SLICE kept, not off `built.model`: the 2D build can
-      // drop a load of its own accord, and folding the two together would report
-      // one number for two different decisions.
-      loads: keptLoads.length,
+      /*
+       * What the 2D model CARRIES, not what the slice handed to the builder.
+       *
+       * This reported `keptLoads.length` — the loads whose node or member
+       * survived — and that is a count of objects, not of load. A load
+       * survives the cut whenever the thing it acts on does, but it carries
+       * only its in-plane component into the frame, and for a roof load on a
+       * horizontal cut that component is zero. Seven cuts of the shipped
+       * library advertised between one and forty loads, "kept" all of them,
+       * and produced a frame carrying nothing.
+       *
+       * `carriedLoads` counts SOURCE loads rather than emitted ones, because
+       * the builder sums nodal loads landing on a merged node — three loads
+       * can leave as one, and counting the output would report two missing
+       * when none are. That is what keeps `loads + droppedLoads` equal to the
+       * model's own total, which a test pins across the shipped library.
+       */
+      loads: built.model.stats.carriedLoads,
     },
   };
 }


### PR DESCRIPTION
Finishing my own #153, which did not do what its commit message claimed. Targets `basic/stress-maps-and-selection` (#154's head), since that is where the slice code currently lives.

## What was wrong

#153 counted load **objects**. A load survives a cut whenever the thing it acts on survives — but it carries only its **in-plane component** into the 2D frame. `plane-projection` kept the in-plane part and pushed the object regardless, so a roof load pointing down global Z, cut onto a **horizontal** frame, became `qI = qJ = 0` and was counted as kept.

Measured over every cut of every shipped 3D model:

```
3d-torsion-beam     xy=0     advertised  1 load   → frame carries 0
3d-space-truss      xy=1.5   advertised  8 loads  → 0
3d-grid-slab        xy=0     advertised  4 loads  → 0
3d-nave-industrial  xy=8.5   advertised 40 loads  → 0
3d-nave-industrial  xy=9     advertised 40 loads  → 0
3d-nave-industrial  xy=9.5   advertised 40 loads  → 0
3d-nave-industrial  xy=10    advertised 20 loads  → 0
```

The zero-load warning is gated on that count, so it stayed silent on exactly the seven cuts that needed it. The frame solves, every result is zero, and the utilisation map paints it uniformly green — the quiet failure #153 exists to prevent, still there and now carrying the counter's approval.

#154 added the builder's own `droppedLoads` to the slice's, which closes the "element removed" and "3D-only kind" cases. It does not close this one, and I verified that against its head before starting.

## What this does

- **`inPlaneLoadMagnitude`** — one definition of what a load carries in a plane, used by the preview *and* by the builder's drop decision, so the two cannot answer differently.
- A distributed load projecting to zero is **dropped and counted**, not pushed as an empty object. Nodal sums that vanish, and sums on a node that did not survive, are counted too — by **how many source loads fed them**, because three loads merging into one that then drops is three lost, not one.
- **`stats.carriedLoads`** counts source loads rather than emitted ones, since the builder merges nodal loads at a shared node. Counting the output would report losses that never happened — which is how the conservation check caught this while I was writing it.

## A claim I had to withdraw

#153 left a comment saying the number shown before the cut equals the number the cut honours. **It does not**, and four cuts of the library disprove it: the preview runs before the projection, so it cannot know which members will collapse or duplicate away, and a load on one of those goes with it. Making it exact would mean running a full build per candidate offset — 25 of them on the nave alone.

So the test asserts the equivalence the warning actually depends on, in both directions: **zero advertised if and only if zero carried**. That is deliverable and it is what protects the user; an equality I cannot deliver would have been another comment that reads true and is not.

## Verification

- Library sweep added beside the existing cut audit, reusing its fixtures and mock rather than duplicating them. Over 75 cuts: **silent zero-load 7 → 0**, zero-disagreement 0, and `loads + droppedLoads` equal to the model's own total on every one.
- Reverting the zero-magnitude drop turns the sweep red — checked.
- `geometry` + slice audit + `store`: 562 passed, 0 failed. (Two files fail to *collect* in my worktree: `fake-indexeddb` postdates the `node_modules` I have linked.)
- `npm run typecheck`: no new errors (479, baseline 479).

## Note

`planeOffsets`' `loads` parameter now needs `type` as well as `data` — what a load carries depends on its kind, so the count cannot come from the payload alone. Every caller already passes whole load objects.
