### PR TITLE
fix(stress): peak shear comes from the section, not from a constant

### DIFF
--- a/web/src/lib/engine/__tests__/shear-peak-factor.test.ts
+++ b/web/src/lib/engine/__tests__/shear-peak-factor.test.ts
@@ -1,0 +1,82 @@
+/**
+ * τ_max = k·V/A, and k belongs to the SECTION.
+ *
+ * Two colour maps each estimated peak shear with a constant. The 3D map used
+ * 1.2, which is not a peak factor at all — it is `A/A_s` for a rectangle, the
+ * shear-DEFLECTION coefficient. The 2D map used 1.5, which is the peak factor
+ * for a solid rectangle and for nothing else. Every rolled profile carries
+ * both `b` and `h`, so every I-beam in the catalogue got the rectangle's
+ * answer while its web carried nearly all the shear over a fraction of the
+ * gross area.
+ *
+ * The values below are the textbook shear form factors, written here rather
+ * than read back from the implementation — a test that asks the code what it
+ * computes cannot tell whether the code is right.
+ */
+import { describe, it, expect } from 'vitest';
+import { shearPeakFactor } from '../section-stress';
+import { computeSectionStress } from '../section-stress-3d';
+import { computeElementStress } from '../../store/results.svelte';
+
+const RECT = { id: 1, name: 'R', shape: 'rect', a: 0.15, iy: 3.125e-3, iz: 1.125e-3, j: 1e-3, h: 0.5, b: 0.3 } as never;
+const IPE300 = { id: 2, name: 'IPE300', shape: 'I', a: 5.381e-3, iy: 8.356e-5, iz: 6.04e-6, j: 2.01e-7, h: 0.3, b: 0.15, tw: 0.0071, tf: 0.0107 } as never;
+const CHS = { id: 3, name: 'CHS300x8', shape: 'CHS', a: 7.3387e-3, iy: 7.8275e-5, iz: 7.8275e-5, j: 1.5655e-4, h: 0.3, b: 0.3, t: 0.008 } as never;
+
+describe('the shear form factor comes from the section', () => {
+  it('a solid rectangle is exactly 3/2 — the one case the old constant had right', () => {
+    expect(shearPeakFactor(RECT)).toBeCloseTo(1.5, 2);
+  });
+
+  it('a thin circular tube is 2, not 1.5', () => {
+    // The classic thin-tube result. A real 8 mm wall on a 300 mm tube lands a
+    // few per cent above the thin-wall ideal, hence the band.
+    const k = shearPeakFactor(CHS);
+    expect(k).toBeGreaterThan(1.95);
+    expect(k).toBeLessThan(2.25);
+  });
+
+  it('an I-section is far above either constant, because the web carries it', () => {
+    // A_web ≈ (h − 2·tf)·tw = 1.98e-3 m² against A = 5.381e-3, so the peak is
+    // roughly A/A_web ≈ 2.7 times the mean — nowhere near 1.2 or 1.5.
+    const k = shearPeakFactor(IPE300);
+    expect(k).toBeGreaterThan(2.4);
+    expect(k).toBeLessThan(3.1);
+  });
+
+  it('never silently returns the rectangle for a shape it could resolve', () => {
+    // The regression that motivated this: every one of these used to be 1.5.
+    expect(shearPeakFactor(IPE300)).not.toBeCloseTo(1.5, 1);
+    expect(shearPeakFactor(CHS)).not.toBeCloseTo(1.5, 1);
+  });
+});
+
+describe('both viewports now report the same peak shear', () => {
+  const V = 100;                       // kN
+  const ef = {
+    elementId: 1, length: 4,
+    nStart: 0, nEnd: 0, vStart: V, vEnd: V, mStart: 0, mEnd: 0,
+    qI: 0, qJ: 0, pointLoads: [], distributedLoads: [],
+  } as never;
+  const mat = { id: 1, name: 'S275', e: 210000, nu: 0.3, rho: 78.5, fy: 275 } as never;
+
+  for (const [label, sec] of [['rect', RECT], ['IPE 300', IPE300], ['CHS 300x8', CHS]] as const) {
+    it(`${label}: the 2D and 3D maps agree`, () => {
+      const k = shearPeakFactor(sec);
+      const A = (sec as unknown as { a: number }).a;
+
+      // 2D path, in MPa.
+      const twoD = computeElementStress(ef, sec, mat).tauStart ?? 0;
+      // 3D path works in kPa; same forces, shear on one axis.
+      const threeD = computeSectionStress(
+        0, V, 0, 0, 0, 0, A,
+        (sec as unknown as { iz: number }).iz, (sec as unknown as { iy: number }).iy,
+        (sec as unknown as { h: number }).h, (sec as unknown as { b: number }).b,
+        275_000, k,
+      ).tauMax / 1000;
+
+      expect(threeD).toBeCloseTo(twoD, 6);
+      // And both are the section's own factor times the mean, not a constant.
+      expect(twoD).toBeCloseTo(k * V / A / 1000, 6);
+    });
+  }
+});

--- a/web/src/lib/engine/section-stress-3d.ts
+++ b/web/src/lib/engine/section-stress-3d.ts
@@ -40,6 +40,12 @@ export function computeSectionStress(
   A: number, Iz: number, Iy: number,
   h: number = 0, b: number = 0,
   fy: number = 355_000,
+  /**
+   * τ_max/(V/A) for this section — `shearPeakFactor`, computed once by the
+   * caller. Defaults to the solid rectangle, which is what the 2D map assumed
+   * for every section before this became section-aware.
+   */
+  shearFactor: number = 1.5,
 ): SectionStress3D {
   // PR [12] convention (aligned with PR [10] solver + PR [11] render):
   //   My = moment about local y → bends over the DEPTH (h) → max at h/2 → uses Iy (strong).
@@ -51,9 +57,22 @@ export function computeSectionStress(
   const sigmaMy = Iy > 0 ? Math.abs(My) * depthMax / Iy : 0; // depth bending
   const sigmaMz = Iz > 0 ? Math.abs(Mz) * widthMax / Iz : 0; // width bending
   const sigmaMax = Math.abs(sigmaN) + sigmaMy + sigmaMz;
-  const kappa = 1.2;
-  const tauY = A > 0 ? Math.abs(Vy) * kappa / A : 0;
-  const tauZ = A > 0 ? Math.abs(Vz) * kappa / A : 0;
+  /*
+   * τ_max = k·V/A, with k the section's own shear form factor.
+   *
+   * This was a hard-coded 1.2, which is not a peak factor at all: it is
+   * `A/A_s` for a rectangle — the shear-DEFLECTION coefficient, which answers
+   * how much shear adds to the deflection, not how high the stress gets. Used
+   * as a peak it reported an IPE 300 at 56% below its real maximum and an
+   * HEB 300 at 75% below, in the unsafe direction, on the ordinary case: an
+   * I-section carries nearly all its shear in the web, so V over the GROSS
+   * area is the wrong quantity to scale.
+   *
+   * Passed in rather than derived here so the caller can compute it once per
+   * section — this runs per vertex, per station, per load case.
+   */
+  const tauY = A > 0 ? Math.abs(Vy) * shearFactor / A : 0;
+  const tauZ = A > 0 ? Math.abs(Vz) * shearFactor / A : 0;
   const tauMax = Math.sqrt(tauY * tauY + tauZ * tauZ);
   const vonMises = Math.sqrt(sigmaMax * sigmaMax + 3 * tauMax * tauMax);
   const ratio = fy > 0 ? vonMises / fy : 0;

--- a/web/src/lib/engine/section-stress.ts
+++ b/web/src/lib/engine/section-stress.ts
@@ -563,6 +563,77 @@ export function shearStress(V: number, y: number, rs: ResolvedSection): number {
   return (V * Q) / (rs.iy * bAtY) / 1000;
 }
 
+/**
+ * τ_max / (V/A) for a section: the shear form factor, from Jourawski.
+ *
+ * ── Why this exists ────────────────────────────────────────────────
+ *
+ * Two colour maps were each estimating peak shear with a CONSTANT, and neither
+ * constant belongs to the sections people actually use:
+ *
+ *   * the 3D heat map used 1.2, which is not a peak factor at all — it is
+ *     `A/A_s` for a rectangle, the SHEAR-DEFLECTION coefficient. It answers
+ *     "how much does shear add to the deflection", not "how high does the
+ *     stress get";
+ *   * the 2D map used 1.5, which IS the peak factor — for a solid rectangle,
+ *     and only for one.
+ *
+ * Measured against this function on catalogue sections, both under-report the
+ * real peak, in the unsafe direction:
+ *
+ *       section        1.2·V/A    1.5·V/A    Jourawski     error
+ *       IPE 300         22.30      27.88       50.74      −56% / −45%
+ *       HEB 300          8.05      10.06       32.33      −75% / −69%
+ *       CHS 300×8       16.35      20.44       28.74      −43% / −29%
+ *       rect 0.3×0.5     0.80       1.00        1.00      −20% /   0%
+ *
+ * An I-section is where the gap is worst and it is the ordinary case: the web
+ * carries nearly all the shear over a fraction of the gross area, so V/A is
+ * simply the wrong denominator. The factors this returns are the familiar
+ * ones — 1.5 for a rectangle, ~2 for a thin tube, and whatever the geometry
+ * gives for an I.
+ *
+ * ── Why a factor rather than the stress ────────────────────────────
+ *
+ * It depends only on the SECTION, so it can be computed once and reused for
+ * every station of every load case. The callers are per-vertex render paths;
+ * resolving the geometry inside them would put a profile-catalogue lookup on
+ * the hot path for a number that never changes.
+ *
+ * Falls back to 1.5 — the rectangle — when the geometry is not resolvable,
+ * which is what the 2D map already assumed for everything.
+ */
+const SHEAR_FACTOR_CACHE = new WeakMap<object, number>();
+
+export function shearPeakFactor(sec: Section): number {
+  const cached = SHEAR_FACTOR_CACHE.get(sec as unknown as object);
+  if (cached !== undefined) return cached;
+
+  let factor = 1.5;
+  try {
+    const rs = resolveSectionGeometryLegacy(sec);
+    if (rs.a > 1e-15 && rs.iy > 1e-15) {
+      // Walk the fibre range: the peak is at the neutral axis for the common
+      // shapes, but not for a tee or an angle, whose centroid is off-centre.
+      const lo = rs.yMin, hi = rs.yMax;
+      let peak = 0;
+      for (let i = 0; i <= 100; i++) {
+        const y = lo + ((hi - lo) * i) / 100;
+        peak = Math.max(peak, Math.abs(shearStress(1, y, rs)));
+      }
+      // `shearStress` divides by 1000 for MPa; the mean here is in the same
+      // units, so the ratio is dimensionless either way.
+      const mean = 1 / rs.a / 1000;
+      if (peak > 0 && mean > 0) factor = peak / mean;
+    }
+  } catch {
+    /* An unresolvable section keeps the rectangle default. */
+  }
+
+  SHEAR_FACTOR_CACHE.set(sec as unknown as object, factor);
+  return factor;
+}
+
 // ─── Full stress distribution ─────────────────────────────────────────
 
 const NUM_STRESS_POINTS = 31;

--- a/web/src/lib/store/results.svelte.ts
+++ b/web/src/lib/store/results.svelte.ts
@@ -1,6 +1,7 @@
 // Results store
 
 import type { AnalysisResults, InfluenceLineResult, Section, Material } from './model.svelte';
+import { shearPeakFactor } from '../engine/section-stress';
 import type { ElementForces, FullEnvelope, ConstraintForce, SolverDiagnostic, SolveTimings } from '../engine/types';
 import type { AnalysisResults3D, Displacement3D, Reaction3D, ElementForces3D, FullEnvelope3D } from '../engine/types-3d';
 import type { GoverningPerElement, GoverningPerElement3D } from '../engine/governing-case';
@@ -48,10 +49,20 @@ export function computeElementStress(ef: ElementForces, sec: Section, mat: Mater
   const sigmaEnd = A > 1e-15 && Iz > 1e-15
     ? (Math.abs(ef.nEnd) / A + Math.abs(ef.mEnd) * yMax / Iz) / 1000 : 0;
 
-  // Shear stress: τ_max
-  // For rectangular: τ_max = 1.5·V/A
-  // For general section: τ ≈ V/A (conservative lower bound, actual depends on shape)
-  const shearFactor = (sec.b !== undefined && sec.h !== undefined) ? 1.5 : 1.0;
+  /*
+   * Shear stress: τ_max = k·V/A, with k from the section's own geometry.
+   *
+   * This used 1.5 whenever `b` and `h` existed and 1.0 otherwise. 1.5 is the
+   * peak factor for a solid RECTANGLE and for nothing else, and every rolled
+   * profile has both dimensions, so every I-beam in the catalogue got the
+   * rectangle's answer: an IPE 300 came out 45% below its real peak and an
+   * HEB 300 69% below, because the web carries almost all the shear over a
+   * fraction of the gross area. `shearPeakFactor` runs Jourawski over the
+   * section's own fibres and caches the result, so the shape decides the
+   * number instead of a constant. It returns 1.5 for a rectangle, so that
+   * case is unchanged.
+   */
+  const shearFactor = shearPeakFactor(sec);
   const tauStart = A > 1e-15 ? (shearFactor * Math.abs(ef.vStart) / A) / 1000 : 0;
   const tauEnd = A > 1e-15 ? (shearFactor * Math.abs(ef.vEnd) / A) / 1000 : 0;
 

--- a/web/src/lib/three/stress-heatmap.ts
+++ b/web/src/lib/three/stress-heatmap.ts
@@ -39,6 +39,13 @@ interface SectionProps {
    * member" — the painters skip it rather than assume a steel strength.
    */
   fy: number | null;
+  /**
+   * τ_max/(V/A) for this section — see `shearPeakFactor` in `section-stress`.
+   *
+   * Resolved once per section by the caller, because deriving it needs the
+   * profile catalogue and this is read 17 times per member per load case.
+   */
+  shearFactor?: number;
 }
 
 /**
@@ -91,7 +98,10 @@ function sampleValue(ef: ElementForces3D, variable: HeatmapVariable, t: number, 
        * then produces is fictitious, which is why the stressRatio painter
        * skips a null-fy member upstream instead of sampling it.
        */
-      const stress = computeSectionStress(N, Vy, Vz, Mx, My, Mz, sec.A, sec.Iz, sec.Iy, sec.h, sec.b, sec.fy ?? 355_000);
+      const stress = computeSectionStress(
+        N, Vy, Vz, Mx, My, Mz, sec.A, sec.Iz, sec.Iy, sec.h, sec.b,
+        sec.fy ?? 355_000, sec.shearFactor,
+      );
       return variable === 'stressRatio' ? stress.ratio
         : variable === 'vonMises' ? stress.vonMises
         : variable === 'sigmaMax' ? stress.sigmaMax

--- a/web/src/lib/viewport3d/results-sync.ts
+++ b/web/src/lib/viewport3d/results-sync.ts
@@ -21,6 +21,7 @@ import type { Diagram3DKind } from '../engine/diagrams-3d';
 import type { Displacement3D } from '../engine/types-3d';
 import { sampleElementValues, createHeatmapCylinder, orientHeatmapMesh, applyShellVertexColors, applyShellFlatColor, divergingColor, type HeatmapVariable } from '../three/stress-heatmap';
 import { colourMapUnit } from '../three/colour-ramp';
+import { shearPeakFactor } from '../engine/section-stress';
 import { restoreShellColor } from '../three/create-shell-mesh';
 import { shellComponentMeta, shellComponentValue, shellComponentRange } from '../engine/shell-stress';
 import { getCachedProjectModelToXZ, projectNodeToScene, shouldProjectModelToXZ } from '../geometry/coordinate-system';
@@ -613,6 +614,12 @@ export function getSectionProps(elemId: number) {
     Iy: sec.iy ?? sec.iz,
     h: sec.h ?? 0,
     b: sec.b ?? 0,
+    /*
+     * The section's own shear form factor, resolved once here rather than per
+     * vertex: `sampleValue` runs 17 times per member per load case, and this
+     * needs the profile catalogue. `shearPeakFactor` caches per section too.
+     */
+    shearFactor: shearPeakFactor(sec),
     /*
      * fy arrives in MPa (the model store's unit) and the section-stress
      * evaluation works in kPa (kN/m²) — feeding one into the other made every


### PR DESCRIPTION
Found while re-reviewing #154. Targets `basic/stress-maps-and-selection` because that is where the stress maps currently live; the defect itself is older than the branch, but the branch is what makes `τ max` a first-class, legend-labelled measure.

## What was wrong

Two colour maps each estimated peak shear with a constant:

- the **3D** heat map used `kappa = 1.2` — which is not a peak factor at all. It is `A/A_s` for a rectangle, the shear-**deflection** coefficient. It answers "how much does shear add to the deflection", not "how high does the stress get";
- the **2D** map used `1.5`, which *is* the peak factor — for a solid rectangle, and for nothing else. Every rolled profile carries both `b` and `h`, so every I-beam in the catalogue was handed the rectangle's answer.

Measured against Jourawski over each section's own fibres, using the `computeQandB` machinery already in the repo:

| section | 1.2·V/A | 1.5·V/A | Jourawski | 3D error | 2D error |
|---|---|---|---|---|---|
| IPE 300 | 22.30 | 27.88 | **50.74** | −56% | −45% |
| HEB 300 | 8.05 | 10.06 | **32.33** | −75% | −69% |
| CHS 300×8 | 16.35 | 20.44 | 28.74 | −43% | −29% |
| rect 0.3×0.5 | 0.80 | 1.00 | 1.00 | −20% | 0% |

An I-section carries nearly all its shear in the web, over a fraction of the gross area, so `V/A` is the wrong quantity to scale — and it is the ordinary case. **Every error is an under-report**, which is the unsafe direction, and it feeds von Mises and from there utilisation.

## What this does

`shearPeakFactor(section)` returns `τ_max/(V/A)` by walking the section's fibres with the existing, tested Jourawski path. It gives back the familiar numbers — **1.5** for a rectangle, **≈2** for a thin tube, **≈2.7** for an IPE 300.

Cached in a `WeakMap` keyed on the section object: the factor depends only on the section, and deriving it needs the profile catalogue, while the 3D caller reads it 17 times per member per load case. So it is computed once and reused for every station of every load case, and a section that is edited (a new object) naturally gets a new entry.

Both viewports now take the same number from the same function, so the 20% disagreement between them goes with it. A rectangle stays at 1.5, so the one case the old constant had right does not move.

## On the tests

They assert the **textbook** form factors — 3/2, 2, and the I-section band — written out rather than read back from the implementation. A test that asks the code what it computes cannot tell whether the code is right, and this is a case where the previous constants would have passed such a test happily.

There is also a pair asserting the two viewports agree, per section, rather than only that each is individually plausible. The disagreement is what made this visible in the first place.

## Deliberately not in here

**`tauMax` ignores torsion entirely.** `computeSectionStress` names the argument `_Mx` and never reads it, so a member twisted by 40 kN·m paints as unstressed. Fixing that needs `J` and the section's torsion model (Bredt for closed, `T·t/J` for open, `T·r/J` for circular) plumbed through a function that currently receives neither — a larger change than swapping a factor, and one that deserves its own review.

## Verification

- `engine` + `store` + `three` + `viewport3d`: **4707 passed, 0 failed**. (Three files fail to *collect* in my worktree: `fake-indexeddb` and a `katex` resolution that my symlinked `node_modules` cannot serve.)
- `npm run typecheck`: no new errors (479, baseline 479).
