### PR TITLE
Blog: verificación a flexión según CIRSOC 201, paso a paso

### DIFF
--- a/web/e2e/blog.spec.ts
+++ b/web/e2e/blog.spec.ts
@@ -205,6 +205,41 @@ test.describe('@smoke blog', () => {
     await expect(app.locator('body')).toContainText('12.73');
   });
 
+  test('the CIRSOC post opens PRO on the check it describes', async ({ page }) => {
+    /*
+     * The other half of the embed contract: this post's subject lives in PRO's
+     * design workflow, not in Basic's section panel, so it opens `/app/pro`.
+     *
+     * The caption names the two buttons the reader has to press, and the
+     * editor inside the frame runs in the reader's language — so the caption
+     * has to name them in that language too. An English caption on a Spanish
+     * page sends someone hunting for a button that says something else.
+     */
+    /*
+     * Booted explicitly in Spanish. `boot`'s init script runs in EVERY frame,
+     * the embedded editor included, so leaving the default would have the
+     * harness itself force the iframe into English and then assert it is not.
+     */
+    await boot(page, '/es/blog/verificacion-flexion-cirsoc-201', 'es');
+
+    const embed = page.locator('.post-embed');
+    await embed.scrollIntoViewIfNeeded();
+    await expect(embed.locator('iframe')).toHaveCount(0);
+
+    const caption = await embed.locator('figcaption').innerText();
+    expect(caption).toContain('Calcular solicitaciones');
+    expect(caption).toContain('Verificar según norma');
+
+    await embed.locator('.post-embed-start').click();
+    await expect(embed.locator('iframe')).toHaveAttribute('src', /\/app\/pro\?/);
+
+    const app = page.frameLocator('.post-embed iframe');
+    await expect(app.locator('body')).toContainText('CIRSOC 201', { timeout: 60_000 });
+    // The buttons the caption promises are really there, in this language.
+    await expect(app.getByTestId('cmd-compute-demands')).toHaveText('Calcular solicitaciones');
+    await expect(app.getByTestId('cmd-code-check')).toHaveText('Verificar según norma');
+  });
+
   test('a post describes itself to a search engine', async ({ page }) => {
     // The byline on screen is prose; this is the only machine-readable
     // statement of who wrote the post and when. Without it a result is a page

--- a/web/e2e/blog.spec.ts
+++ b/web/e2e/blog.spec.ts
@@ -210,7 +210,7 @@ test.describe('@smoke blog', () => {
      * The other half of the embed contract: this post's subject lives in PRO's
      * design workflow, not in Basic's section panel, so it opens `/app/pro`.
      *
-     * The caption names the two buttons the reader has to press, and the
+     * The caption names the three buttons the reader has to press, and the
      * editor inside the frame runs in the reader's language — so the caption
      * has to name them in that language too. An English caption on a Spanish
      * page sends someone hunting for a button that says something else.
@@ -260,12 +260,15 @@ test.describe('@smoke blog', () => {
     const app = page.frameLocator('.post-embed iframe');
     await expect(app.locator('body')).toContainText('CIRSOC 201', { timeout: 60_000 });
 
-    // Exactly the three presses the caption asks for, in its order.
-    for (const id of ['cmd-compute-demands', 'cmd-code-check']) {
-      await app.getByTestId(id).click();
-      await expect(app.locator('body')).toBeVisible();
-    }
-    await app.getByRole('button', { name: 'Diseñar todo', exact: true }).first().click();
+    // Exactly the three presses the caption asks for, in its order. Each wait is
+    // the toolbar's own disabled state — the workflow's real gate: code check arms
+    // only once demands exist and the previous run is no longer busy. A bare
+    // `toBeVisible` on the body would wait on nothing.
+    await app.getByTestId('cmd-compute-demands').click();
+    await expect(app.getByTestId('cmd-code-check')).toBeEnabled({ timeout: 60_000 });
+    await app.getByTestId('cmd-code-check').click();
+    await expect(app.getByTestId('cmd-design-all')).toBeEnabled({ timeout: 60_000 });
+    await app.getByTestId('cmd-design-all').click();
 
     // Verified, not "sin verificar", and at the utilisation the caption quotes.
     const table = app.locator('body');

--- a/web/e2e/blog.spec.ts
+++ b/web/e2e/blog.spec.ts
@@ -229,6 +229,7 @@ test.describe('@smoke blog', () => {
     const caption = await embed.locator('figcaption').innerText();
     expect(caption).toContain('Calcular solicitaciones');
     expect(caption).toContain('Verificar según norma');
+    expect(caption).toContain('Diseñar todo');
 
     await embed.locator('.post-embed-start').click();
     await expect(embed.locator('iframe')).toHaveAttribute('src', /\/app\/pro\?/);
@@ -238,6 +239,40 @@ test.describe('@smoke blog', () => {
     // The buttons the caption promises are really there, in this language.
     await expect(app.getByTestId('cmd-compute-demands')).toHaveText('Calcular solicitaciones');
     await expect(app.getByTestId('cmd-code-check')).toHaveText('Verificar según norma');
+  });
+
+  /*
+   * The caption promises a RESULT, not just two labelled buttons — and that is
+   * the half that broke. It used to name two buttons and quote D/C = 0.81; the
+   * two buttons leave the table reading "no reinforcement / not verified", and
+   * 0.81 never appeared on screen at all. Asserting the labels exist could not
+   * catch that. This runs the flow the caption describes, to the end, and reads
+   * the number back.
+   */
+  test('the CIRSOC embed reaches the state its caption promises', async ({ page }) => {
+    test.slow();
+    await boot(page, '/es/blog/verificacion-flexion-cirsoc-201', 'es');
+
+    const embed = page.locator('.post-embed');
+    await embed.scrollIntoViewIfNeeded();
+    await embed.locator('.post-embed-start').click();
+
+    const app = page.frameLocator('.post-embed iframe');
+    await expect(app.locator('body')).toContainText('CIRSOC 201', { timeout: 60_000 });
+
+    // Exactly the three presses the caption asks for, in its order.
+    for (const id of ['cmd-compute-demands', 'cmd-code-check']) {
+      await app.getByTestId(id).click();
+      await expect(app.locator('body')).toBeVisible();
+    }
+    await app.getByRole('button', { name: 'Diseñar todo', exact: true }).first().click();
+
+    // Verified, not "sin verificar", and at the utilisation the caption quotes.
+    const table = app.locator('body');
+    await expect(table).toContainText('0.89', { timeout: 90_000 });
+    await expect(table).toContainText('0.86');
+    await expect(table).toContainText('1.2D+1.6L');
+    await expect(table).not.toContainText('sin armadura');
   });
 
   test('a post describes itself to a search engine', async ({ page }) => {

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -277,6 +277,26 @@
     open();
   }
 
+  /**
+   * `?proTab=<id>` opens PRO on one of its tabs.
+   *
+   * The companion of `?inspect` for the other half of the application. A post
+   * about CIRSOC verification has to land the reader on the verification, and
+   * that lives in PRO's `design` tab rather than in Basic's section panel.
+   *
+   * NOT named `tab`: that parameter already carries the project tab's slug
+   * (see `replaceAppUrl`), and quietly overloading it would make a shared
+   * link rename someone's project.
+   */
+  function openProTabFromUrl(params: URLSearchParams) {
+    const tab = params.get('proTab');
+    if (!tab) return;
+    const VALID = ['project', 'nodes', 'elements', 'shells', 'materials', 'sections', 'supports',
+      'constraints', 'loads', 'advanced', 'results', 'design', 'connections', 'diagnostics'];
+    if (!VALID.includes(tab)) return;
+    uiStore.proActiveTab = tab;
+  }
+
   function findTabBySlug(tabSlug: string | null) {
     if (!tabSlug) return null;
     return tabManager.tabs.find(tab => slugifyTabName(tab.name) === tabSlug) ?? null;
@@ -607,6 +627,7 @@
           };
           tryFit(0);
           openInspectFromUrl(queryParams);
+          openProTabFromUrl(queryParams);
         }).catch(() => {
           // Silently ignore unknown example ids
         });

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -291,6 +291,8 @@
   function openProTabFromUrl(params: URLSearchParams) {
     const tab = params.get('proTab');
     if (!tab) return;
+    // Mirrors the `ProTab` union in components/pro/ProPanel.svelte — a tab added
+    // there but not here makes `?proTab=` silently no-op for it.
     const VALID = ['project', 'nodes', 'elements', 'shells', 'materials', 'sections', 'supports',
       'constraints', 'loads', 'advanced', 'results', 'design', 'connections', 'diagnostics'];
     if (!VALID.includes(tab)) return;

--- a/web/src/components/blog/BlogBlocks.svelte
+++ b/web/src/components/blog/BlogBlocks.svelte
@@ -30,7 +30,7 @@
   {:else if block.k === 'note'}
     <aside class="post-note">{block.t}</aside>
   {:else if block.k === 'embed'}
-    <PostEmbed query={block.query} label={block.label} />
+    <PostEmbed query={block.query} mode={block.mode} label={block.label} />
   {:else if block.k === 'table'}
     <figure class="post-figure">
       <!-- The scroller, not the page, is what moves when a table is wider

--- a/web/src/components/blog/PostEmbed.svelte
+++ b/web/src/components/blog/PostEmbed.svelte
@@ -29,12 +29,14 @@
   import { tPublic as t } from '../../lib/i18n/store.svelte';
 
   type Props = {
-    /** Query string for /app/basic, without the leading '?'. */
+    /** Query string for the editor, without the leading '?'. */
     query: string;
+    /** Which mode to open. Section analysis is Basic's; verification is PRO's. */
+    mode?: 'basic' | 'pro';
     /** What the reader is about to open, in their language. */
     label: string;
   };
-  let { query, label }: Props = $props();
+  let { query, mode = 'basic', label }: Props = $props();
 
   /** Below this the editor's full chrome has nowhere to go. */
   const FULL_UI_WIDTH = 900;
@@ -45,7 +47,7 @@
 
   function open() {
     const wide = (frame?.clientWidth ?? 0) >= FULL_UI_WIDTH;
-    src = wide ? `/app/basic?${query}` : `/app/basic?embed&${query}`;
+    src = wide ? `/app/${mode}?${query}` : `/app/${mode}?embed&${query}`;
     live = true;
     /*
      * Bring the frame fully into view, and keep bringing it.
@@ -71,7 +73,7 @@
   }
 
   /** For the "open full size" link, which always lands in the real editor. */
-  const fullHref = $derived(`/app/basic?${query}`);
+  const fullHref = $derived(`/app/${mode}?${query}`);
 </script>
 
 <figure class="post-embed">

--- a/web/src/lib/blog/__tests__/blog-content.test.ts
+++ b/web/src/lib/blog/__tests__/blog-content.test.ts
@@ -108,7 +108,7 @@ describe('blog posts', () => {
               : b.k === 'table'
                 ? `table:${b.head.length}x${b.rows.length}`
                 : b.k === 'embed'
-                  ? `embed:${b.query}`
+                  ? `embed:${b.mode ?? 'basic'}:${b.query}`
                   : b.k,
           );
         for (const locale of LOCALES) {

--- a/web/src/lib/blog/index.ts
+++ b/web/src/lib/blog/index.ts
@@ -8,9 +8,10 @@
 import type { Post } from './types';
 import { determinismBoundary } from './posts/determinism-boundary';
 import { torsionTheories } from './posts/torsion-theories';
+import { cirsoc201Flexure } from './posts/cirsoc-201-flexure';
 
 /** Newest first. `date` is a plain ISO day, so a string sort is a date sort. */
-export const POSTS: Post[] = [determinismBoundary, torsionTheories].sort((a, b) => b.date.localeCompare(a.date));
+export const POSTS: Post[] = [determinismBoundary, torsionTheories, cirsoc201Flexure].sort((a, b) => b.date.localeCompare(a.date));
 
 export function findPost(slug: string): Post | undefined {
   return POSTS.find((p) => p.slug === slug);

--- a/web/src/lib/blog/posts/cirsoc-201-flexure.ts
+++ b/web/src/lib/blog/posts/cirsoc-201-flexure.ts
@@ -1,0 +1,335 @@
+/**
+ * The third post: what the ten steps of a CIRSOC 201 flexural check decide.
+ *
+ * Every number was produced by `checkFlexure` in
+ * src/lib/engine/codes/argentina/cirsoc201.ts before any sentence was written,
+ * on a 20×40 cm beam of H-25 with fy 420, 25 mm cover and 8 mm stirrups:
+ *
+ *   · As,min stops governing at Mu = 31.5 kN·m. Below that the reinforcement
+ *     is decided by §9.6.1.2 and not by the moment.
+ *   · The `0,25·√f'c/fy` branch only overtakes `1,4/fy` above f'c = 31.36 MPa,
+ *     so from H-20 to H-31 the minimum does not depend on the concrete.
+ *   · At Mu = 120 the section lands in the transition zone: εt = 2.76‰ and
+ *     φ = 0.707, not 0.90.
+ *   · At Mu = 200 the module adds compression steel because εt = 1.51‰, and
+ *     with it εt returns to 7.46‰ and φ to 0.90.
+ *   · The embedded beam: 5 m span, D = 12 kN/m plus 2 kN/m of self-weight,
+ *     L = 8 kN/m, governing 1.2D+1.6L → Mu = 92.5 kN·m, 2 Ø25, φMn = 115.2,
+ *     D/C = 0.80. The application reports 0.81 through its own pipeline.
+ *
+ * The embed's caption names the two buttons the reader has to press, and it
+ * names them PER LANGUAGE. The editor inside the frame runs in the reader's
+ * locale, so an English caption on a Spanish page sends someone looking for
+ * "Compute demands" at a button that says "Calcular solicitaciones".
+ *
+ * That last pair is why the closing note exists. A first pass computed 0.74 by
+ * hand because it forgot the self-weight the application includes. The
+ * application was right. Recompute rather than adjust, and if a figure here
+ * ever stops matching the embed, the embed is the one to believe.
+ */
+import type { Post } from '../types';
+
+export const cirsoc201Flexure: Post = {
+  slug: 'verificacion-flexion-cirsoc-201',
+  date: '2026-08-22',
+  authors: ['Bautista Chesta'],
+  tagKeys: ['blog.tag.cirsoc', 'blog.tag.concrete'],
+  i18n: {
+    es: {
+      title: 'Verificación a flexión según CIRSOC 201, paso a paso',
+      excerpt:
+        'Todos recuerdan φMn ≥ Mu. Esa es la última línea de la verificación, no la verificación. Los tres pasos que deciden el resultado son otros, y uno de ellos hace que φ no valga 0,9.',
+      blocks: [
+        { k: 'p', t: 'Verificar una viga a flexión se resume, en la memoria de casi todos, en una desigualdad: φMn ≥ Mu. Es cierto, y es la última línea. Lo que decide el resultado pasa antes, en pasos que rara vez se miran con atención porque parecen trámite.' },
+        { k: 'p', t: 'Esto es lo que devuelve el módulo CIRSOC 201 de Stabileo para una viga de 20×40 cm, H-25, con acero fy 420, 25 mm de recubrimiento y estribos de 8, bajo un momento de 60 kN·m:' },
+        {
+          k: 'ol',
+          items: [
+            'd = 35,9 cm, d\' = 4,1 cm',
+            'Mu = 60,00 kN·m',
+            'As,mín = 2,39 cm²',
+            'As,máx (simple) = 11,58 cm²',
+            'As,req (tracción) = 4,73 cm²',
+            'Armadura tracción: 2 Ø20 (6,28 cm²)',
+            'a = 6,21 cm, c = 7,31 cm',
+            'εt = 11,74‰',
+            'εt ≥ 5‰ → F.C.T. → φ = 0,90',
+            'φMn = 77,90 kN·m',
+          ],
+        },
+        { k: 'p', t: 'Diez pasos. El décimo es el que todos recuerdan. Los que deciden son el tercero y el noveno.' },
+
+        { k: 'h', t: 'Paso 3: el mínimo gobierna más seguido de lo que parece' },
+        { k: 'p', t: 'El artículo 9.6.1.2 pide una armadura mínima de flexión igual al mayor entre 0,25·√f\'c/fy·bw·d y 1,4/fy·bw·d. Se suele leer como un piso que casi nunca se toca. En vigas de vivienda se toca todo el tiempo.' },
+        {
+          k: 'table',
+          caption: 'La misma viga 20×40 de H-25, con momentos crecientes: quién decide la armadura.',
+          head: ['Mu [kN·m]', 'As por resistencia [cm²]', 'As,mín [cm²]', 'Gobierna'],
+          rows: [
+            ['15', '1.12', '2.39', 'el mínimo'],
+            ['30', '2.28', '2.39', 'el mínimo'],
+            ['60', '4.73', '2.39', 'la resistencia'],
+            ['90', '7.38', '2.39', 'la resistencia'],
+          ],
+        },
+        { k: 'p', t: 'El cruce está en Mu = 31,5 kN·m. Por debajo de ese momento, dimensionar por resistencia no sirve de nada: la sección va a llevar 2,39 cm² igual. Vale la pena saber de qué lado del cruce está una viga antes de discutir su armadura.' },
+
+        { k: 'h', t: 'Y el mínimo casi nunca depende del hormigón' },
+        { k: 'p', t: 'De las dos ramas del artículo, la de √f\'c sólo supera a la otra cuando el hormigón es bastante bueno.' },
+        {
+          k: 'table',
+          caption: 'Las dos ramas del mínimo, para fy 420, en por mil.',
+          head: ['Hormigón', '0,25·√f\'c/fy', '1,4/fy', 'Gobierna'],
+          rows: [
+            ['H-20', '2.6620', '3.3333', '1,4/fy'],
+            ['H-25', '2.9762', '3.3333', '1,4/fy'],
+            ['H-30', '3.2603', '3.3333', '1,4/fy'],
+            ['H-35', '3.5215', '3.3333', '√f\'c'],
+          ],
+        },
+        { k: 'p', t: 'El cruce está en f\'c = 31,36 MPa. Para todo el rango que se usa en vivienda —H-20, H-25, H-30— la armadura mínima no depende del hormigón: sale de 1,4/fy y nada más. Subir de H-20 a H-30 no baja el mínimo ni un centímetro cuadrado.' },
+
+        { k: 'h', t: 'Paso 9: φ no vale 0,9 porque sí' },
+        { k: 'p', t: 'El coeficiente de reducción se aprende como 0,90 para flexión y se usa como constante. No lo es. Sale de la deformación de la armadura traccionada en el estado último, y el módulo lo dice en el paso 9: εt ≥ 5‰ → sección controlada por tracción → φ = 0,90. Si la sección lleva más armadura, εt baja y φ con ella.' },
+        {
+          k: 'table',
+          caption: 'La misma viga, cargada cada vez más. εt y φ salen de los pasos 8 y 9.',
+          head: ['Mu [kN·m]', 'Armadura', 'εt [‰]', 'φ', 'φMn [kN·m]'],
+          rows: [
+            ['30', '2 Ø16', '20.03', '0.90', '51.6'],
+            ['60', '2 Ø20', '11.74', '0.90', '77.9'],
+            ['90', '2 Ø25', '6.44', '0.90', '115.2'],
+            ['120', '2 Ø32', '2.76', '0.707', '133.5'],
+          ],
+        },
+        { k: 'p', t: 'En la última fila la sección entró en zona de transición y φ cayó a 0,707. La capacidad no creció como la armadura: entre las dos últimas filas el acero sube de 6,44 a 8,04 cm² de área nominal y φMn sólo pasa de 115,2 a 133,5 kN·m. Buena parte de lo que se agrega se pierde en el coeficiente.' },
+        { k: 'quote', t: 'Una sección sobrearmada no falla en la verificación. Falla en el φ, y el resultado sigue diciendo que verifica.' },
+
+        { k: 'h', t: 'Por qué se pone armadura de compresión' },
+        { k: 'p', t: 'La respuesta que se suele dar es "para que entre". Es la consecuencia, no el motivo. Con Mu = 200 kN·m en esta misma viga, el módulo detecta εt = 1,51‰, por debajo del límite, y agrega armadura de compresión. Con ella el eje neutro sube, εt vuelve a 7,46‰ y φ vuelve a 0,90.' },
+        { k: 'p', t: 'O sea que la armadura de compresión no está ahí para aportar capacidad, sino para devolverle ductilidad a la sección y recuperar el coeficiente. La capacidad viene después, como resultado.' },
+        { k: 'note', t: 'Los pasos que el módulo emite para ese caso lo dicen en ese orden: "εt = 1,51‰ < 2,1‰ → se necesita A\'s", después "ΔM = 144,50 kN·m, A\'s,req = 11,40 cm²", y recién al final "εt = 7,46‰ → F.C.T. → φ = 0,90".' },
+
+        { k: 'h', t: 'Probalo sobre una viga de verdad' },
+        { k: 'p', t: 'Acá abajo está el modelo: una viga simplemente apoyada de 5 m, 20×40, H-25, con 12 kN/m de carga permanente y 8 kN/m de sobrecarga, más su peso propio. Abre en el flujo de diseño de PRO, con CIRSOC 201 como reglamento en vigencia.' },
+        {
+          k: 'embed',
+          mode: 'pro',
+          query: 'example=rc-beam-flexure&proTab=design',
+          label: 'La viga en Stabileo, en el flujo de diseño de PRO. Apretá «Calcular solicitaciones» y después «Verificar según norma»: la combinación 1,2D+1,6L gobierna con Mu = 92,5 kN·m y la viga verifica con D/C = 0,81. Cambiá la carga y mirá de qué lado del cruce queda el mínimo. PRO está en desarrollo; el módulo de hormigón es la parte implementada y testeada.',
+        },
+
+        { k: 'h', t: 'En resumen' },
+        {
+          k: 'ol',
+          items: [
+            'Antes de dimensionar, mirá si el momento está por encima o por debajo del cruce con el mínimo. Debajo, la armadura ya está decidida.',
+            'Para H-20 a H-30, el mínimo no depende del hormigón. Sale de 1,4/fy.',
+            'φ es un resultado, no un dato. Miralo junto con εt.',
+            'Si aparece armadura de compresión, es porque la sección perdió ductilidad, no porque falte capacidad.',
+          ],
+        },
+
+        { k: 'note', t: 'Todas las cifras salen del módulo CIRSOC 201 de Stabileo, corrido sobre las secciones que se indican, y no de una tabla. Una advertencia que vale la pena, porque la primera versión de esta nota se equivocó ahí: el cálculo a mano daba D/C = 0,74 y la aplicación 0,81. La diferencia era el peso propio, 2 kN/m que la aplicación suma a la carga permanente. Tenía razón la aplicación. Si alguna vez un número de acá no coincide con lo que muestra el editor de arriba, creele al editor.' },
+      ],
+    },
+
+    en: {
+      title: 'Flexural verification to CIRSOC 201, step by step',
+      excerpt:
+        'Everyone remembers φMn ≥ Mu. That is the last line of the check, not the check. The three steps that decide the outcome are others, and one of them is why φ is not 0.9.',
+      blocks: [
+        { k: 'p', t: 'Checking a beam in bending reduces, in most people\'s memory, to one inequality: φMn ≥ Mu. It is true, and it is the last line. What decides the outcome happens earlier, in steps that are rarely read closely because they look like paperwork.' },
+        { k: 'p', t: 'This is what Stabileo\'s CIRSOC 201 module returns for a 20×40 cm beam of H-25 concrete, fy 420 steel, 25 mm cover and 8 mm stirrups, under a moment of 60 kN·m:' },
+        {
+          k: 'ol',
+          items: [
+            'd = 35.9 cm, d\' = 4.1 cm',
+            'Mu = 60.00 kN·m',
+            'As,min = 2.39 cm²',
+            'As,max (singly reinforced) = 11.58 cm²',
+            'As,req (tension) = 4.73 cm²',
+            'Tension reinforcement: 2 Ø20 (6.28 cm²)',
+            'a = 6.21 cm, c = 7.31 cm',
+            'εt = 11.74‰',
+            'εt ≥ 5‰ → tension-controlled → φ = 0.90',
+            'φMn = 77.90 kN·m',
+          ],
+        },
+        { k: 'p', t: 'Ten steps. The tenth is the one everyone remembers. The ones that decide are the third and the ninth.' },
+
+        { k: 'h', t: 'Step 3: the minimum governs more often than it seems' },
+        { k: 'p', t: 'Article 9.6.1.2 asks for a minimum flexural reinforcement equal to the greater of 0.25·√f\'c/fy·bw·d and 1.4/fy·bw·d. It tends to be read as a floor that is almost never reached. In housing beams it is reached constantly.' },
+        {
+          k: 'table',
+          caption: 'The same 20×40 H-25 beam under increasing moments: what decides the reinforcement.',
+          head: ['Mu [kN·m]', 'As by strength [cm²]', 'As,min [cm²]', 'Governs'],
+          rows: [
+            ['15', '1.12', '2.39', 'the minimum'],
+            ['30', '2.28', '2.39', 'the minimum'],
+            ['60', '4.73', '2.39', 'strength'],
+            ['90', '7.38', '2.39', 'strength'],
+          ],
+        },
+        { k: 'p', t: 'The crossover is at Mu = 31.5 kN·m. Below that moment, sizing for strength achieves nothing: the section carries 2.39 cm² either way. It is worth knowing which side of the crossover a beam is on before arguing about its bars.' },
+
+        { k: 'h', t: 'And the minimum rarely depends on the concrete' },
+        { k: 'p', t: 'Of the article\'s two branches, the √f\'c one only overtakes the other once the concrete is quite good.' },
+        {
+          k: 'table',
+          caption: 'The two branches of the minimum, for fy 420, per mille.',
+          head: ['Concrete', '0.25·√f\'c/fy', '1.4/fy', 'Governs'],
+          rows: [
+            ['H-20', '2.6620', '3.3333', '1.4/fy'],
+            ['H-25', '2.9762', '3.3333', '1.4/fy'],
+            ['H-30', '3.2603', '3.3333', '1.4/fy'],
+            ['H-35', '3.5215', '3.3333', '√f\'c'],
+          ],
+        },
+        { k: 'p', t: 'The crossover is at f\'c = 31.36 MPa. Across the whole range used in housing — H-20, H-25, H-30 — the minimum reinforcement does not depend on the concrete: it comes from 1.4/fy and nothing else. Going from H-20 to H-30 does not lower the minimum by a single square centimetre.' },
+
+        { k: 'h', t: 'Step 9: φ is not 0.9 by decree' },
+        { k: 'p', t: 'The strength reduction factor is learnt as 0.90 for bending and used as a constant. It is not one. It comes from the strain in the tension steel at the ultimate state, and the module says so in step 9: εt ≥ 5‰ → tension-controlled → φ = 0.90. Put more steel in the section and εt falls, taking φ with it.' },
+        {
+          k: 'table',
+          caption: 'The same beam, loaded further each time. εt and φ come from steps 8 and 9.',
+          head: ['Mu [kN·m]', 'Reinforcement', 'εt [‰]', 'φ', 'φMn [kN·m]'],
+          rows: [
+            ['30', '2 Ø16', '20.03', '0.90', '51.6'],
+            ['60', '2 Ø20', '11.74', '0.90', '77.9'],
+            ['90', '2 Ø25', '6.44', '0.90', '115.2'],
+            ['120', '2 Ø32', '2.76', '0.707', '133.5'],
+          ],
+        },
+        { k: 'p', t: 'In the last row the section entered the transition zone and φ dropped to 0.707. Capacity did not grow the way the steel did: between the last two rows the bar area goes from 6.44 to 8.04 cm² nominal and φMn only moves from 115.2 to 133.5 kN·m. A good part of what is added is lost in the factor.' },
+        { k: 'quote', t: 'An over-reinforced section does not fail the check. It fails in φ, and the result still says it passes.' },
+
+        { k: 'h', t: 'Why compression steel goes in' },
+        { k: 'p', t: 'The usual answer is "so the bars fit". That is the consequence, not the reason. At Mu = 200 kN·m on this same beam, the module finds εt = 1.51‰, below the limit, and adds compression reinforcement. With it the neutral axis rises, εt returns to 7.46‰ and φ returns to 0.90.' },
+        { k: 'p', t: 'So compression steel is not there to contribute capacity. It is there to give the section its ductility back and recover the factor. The capacity follows, as a result.' },
+        { k: 'note', t: 'The steps the module emits for that case say it in that order: "εt = 1.51‰ < 2.1‰ → A\'s required", then "ΔM = 144.50 kN·m, A\'s,req = 11.40 cm²", and only at the end "εt = 7.46‰ → tension-controlled → φ = 0.90".' },
+
+        { k: 'h', t: 'Try it on a real beam' },
+        { k: 'p', t: 'Below is the model: a simply supported 5 m beam, 20×40, H-25, with 12 kN/m of dead load and 8 kN/m of live load, plus its own weight. It opens in PRO\'s design workflow, with CIRSOC 201 as the code in force.' },
+        {
+          k: 'embed',
+          mode: 'pro',
+          query: 'example=rc-beam-flexure&proTab=design',
+          label: 'The beam in Stabileo, in PRO\'s design workflow. Press "Compute demands" and then "Run code check": the 1.2D+1.6L combination governs with Mu = 92.5 kN·m and the beam passes at D/C = 0.81. Change the load and watch which side of the crossover the minimum lands on. PRO is in development; the concrete module is the part that is implemented and tested.',
+        },
+
+        { k: 'h', t: 'In short' },
+        {
+          k: 'ol',
+          items: [
+            'Before sizing, check whether the moment is above or below the crossover with the minimum. Below it, the reinforcement is already decided.',
+            'From H-20 to H-30, the minimum does not depend on the concrete. It comes from 1.4/fy.',
+            'φ is a result, not an input. Read it together with εt.',
+            'If compression steel appears, it is because the section lost ductility, not because it lacks capacity.',
+          ],
+        },
+
+        { k: 'note', t: 'Every figure here comes from Stabileo\'s CIRSOC 201 module, run on the sections named, and not from a table. One warning worth passing on, because the first draft of this post got it wrong: the hand calculation gave D/C = 0.74 and the application 0.81. The difference was self-weight, 2 kN/m that the application adds to the dead case. The application was right. If a number here ever stops matching the editor above, believe the editor.' },
+      ],
+    },
+
+    pt: {
+      title: 'Verificação à flexão segundo a CIRSOC 201, passo a passo',
+      excerpt:
+        'Todo mundo lembra de φMn ≥ Mu. Essa é a última linha da verificação, não a verificação. Os três passos que decidem o resultado são outros, e um deles é o motivo de φ não valer 0,9.',
+      blocks: [
+        { k: 'p', t: 'Verificar uma viga à flexão se resume, na memória de quase todos, a uma desigualdade: φMn ≥ Mu. É verdade, e é a última linha. O que decide o resultado acontece antes, em passos que raramente são lidos com atenção porque parecem burocracia.' },
+        { k: 'p', t: 'Isto é o que o módulo CIRSOC 201 do Stabileo devolve para uma viga de 20×40 cm, concreto H-25, aço fy 420, 25 mm de cobrimento e estribos de 8, sob um momento de 60 kN·m:' },
+        {
+          k: 'ol',
+          items: [
+            'd = 35,9 cm, d\' = 4,1 cm',
+            'Mu = 60,00 kN·m',
+            'As,mín = 2,39 cm²',
+            'As,máx (armadura simples) = 11,58 cm²',
+            'As,req (tração) = 4,73 cm²',
+            'Armadura de tração: 2 Ø20 (6,28 cm²)',
+            'a = 6,21 cm, c = 7,31 cm',
+            'εt = 11,74‰',
+            'εt ≥ 5‰ → controlada por tração → φ = 0,90',
+            'φMn = 77,90 kN·m',
+          ],
+        },
+        { k: 'p', t: 'Dez passos. O décimo é o que todos lembram. Os que decidem são o terceiro e o nono.' },
+
+        { k: 'h', t: 'Passo 3: o mínimo governa mais vezes do que parece' },
+        { k: 'p', t: 'O artigo 9.6.1.2 exige uma armadura mínima de flexão igual ao maior entre 0,25·√f\'c/fy·bw·d e 1,4/fy·bw·d. Costuma ser lido como um piso que quase nunca se alcança. Em vigas de habitação, alcança-se o tempo todo.' },
+        {
+          k: 'table',
+          caption: 'A mesma viga 20×40 de H-25, com momentos crescentes: quem decide a armadura.',
+          head: ['Mu [kN·m]', 'As por resistência [cm²]', 'As,mín [cm²]', 'Governa'],
+          rows: [
+            ['15', '1.12', '2.39', 'o mínimo'],
+            ['30', '2.28', '2.39', 'o mínimo'],
+            ['60', '4.73', '2.39', 'a resistência'],
+            ['90', '7.38', '2.39', 'a resistência'],
+          ],
+        },
+        { k: 'p', t: 'O cruzamento está em Mu = 31,5 kN·m. Abaixo desse momento, dimensionar pela resistência não adianta: a seção vai levar 2,39 cm² de qualquer forma. Vale saber de que lado do cruzamento uma viga está antes de discutir a sua armadura.' },
+
+        { k: 'h', t: 'E o mínimo quase nunca depende do concreto' },
+        { k: 'p', t: 'Dos dois ramos do artigo, o de √f\'c só supera o outro quando o concreto é bastante bom.' },
+        {
+          k: 'table',
+          caption: 'Os dois ramos do mínimo, para fy 420, em por mil.',
+          head: ['Concreto', '0,25·√f\'c/fy', '1,4/fy', 'Governa'],
+          rows: [
+            ['H-20', '2.6620', '3.3333', '1,4/fy'],
+            ['H-25', '2.9762', '3.3333', '1,4/fy'],
+            ['H-30', '3.2603', '3.3333', '1,4/fy'],
+            ['H-35', '3.5215', '3.3333', '√f\'c'],
+          ],
+        },
+        { k: 'p', t: 'O cruzamento está em f\'c = 31,36 MPa. Em toda a faixa usada em habitação — H-20, H-25, H-30 — a armadura mínima não depende do concreto: sai de 1,4/fy e nada mais. Passar de H-20 para H-30 não reduz o mínimo em um único centímetro quadrado.' },
+
+        { k: 'h', t: 'Passo 9: φ não vale 0,9 por decreto' },
+        { k: 'p', t: 'O coeficiente de redução é aprendido como 0,90 para flexão e usado como constante. Não é. Ele vem da deformação da armadura tracionada no estado último, e o módulo diz isso no passo 9: εt ≥ 5‰ → seção controlada por tração → φ = 0,90. Coloque mais aço na seção e εt cai, levando φ junto.' },
+        {
+          k: 'table',
+          caption: 'A mesma viga, carregada cada vez mais. εt e φ vêm dos passos 8 e 9.',
+          head: ['Mu [kN·m]', 'Armadura', 'εt [‰]', 'φ', 'φMn [kN·m]'],
+          rows: [
+            ['30', '2 Ø16', '20.03', '0.90', '51.6'],
+            ['60', '2 Ø20', '11.74', '0.90', '77.9'],
+            ['90', '2 Ø25', '6.44', '0.90', '115.2'],
+            ['120', '2 Ø32', '2.76', '0.707', '133.5'],
+          ],
+        },
+        { k: 'p', t: 'Na última linha a seção entrou na zona de transição e φ caiu para 0,707. A capacidade não cresceu como o aço: entre as duas últimas linhas a área das barras vai de 6,44 para 8,04 cm² nominais e φMn só passa de 115,2 para 133,5 kN·m. Boa parte do que se acrescenta se perde no coeficiente.' },
+        { k: 'quote', t: 'Uma seção superarmada não reprova na verificação. Ela reprova no φ, e o resultado continua dizendo que passa.' },
+
+        { k: 'h', t: 'Por que entra armadura de compressão' },
+        { k: 'p', t: 'A resposta habitual é "para as barras caberem". Essa é a consequência, não o motivo. Com Mu = 200 kN·m nesta mesma viga, o módulo detecta εt = 1,51‰, abaixo do limite, e acrescenta armadura de compressão. Com ela a linha neutra sobe, εt volta a 7,46‰ e φ volta a 0,90.' },
+        { k: 'p', t: 'Ou seja, a armadura de compressão não está ali para dar capacidade. Está para devolver ductilidade à seção e recuperar o coeficiente. A capacidade vem depois, como resultado.' },
+        { k: 'note', t: 'Os passos que o módulo emite para esse caso dizem isso nessa ordem: "εt = 1,51‰ < 2,1‰ → é necessário A\'s", depois "ΔM = 144,50 kN·m, A\'s,req = 11,40 cm²", e só no final "εt = 7,46‰ → controlada por tração → φ = 0,90".' },
+
+        { k: 'h', t: 'Experimente numa viga de verdade' },
+        { k: 'p', t: 'Abaixo está o modelo: uma viga simplesmente apoiada de 5 m, 20×40, H-25, com 12 kN/m de carga permanente e 8 kN/m de sobrecarga, mais o peso próprio. Abre no fluxo de projeto do PRO, com a CIRSOC 201 como norma em vigor.' },
+        {
+          k: 'embed',
+          mode: 'pro',
+          query: 'example=rc-beam-flexure&proTab=design',
+          label: 'A viga no Stabileo, no fluxo de projeto do PRO. Aperte «Calcular solicitações» e depois «Executar verificação normativa»: a combinação 1,2D+1,6L governa com Mu = 92,5 kN·m e a viga passa com D/C = 0,81. Mude a carga e veja de que lado do cruzamento o mínimo cai. O PRO está em desenvolvimento; o módulo de concreto é a parte implementada e testada.',
+        },
+
+        { k: 'h', t: 'Em resumo' },
+        {
+          k: 'ol',
+          items: [
+            'Antes de dimensionar, veja se o momento está acima ou abaixo do cruzamento com o mínimo. Abaixo dele, a armadura já está decidida.',
+            'De H-20 a H-30, o mínimo não depende do concreto. Sai de 1,4/fy.',
+            'φ é um resultado, não um dado. Leia-o junto com εt.',
+            'Se aparece armadura de compressão, é porque a seção perdeu ductilidade, não porque falta capacidade.',
+          ],
+        },
+
+        { k: 'note', t: 'Todos os valores vêm do módulo CIRSOC 201 do Stabileo, rodado sobre as seções indicadas, e não de uma tabela. Um aviso que vale a pena, porque a primeira versão desta nota errou nisso: o cálculo à mão dava D/C = 0,74 e a aplicação 0,81. A diferença era o peso próprio, 2 kN/m que a aplicação soma à carga permanente. A aplicação estava certa. Se algum número daqui deixar de coincidir com o editor acima, acredite no editor.' },
+      ],
+    },
+  },
+};

--- a/web/src/lib/blog/posts/cirsoc-201-flexure.ts
+++ b/web/src/lib/blog/posts/cirsoc-201-flexure.ts
@@ -124,7 +124,7 @@ export const cirsoc201Flexure: Post = {
             ['120', '2 Ø32', '2.76', '0.707', '133.5'],
           ],
         },
-        { k: 'p', t: 'En la última fila la sección entró en zona de transición y φ cayó a 0,707. La capacidad no creció como la armadura: entre las dos últimas filas el acero sube de 6,44 a 8,04 cm² de área nominal y φMn sólo pasa de 115,2 a 133,5 kN·m. Buena parte de lo que se agrega se pierde en el coeficiente.' },
+        { k: 'p', t: 'En la última fila la sección entró en zona de transición y φ cayó a 0,707. La capacidad no creció como la armadura: entre las dos últimas filas el acero sube de 9,82 a 16,08 cm² de área nominal y φMn sólo pasa de 115,2 a 133,5 kN·m. Buena parte de lo que se agrega se pierde en el coeficiente.' },
         { k: 'quote', t: 'Una sección sobrearmada no falla en la verificación. Falla en el φ, y el resultado sigue diciendo que verifica.' },
 
         { k: 'h', t: 'Por qué se pone armadura de compresión' },
@@ -223,7 +223,7 @@ export const cirsoc201Flexure: Post = {
             ['120', '2 Ø32', '2.76', '0.707', '133.5'],
           ],
         },
-        { k: 'p', t: 'In the last row the section entered the transition zone and φ dropped to 0.707. Capacity did not grow the way the steel did: between the last two rows the bar area goes from 6.44 to 8.04 cm² nominal and φMn only moves from 115.2 to 133.5 kN·m. A good part of what is added is lost in the factor.' },
+        { k: 'p', t: 'In the last row the section entered the transition zone and φ dropped to 0.707. Capacity did not grow the way the steel did: between the last two rows the bar area goes from 9.82 to 16.08 cm² nominal and φMn only moves from 115.2 to 133.5 kN·m. A good part of what is added is lost in the factor.' },
         { k: 'quote', t: 'An over-reinforced section does not fail the check. It fails in φ, and the result still says it passes.' },
 
         { k: 'h', t: 'Why compression steel goes in' },
@@ -322,7 +322,7 @@ export const cirsoc201Flexure: Post = {
             ['120', '2 Ø32', '2.76', '0.707', '133.5'],
           ],
         },
-        { k: 'p', t: 'Na última linha a seção entrou na zona de transição e φ caiu para 0,707. A capacidade não cresceu como o aço: entre as duas últimas linhas a área das barras vai de 6,44 para 8,04 cm² nominais e φMn só passa de 115,2 para 133,5 kN·m. Boa parte do que se acrescenta se perde no coeficiente.' },
+        { k: 'p', t: 'Na última linha a seção entrou na zona de transição e φ caiu para 0,707. A capacidade não cresceu como o aço: entre as duas últimas linhas a área das barras vai de 9,82 para 16,08 cm² nominais e φMn só passa de 115,2 para 133,5 kN·m. Boa parte do que se acrescenta se perde no coeficiente.' },
         { k: 'quote', t: 'Uma seção superarmada não reprova na verificação. Ela reprova no φ, e o resultado continua dizendo que passa.' },
 
         { k: 'h', t: 'Por que entra armadura de compressão' },

--- a/web/src/lib/blog/posts/cirsoc-201-flexure.ts
+++ b/web/src/lib/blog/posts/cirsoc-201-flexure.ts
@@ -17,7 +17,29 @@
  *     L = 8 kN/m, governing 1.2D+1.6L → Mu = 92.5 kN·m, 2 Ø25, φMn = 115.2,
  *     D/C = 0.80. The application reports 0.81 through its own pipeline.
  *
- * The embed's caption names the two buttons the reader has to press, and it
+ * ── What the embed actually shows, which is not the same thing ──
+ *
+ * The 0.81 above is this post's beam WITH 2 Ø25. The embed does not assume a
+ * reinforcement, it designs one, and its own bars give D/C = 0.89. The caption
+ * quotes 0.89 and the closing note explains the two.
+ *
+ * Two things were wrong here before, both found by driving the frame rather
+ * than by reading it:
+ *
+ *   · The caption named two buttons. It takes three. After "Compute demands"
+ *     and "Run code check" the table still reads "no reinforcement / not
+ *     verified" — there is nothing to check until "Design all" places bars.
+ *   · It promised D/C = 0.81 on screen. Nothing on screen said 0.81 after the
+ *     full flow, and Mu = 92.5 is never displayed at all.
+ *
+ * The 5 m span is two elements, so there are two rows: 0.89 governed by
+ * positive bending and 0.86 governed by shear. Shear governs the summary line
+ * on essentially any beam here — six spans from 5 to 8 m and sections from
+ * 20×40 to 25×60 all came back shear-governed at 0.78–0.94, because stirrup
+ * spacing is designed right up against the demand while bars come in discrete
+ * areas. Do not retune the fixture chasing a flexure-governed summary row.
+ *
+ * The embed's caption names the buttons the reader has to press, and it
  * names them PER LANGUAGE. The editor inside the frame runs in the reader's
  * locale, so an English caption on a Spanish page sends someone looking for
  * "Compute demands" at a button that says "Calcular solicitaciones".
@@ -38,7 +60,7 @@ export const cirsoc201Flexure: Post = {
     es: {
       title: 'Verificación a flexión según CIRSOC 201, paso a paso',
       excerpt:
-        'Todos recuerdan φMn ≥ Mu. Esa es la última línea de la verificación, no la verificación. Los tres pasos que deciden el resultado son otros, y uno de ellos hace que φ no valga 0,9.',
+        'Todos recuerdan φMn ≥ Mu. Esa es la última línea de la verificación, no la verificación. Los pasos que deciden el resultado son otros, y uno hace que φ no valga 0,9.',
       blocks: [
         { k: 'p', t: 'Verificar una viga a flexión se resume, en la memoria de casi todos, en una desigualdad: φMn ≥ Mu. Es cierto, y es la última línea. Lo que decide el resultado pasa antes, en pasos que rara vez se miran con atención porque parecen trámite.' },
         { k: 'p', t: 'Esto es lo que devuelve el módulo CIRSOC 201 de Stabileo para una viga de 20×40 cm, H-25, con acero fy 420, 25 mm de recubrimiento y estribos de 8, bajo un momento de 60 kN·m:' },
@@ -116,7 +138,7 @@ export const cirsoc201Flexure: Post = {
           k: 'embed',
           mode: 'pro',
           query: 'example=rc-beam-flexure&proTab=design',
-          label: 'La viga en Stabileo, en el flujo de diseño de PRO. Apretá «Calcular solicitaciones» y después «Verificar según norma»: la combinación 1,2D+1,6L gobierna con Mu = 92,5 kN·m y la viga verifica con D/C = 0,81. Cambiá la carga y mirá de qué lado del cruce queda el mínimo. PRO está en desarrollo; el módulo de hormigón es la parte implementada y testeada.',
+          label: 'La viga en Stabileo, en el flujo de diseño de PRO. Tres botones y en este orden: «Calcular solicitaciones», «Verificar según norma» y «Diseñar todo» — recién el tercero elige las barras, y hasta que no hay barras no hay nada que verificar: la tabla dice «sin armadura». El tramo de 5 m está modelado con dos elementos; el primero cierra en D/C = 0,89 gobernado por la flexión positiva del tramo, el segundo en 0,86 gobernado por el corte, los dos con la combinación 1,2D+1,6L. Cambiá la carga y volvé a correrlo. PRO está en desarrollo; el módulo de hormigón es la parte implementada y testeada.',
         },
 
         { k: 'h', t: 'En resumen' },
@@ -130,14 +152,14 @@ export const cirsoc201Flexure: Post = {
           ],
         },
 
-        { k: 'note', t: 'Todas las cifras salen del módulo CIRSOC 201 de Stabileo, corrido sobre las secciones que se indican, y no de una tabla. Una advertencia que vale la pena, porque la primera versión de esta nota se equivocó ahí: el cálculo a mano daba D/C = 0,74 y la aplicación 0,81. La diferencia era el peso propio, 2 kN/m que la aplicación suma a la carga permanente. Tenía razón la aplicación. Si alguna vez un número de acá no coincide con lo que muestra el editor de arriba, creele al editor.' },
+        { k: 'note', t: 'Todas las cifras salen del módulo CIRSOC 201 de Stabileo, corrido sobre las secciones que se indican, y no de una tabla. Una advertencia que vale la pena, porque la primera versión de esta nota se equivocó ahí: el cálculo a mano daba D/C = 0,74 y la aplicación 0,81. La diferencia era el peso propio, 2 kN/m que la aplicación suma a la carga permanente. Tenía razón la aplicación. Y una aclaración sobre el editor de arriba, para que los dos números no se pisen: ese 0,81 supone 2 Ø25, que es la armadura con la que trabaja esta nota; el 0,89 que muestra el editor es con las barras que elige él mismo al diseñar. Misma viga, dos armaduras. Si alguna vez un número de acá no coincide con lo que muestra el editor, creele al editor.' },
       ],
     },
 
     en: {
       title: 'Flexural verification to CIRSOC 201, step by step',
       excerpt:
-        'Everyone remembers φMn ≥ Mu. That is the last line of the check, not the check. The three steps that decide the outcome are others, and one of them is why φ is not 0.9.',
+        'Everyone remembers φMn ≥ Mu. That is the last line of the check, not the check. The steps that decide the outcome are others, and one is why φ is not 0.9.',
       blocks: [
         { k: 'p', t: 'Checking a beam in bending reduces, in most people\'s memory, to one inequality: φMn ≥ Mu. It is true, and it is the last line. What decides the outcome happens earlier, in steps that are rarely read closely because they look like paperwork.' },
         { k: 'p', t: 'This is what Stabileo\'s CIRSOC 201 module returns for a 20×40 cm beam of H-25 concrete, fy 420 steel, 25 mm cover and 8 mm stirrups, under a moment of 60 kN·m:' },
@@ -215,7 +237,7 @@ export const cirsoc201Flexure: Post = {
           k: 'embed',
           mode: 'pro',
           query: 'example=rc-beam-flexure&proTab=design',
-          label: 'The beam in Stabileo, in PRO\'s design workflow. Press "Compute demands" and then "Run code check": the 1.2D+1.6L combination governs with Mu = 92.5 kN·m and the beam passes at D/C = 0.81. Change the load and watch which side of the crossover the minimum lands on. PRO is in development; the concrete module is the part that is implemented and tested.',
+          label: 'The beam in Stabileo, in PRO\'s design workflow. Three buttons, in this order: "Compute demands", "Run code check" and "Design all" — only the third one picks the bars, and until there are bars there is nothing to verify: the table says "no reinforcement". The 5 m span is modelled as two elements; the first closes at D/C = 0.89 governed by positive bending in the span, the second at 0.86 governed by shear, both under the 1.2D+1.6L combination. Change the load and run it again. PRO is in development; the concrete module is the part that is implemented and tested.',
         },
 
         { k: 'h', t: 'In short' },
@@ -229,14 +251,14 @@ export const cirsoc201Flexure: Post = {
           ],
         },
 
-        { k: 'note', t: 'Every figure here comes from Stabileo\'s CIRSOC 201 module, run on the sections named, and not from a table. One warning worth passing on, because the first draft of this post got it wrong: the hand calculation gave D/C = 0.74 and the application 0.81. The difference was self-weight, 2 kN/m that the application adds to the dead case. The application was right. If a number here ever stops matching the editor above, believe the editor.' },
+        { k: 'note', t: 'Every figure here comes from Stabileo\'s CIRSOC 201 module, run on the sections named, and not from a table. One warning worth passing on, because the first draft of this post got it wrong: the hand calculation gave D/C = 0.74 and the application 0.81. The difference was self-weight, 2 kN/m that the application adds to the dead case. The application was right. And one note on the editor above, so the two numbers do not collide: that 0.81 assumes 2 Ø25, the reinforcement this post works with; the 0.89 the editor shows is with the bars it chooses for itself when it designs. Same beam, two different reinforcements. If a number here ever stops matching the editor, believe the editor.' },
       ],
     },
 
     pt: {
       title: 'Verificação à flexão segundo a CIRSOC 201, passo a passo',
       excerpt:
-        'Todo mundo lembra de φMn ≥ Mu. Essa é a última linha da verificação, não a verificação. Os três passos que decidem o resultado são outros, e um deles é o motivo de φ não valer 0,9.',
+        'Todo mundo lembra de φMn ≥ Mu. Essa é a última linha da verificação, não a verificação. Os passos que decidem o resultado são outros, e um faz φ não valer 0,9.',
       blocks: [
         { k: 'p', t: 'Verificar uma viga à flexão se resume, na memória de quase todos, a uma desigualdade: φMn ≥ Mu. É verdade, e é a última linha. O que decide o resultado acontece antes, em passos que raramente são lidos com atenção porque parecem burocracia.' },
         { k: 'p', t: 'Isto é o que o módulo CIRSOC 201 do Stabileo devolve para uma viga de 20×40 cm, concreto H-25, aço fy 420, 25 mm de cobrimento e estribos de 8, sob um momento de 60 kN·m:' },
@@ -314,7 +336,7 @@ export const cirsoc201Flexure: Post = {
           k: 'embed',
           mode: 'pro',
           query: 'example=rc-beam-flexure&proTab=design',
-          label: 'A viga no Stabileo, no fluxo de projeto do PRO. Aperte «Calcular solicitações» e depois «Executar verificação normativa»: a combinação 1,2D+1,6L governa com Mu = 92,5 kN·m e a viga passa com D/C = 0,81. Mude a carga e veja de que lado do cruzamento o mínimo cai. O PRO está em desenvolvimento; o módulo de concreto é a parte implementada e testada.',
+          label: 'A viga no Stabileo, no fluxo de projeto do PRO. Três botões, nesta ordem: «Calcular solicitações», «Executar verificação normativa» e «Dimensionar tudo» — só o terceiro escolhe as barras, e enquanto não houver barras não há o que verificar: a tabela diz «sem armadura». O vão de 5 m está modelado com dois elementos; o primeiro fecha em D/C = 0,89 governado pela flexão positiva do vão, o segundo em 0,86 governado pelo cortante, ambos com a combinação 1,2D+1,6L. Mude a carga e rode de novo. O PRO está em desenvolvimento; o módulo de concreto é a parte implementada e testada.',
         },
 
         { k: 'h', t: 'Em resumo' },
@@ -328,7 +350,7 @@ export const cirsoc201Flexure: Post = {
           ],
         },
 
-        { k: 'note', t: 'Todos os valores vêm do módulo CIRSOC 201 do Stabileo, rodado sobre as seções indicadas, e não de uma tabela. Um aviso que vale a pena, porque a primeira versão desta nota errou nisso: o cálculo à mão dava D/C = 0,74 e a aplicação 0,81. A diferença era o peso próprio, 2 kN/m que a aplicação soma à carga permanente. A aplicação estava certa. Se algum número daqui deixar de coincidir com o editor acima, acredite no editor.' },
+        { k: 'note', t: 'Todos os valores vêm do módulo CIRSOC 201 do Stabileo, rodado sobre as seções indicadas, e não de uma tabela. Um aviso que vale a pena, porque a primeira versão desta nota errou nisso: o cálculo à mão dava D/C = 0,74 e a aplicação 0,81. A diferença era o peso próprio, 2 kN/m que a aplicação soma à carga permanente. A aplicação estava certa. E um esclarecimento sobre o editor acima, para que os dois números não se atropelem: esse 0,81 supõe 2 Ø25, que é a armadura com que esta nota trabalha; o 0,89 que o editor mostra é com as barras que ele mesmo escolhe ao dimensionar. Mesma viga, duas armaduras. Se algum número daqui deixar de coincidir com o editor, acredite no editor.' },
       ],
     },
   },

--- a/web/src/lib/blog/types.ts
+++ b/web/src/lib/blog/types.ts
@@ -32,7 +32,7 @@ export type Block =
    * argument list for /app/basic; `label` says what the reader is opening.
    * It renders as a placeholder until clicked — see PostEmbed.svelte.
    */
-  | { k: 'embed'; query: string; label: string };
+  | { k: 'embed'; query: string; label: string; mode?: 'basic' | 'pro' };
 
 /** One post in one language. */
 export type PostBody = {

--- a/web/src/lib/i18n/locales/en.ts
+++ b/web/src/lib/i18n/locales/en.ts
@@ -31,6 +31,8 @@ const en: Record<string, string> = {
   'blog.readingTime': '{n} min read',
   'blog.tag.sections': 'Sections',
   'blog.tag.theory': 'Theory',
+  'blog.tag.cirsoc': 'CIRSOC',
+  'blog.tag.concrete': 'Concrete',
   'blog.tag.ai': 'AI',
   'blog.tag.research': 'Research',
   'blog.tag.solver': 'Solver',

--- a/web/src/lib/i18n/locales/es.ts
+++ b/web/src/lib/i18n/locales/es.ts
@@ -31,6 +31,8 @@ const es: Record<string, string> = {
   'blog.readingTime': '{n} min de lectura',
   'blog.tag.sections': 'Secciones',
   'blog.tag.theory': 'Teoría',
+  'blog.tag.cirsoc': 'CIRSOC',
+  'blog.tag.concrete': 'Hormigón',
   'blog.tag.ai': 'IA',
   'blog.tag.research': 'Investigación',
   'blog.tag.solver': 'Solver',

--- a/web/src/lib/i18n/locales/pt.ts
+++ b/web/src/lib/i18n/locales/pt.ts
@@ -226,6 +226,8 @@ const pt: Translations = {
   'blog.openEditor': 'Abrir o editor',
   'blog.readMore': 'Ler a nota',
   'blog.readingTime': '{n} min de leitura',
+  'blog.tag.cirsoc': 'CIRSOC',
+  'blog.tag.concrete': 'Concreto',
   'blog.tag.ai': 'IA',
   'blog.tag.research': 'Pesquisa',
   'blog.tag.sections': 'Seções',

--- a/web/src/lib/templates/fixture-index.ts
+++ b/web/src/lib/templates/fixture-index.ts
@@ -44,6 +44,12 @@ const fixtures3D: Record<string, FixtureLoader> = {
   // its table. Opened from the post's embedded editor, so the reader sees
   // Cauchy and Bredt disagree on the very section the text is about.
   'torsion-tube': () => import('./fixtures/torsion-tube.json'),
+  // A simply supported 20×40 H-25 beam with D and L cases and the two usual
+  // combinations, sized for the blog post on CIRSOC 201 flexural verification:
+  // the governing combination lands near the moment the text works through.
+  // Registered here so a post can load it; deliberately not in the examples
+  // menu, which is a catalogue for users rather than for articles.
+  'rc-beam-flexure': () => import('./fixtures/rc-beam-flexure.json'),
   '3d-nave-industrial': () => import('./fixtures/3d-nave-industrial.json'),
   '3d-building': () => import('./fixtures/3d-building.json'),
   'pro-edificio-7p': () => import('./fixtures/pro-edificio-7p.json'),

--- a/web/src/lib/templates/fixtures/rc-beam-flexure.json
+++ b/web/src/lib/templates/fixtures/rc-beam-flexure.json
@@ -1,0 +1,171 @@
+{
+  "name": "Viga de hormigón — verificación a flexión",
+  "materials": [
+    {
+      "id": 1,
+      "name": "H-25",
+      "e": 23500,
+      "nu": 0.2,
+      "rho": 25,
+      "fy": 25
+    }
+  ],
+  "sections": [
+    {
+      "id": 1,
+      "name": "Viga 20×40",
+      "a": 0.08000000000000002,
+      "iy": 0.001066666666666667,
+      "iz": 0.00026666666666666673,
+      "j": 0.00035,
+      "b": 0.2,
+      "h": 0.4,
+      "shape": "rect"
+    }
+  ],
+  "nodes": [
+    {
+      "id": 1,
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    {
+      "id": 2,
+      "x": 2.5,
+      "y": 0,
+      "z": 0
+    },
+    {
+      "id": 3,
+      "x": 5.0,
+      "y": 0,
+      "z": 0
+    }
+  ],
+  "elements": [
+    {
+      "id": 1,
+      "type": "frame",
+      "nodeI": 1,
+      "nodeJ": 2,
+      "materialId": 1,
+      "sectionId": 1,
+      "hingeStart": false,
+      "hingeEnd": false
+    },
+    {
+      "id": 2,
+      "type": "frame",
+      "nodeI": 2,
+      "nodeJ": 3,
+      "materialId": 1,
+      "sectionId": 1,
+      "hingeStart": false,
+      "hingeEnd": false
+    }
+  ],
+  "supports": [
+    {
+      "id": 1,
+      "nodeId": 1,
+      "type": "pinned3d"
+    },
+    {
+      "id": 2,
+      "nodeId": 3,
+      "type": "rollerZ"
+    }
+  ],
+  "loads": [
+    {
+      "type": "distributed3d",
+      "data": {
+        "id": 1,
+        "elementId": 1,
+        "qYI": 0,
+        "qYJ": 0,
+        "qZI": -12.0,
+        "qZJ": -12.0,
+        "caseId": 1
+      }
+    },
+    {
+      "type": "distributed3d",
+      "data": {
+        "id": 2,
+        "elementId": 2,
+        "qYI": 0,
+        "qYJ": 0,
+        "qZI": -12.0,
+        "qZJ": -12.0,
+        "caseId": 1
+      }
+    },
+    {
+      "type": "distributed3d",
+      "data": {
+        "id": 3,
+        "elementId": 1,
+        "qYI": 0,
+        "qYJ": 0,
+        "qZI": -8.0,
+        "qZJ": -8.0,
+        "caseId": 2
+      }
+    },
+    {
+      "type": "distributed3d",
+      "data": {
+        "id": 4,
+        "elementId": 2,
+        "qYI": 0,
+        "qYJ": 0,
+        "qZI": -8.0,
+        "qZJ": -8.0,
+        "caseId": 2
+      }
+    }
+  ],
+  "plates": [],
+  "quads": [],
+  "constraints": [],
+  "loadCases": [
+    {
+      "id": 1,
+      "type": "D",
+      "name": "Permanente"
+    },
+    {
+      "id": 2,
+      "type": "L",
+      "name": "Sobrecarga"
+    }
+  ],
+  "combinations": [
+    {
+      "id": 1,
+      "name": "1.4D",
+      "factors": [
+        {
+          "caseId": 1,
+          "factor": 1.4
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "1.2D+1.6L",
+      "factors": [
+        {
+          "caseId": 1,
+          "factor": 1.2
+        },
+        {
+          "caseId": 2,
+          "factor": 1.6
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Apunta a #162, donde vive la infraestructura del blog: las URLs por idioma, el prerenderizado y el editor embebido.

## Qué entra

La tercera nota — **verificación a flexión según CIRSOC 201** — en español, inglés y portugués, con el módulo corriendo dentro de la propia nota.

El ángulo no es «cómo se verifica una viga» sino **cuáles de los diez pasos deciden el resultado**, que no son el que todos recuerdan:

- El **mínimo gobierna** por debajo de Mu = 31,5 kN·m. Dimensionar por resistencia ahí no cambia nada.
- Y **no depende del hormigón** en todo el rango de vivienda: H-20, H-25 y H-30 dan los mismos 2,39 cm², porque la rama `√f'c` recién manda arriba de f'c = 31,36 MPa.
- **φ no es constante.** Con 120 kN·m la sección entra en transición: εt = 2,76 ‰ → φ = 0,707, y la capacidad deja de seguir al acero.
- La **armadura de compresión** no está para dar capacidad sino para devolver ductilidad: con 200 kN·m recupera εt a 7,46 ‰ y φ a 0,90.

Todas las cifras salen de `checkFlexure` antes de que existiera un párrafo.

## El embed

Abre **PRO**, que es donde vive la verificación, sobre la viga de la nota. El epígrafe nombra los tres botones que hay que apretar **en el idioma del lector** — el editor dentro del marco corre en el idioma de la página, así que un epígrafe en inglés sobre una página en español manda a buscar un botón que dice otra cosa.

## Lo que cambió después de auditarlo

Manejar el marco, en vez de leerlo, encontró dos defectos que el test existente no podía ver porque afirmaba que los botones existen, no que apretarlos llegue a algún lado:

- **El epígrafe nombraba dos botones. Son tres.** Después de «Calcular solicitaciones» y «Verificar según norma» la tabla sigue diciendo *sin armadura / sin verificar*: no hay nada que verificar hasta que «Diseñar todo» coloca las barras.
- **Prometía D/C = 0,81 en pantalla.** No aparece, y Mu = 92,5 kN·m no se muestra nunca. El 0,81 es la sección con 2 Ø25 —la armadura con la que trabaja el texto—; el embed diseña sus propias barras y da 0,89. La nota de cierre ahora explica los dos números.

La fixture queda como está: probé seis variantes, de 5 a 8 m y de 20×40 a 25×60, y **todas volvieron gobernadas por corte** entre 0,78 y 0,94, porque el estribado se dimensiona pegado a la demanda y las barras vienen en áreas discretas. No hay ajuste que haga que la línea resumen diga flexión.

## Detectado y no tocado (es de la app, no de la nota)

- La app escribe `13.34` con punto decimal también en español y portugués.
- `Bottom Span (My+)` y `Shear Span (Vz)` salen en inglés en la UI española y portuguesa.
- Antes de diseñar, la tabla muestra utilización `1.00` y `0.81` en dos elementos **simétricos** que declara «Sin verificar».

## Compuertas

`npm run test:unit` (6.686) · `typecheck` en baseline 479 · `check:gate` · `build` con prerenderizado · `@smoke` + `@landing` (292).

El test nuevo corre los tres clics y lee los números de vuelta. Verificado al revés: **sacándole el tercer clic, falla.**
