### PR TITLE
Blog: el lado conceptual de las funciones avanzadas

### DIFF
--- a/web/e2e/blog.spec.ts
+++ b/web/e2e/blog.spec.ts
@@ -275,6 +275,68 @@ test.describe('@smoke blog', () => {
     await expect(table).not.toContainText('sin armadura');
   });
 
+  /*
+   * The kinematic embed, checked the way the CIRSOC one had to be: by driving
+   * it to the end and reading the panel back, not by asserting a button exists.
+   *
+   * Two real defects were found this way while writing the post. The fixture
+   * was missing `plates`, which threw inside the example loader and was
+   * swallowed by an empty catch — the model half-loaded and the deep link
+   * never ran. And `?kin=1` raised the panel flag without opening the Advanced
+   * tab that hosts the report on desktop Basic, so it worked on a phone and
+   * did nothing on a laptop.
+   */
+  test('the kinematic embed reaches the state its caption promises', async ({ page }) => {
+    test.slow();
+    await boot(page, '/es/blog/conceptual-side-advanced-tools', 'es');
+
+    const embed = page.locator('.post-embed');
+    await embed.scrollIntoViewIfNeeded();
+    await embed.locator('.post-embed-start').click();
+    await expect(embed.locator('iframe')).toHaveAttribute('src', /example=hidden-mechanism&kin=1/);
+
+    const app = page.frameLocator('.post-embed iframe');
+    // The report is docked in the Advanced tab; if the deep link fails to open
+    // it, nothing below this line can pass.
+    // 'Avanzado' in the DOM; the ribbon uppercases it in CSS.
+    await expect(app.getByTestId('bp-title')).toHaveText('Avanzado', { timeout: 60_000 });
+
+    const body = app.locator('body');
+    // The formula, and the app overruling it — the whole point of the post.
+    await expect(body).toContainText('g = 3×2 + 3 − 3×3 = 0');
+    await expect(body).toContainText('NO suficiente');
+    await expect(body).toContainText('1 modo de mecanismo');
+    // The verdict the post's table quotes, in the words the panel uses.
+    await expect(body).toContainText('no se puede resolver');
+  });
+
+  test('a post offers the way back to the index, and the index does not', async ({ page }) => {
+    /*
+     * There was no way back. The logo goes to the landing, so returning to the
+     * index from a post meant landing → scroll to the blog section → enter
+     * again. The link is deliberately absent on the index itself, which is
+     * what made the landing's "Blog" nav item useless here in the first place.
+     */
+    await boot(page, `/es/blog/${SLUG}`, 'es');
+    const back = page.locator('.landing.blog .nav-blog-link');
+    await expect(back).toBeVisible();
+    await expect(back).toHaveText('Blog');
+    // A real href, so it is crawlable and middle-clickable, not a button.
+    await expect(back).toHaveAttribute('href', '/es/blog');
+    // And it sits before the GitHub box, where the ask put it.
+    const order = await page.locator('.landing.blog .nav-actions > *').evaluateAll((els) =>
+      els.map((e) => e.className.toString().split(' ')[0]),
+    );
+    expect(order[0]).toBe('nav-blog-link');
+    expect(order[1]).toBe('nav-gh');
+
+    await back.click();
+    await expect(page).toHaveURL(/\/es\/blog$/);
+    await expect(page.locator('.post-card')).not.toHaveCount(0);
+    // Now on the index, it is gone.
+    await expect(page.locator('.landing.blog .nav-blog-link')).toHaveCount(0);
+  });
+
   test('a post describes itself to a search engine', async ({ page }) => {
     // The byline on screen is prose; this is the only machine-readable
     // statement of who wrote the post and when. Without it a result is a page

--- a/web/e2e/blog.spec.ts
+++ b/web/e2e/blog.spec.ts
@@ -302,10 +302,21 @@ test.describe('@smoke blog', () => {
     await expect(app.getByTestId('bp-title')).toHaveText('Avanzado', { timeout: 60_000 });
 
     const body = app.locator('body');
-    // The formula, and the app overruling it — the whole point of the post.
     await expect(body).toContainText('g = 3×2 + 3 − 3×3 = 0');
-    await expect(body).toContainText('NO suficiente');
-    await expect(body).toContainText('1 modo de mecanismo');
+    /*
+     * Generous timeouts on the rank check, and the reason is worth keeping.
+     *
+     * Step 3 needs the WASM engine, and `?kin=1` opens the panel before it has
+     * loaded. The panel says "not verified yet" and retries until the engine
+     * arrives — so this waits for the answer rather than for the first paint.
+     * CI failed here once with the panel claiming the structure was STABLE,
+     * which was the bug this timeout must not hide: see rankChecked in
+     * kinematic-report.ts.
+     */
+    await expect(body).toContainText('NO suficiente', { timeout: 30_000 });
+    await expect(body).toContainText('1 modo de mecanismo', { timeout: 30_000 });
+    // And it must never have settled on the opposite claim.
+    await expect(body).not.toContainText('La estructura es estable');
     // The verdict the post's table quotes, in the words the panel uses.
     await expect(body).toContainText('no se puede resolver');
   });

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -288,6 +288,31 @@
    * (see `replaceAppUrl`), and quietly overloading it would make a shared
    * link rename someone's project.
    */
+  /**
+   * `?kin=1` opens the kinematic analysis panel.
+   *
+   * The third of the deep links a post can use, beside `?inspect` and
+   * `?proTab`. Unlike those two it waits for nothing: the report is derived
+   * from geometry and supports alone, so it is ready before the solver is —
+   * and on the model this exists for, the solver never succeeds at all.
+   */
+  function openKinematicFromUrl(params: URLSearchParams) {
+    if (params.get('kin') !== '1') return;
+    uiStore.showKinematicPanel = true;
+    /*
+     * On desktop Basic the report is docked inside the Advanced tab of the
+     * right panel (see BasicPanel.svelte), so raising the flag on its own
+     * opens a panel that is never mounted. On mobile it floats and the flag
+     * is enough — the same asymmetry that made `?inspect` look like it
+     * worked on a phone and did nothing on a laptop.
+     *
+     * No retry loop, unlike `openInspectFromUrl`: that one waits for the
+     * solver, and this report needs only geometry and supports. By the time
+     * the example loader resolves, both are in place.
+     */
+    if (uiStore.appMode === 'basico' && !uiStore.isMobile) openBasicPanel('advanced', { toggle: false });
+  }
+
   function openProTabFromUrl(params: URLSearchParams) {
     const tab = params.get('proTab');
     if (!tab) return;
@@ -628,8 +653,20 @@
           tryFit(0);
           openInspectFromUrl(queryParams);
           openProTabFromUrl(queryParams);
-        }).catch(() => {
-          // Silently ignore unknown example ids
+          openKinematicFromUrl(queryParams);
+        }).catch((err) => {
+          /*
+           * Reported, not swallowed.
+           *
+           * This used to be an empty catch commented "silently ignore unknown
+           * example ids", and it did far more than that: a fixture missing
+           * `plates` threw `json.plates is not iterable` from inside the
+           * loader, the whole `then` above was skipped, and the page rendered
+           * a half-loaded model with no deep link applied and no sign that
+           * anything had failed. An unknown id is worth ignoring quietly; a
+           * broken one is not.
+           */
+          console.error(`[stabileo] example "${exampleId}" failed to load:`, err);
         });
       }, 80);
     }

--- a/web/src/components/KinematicPanel.svelte
+++ b/web/src/components/KinematicPanel.svelte
@@ -60,7 +60,27 @@
     }
     report = generateKinematicReport(input, slidingJoints);
     lastAnalyzedVersion = modelStore.modelVersion;
+
+    /*
+     * If the rank check could not run, come back for it.
+     *
+     * `analyzeKinematics` needs the WASM engine, and the panel can be opened
+     * before it has loaded — a deep link like `?kin=1` does exactly that. The
+     * report is honest about it (`rankChecked: false`) and the panel now says
+     * so, but "not verified yet" is a state to leave, not to sit in. Bounded,
+     * so a browser where WASM never arrives stops asking rather than polling
+     * for the life of the page.
+     */
+    if (report && !report.rankChecked && rankRetries < 40) {
+      rankRetries++;
+      setTimeout(() => {
+        if (uiStore.showKinematicPanel) recompute();
+      }, 250);
+    }
   }
+
+  /** Attempts spent waiting for the engine. Reset whenever the panel opens. */
+  let rankRetries = 0;
 
   // Main reactive logic: auto-recompute when appropriate
   $effect(() => {
@@ -69,6 +89,7 @@
       if (lastAnalyzedVersion !== -1) {
         lastAnalyzedVersion = -1;
         report = null;
+        rankRetries = 0;
       }
       return;
     }
@@ -229,7 +250,17 @@
               {@html t('kinematic.matrixExplanation').replaceAll('{n}', String(report.nFreeDofs))}
             </div>
 
-            {#if report.mechanismModes === 0}
+            {#if !report.rankChecked}
+              <!--
+                The check could not run — the WASM engine was not ready. This
+                used to fall into the branch below and announce that the
+                structure is stable, which is a claim nothing had verified.
+                Not knowing is a third state and it has to look like one.
+              -->
+              <div class="kp-result kp-warn-bg">
+                {t('kinematic.rankUnavailable')}
+              </div>
+            {:else if report.mechanismModes === 0}
               <div class="kp-result kp-ok-bg">
                 {t('kinematic.noMechanisms')}
               </div>

--- a/web/src/components/blog/BlogNav.svelte
+++ b/web/src/components/blog/BlogNav.svelte
@@ -13,6 +13,17 @@
 
   const LOCALE_NAMES: Record<string, string> = { en: 'English', es: 'Español', pt: 'Português' };
 
+  /**
+   * Whether to offer a way back to the index.
+   *
+   * Only inside a post. On the index itself the link would point at the page
+   * the reader is already on, which is what made the landing's "Blog" item
+   * useless here and got it removed. Inside a post it is the opposite: there
+   * was NO way back to the index at all — the logo goes to the landing, so
+   * returning meant landing → scroll to the blog section → enter again.
+   */
+  let { inPost = false }: { inPost?: boolean } = $props();
+
   /*
    * The star count, same as the landing's header.
    *
@@ -39,12 +50,18 @@
     </PublicLink>
 
     <!--
-      No section links here. The landing's nav scrolls to sections of the
-      landing, and on the blog the only one that survived was "Blog", which
-      pointed at the page the reader was already on. The logo goes home; that
-      is the whole navigation this page needs.
+      No section links here: the landing's nav scrolls to sections of the
+      landing, and none of them exist on this page. The one exception is
+      "Blog", and only from inside a post — see `inPost`. It sits at the head
+      of the actions rather than in a `.nav-links` row of its own, because
+      that class carries `margin-left: auto` and a second one would split the
+      free space and float the actions into the middle of the bar.
     -->
     <div class="nav-actions">
+      {#if inPost}
+        <PublicLink to="/blog" class="nav-blog-link">{t('landing.navBlog')}</PublicLink>
+      {/if}
+
       <a class="nav-gh" href={REPO_URL} target="_blank" rel="noreferrer" aria-label={t('landing.navGithubRepo')}>
         <svg viewBox="0 0 24 24" fill="currentColor" width="13" height="13" aria-hidden="true" focusable="false">
           <path d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.6-4-1.6-.6-1.4-1.4-1.8-1.4-1.8-1-.7 0-.7 0-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.7-1.6-2.7-.3-5.5-1.3-5.5-5.9 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17 4.7 18 5 18 5c.6 1.7.2 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 .3z"/>

--- a/web/src/components/blog/BlogPage.svelte
+++ b/web/src/components/blog/BlogPage.svelte
@@ -68,7 +68,9 @@
 </script>
 
 <div class="landing blog" bind:this={pageEl}>
-  <BlogNav />
+  <!-- `slug`, not `post`: an unknown slug is still inside a post's address,
+       and that reader needs the way back to the index more than anyone. -->
+  <BlogNav inPost={!!slug} />
 
   {#if slug && !post}
     <section class="sec sec--ink blog-head">

--- a/web/src/components/landing/landing.css
+++ b/web/src/components/landing/landing.css
@@ -474,6 +474,29 @@
   margin-left: auto;
 }
 
+/*
+   The way back to the index, shown only inside a post (BlogNav's `inPost`).
+   Same look as a landing nav item — it is the same bar and the same role —
+   but it lives inside `.nav-actions`, so it needs the rules rather than the
+   `.nav-links` wrapper that carries them.
+*/
+.landing.blog .nav-blog-link {
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-family: var(--lp-sans);
+  font-size: 0.87rem;
+  color: var(--lp-slate-2);
+  padding: 0.45rem 0.6rem;
+  border-radius: var(--lp-radius);
+  white-space: nowrap;
+  text-decoration: none;
+}
+
+.landing.blog .nav-blog-link:hover {
+  color: var(--lp-paper-2);
+}
+
 .landing .nav-actions {
   display: flex;
   align-items: center;

--- a/web/src/lib/blog/__tests__/blog-content.test.ts
+++ b/web/src/lib/blog/__tests__/blog-content.test.ts
@@ -41,9 +41,20 @@ describe('blog posts', () => {
     expect(POSTS.length).toBeGreaterThan(0);
   });
 
-  it('lists newest first', () => {
+  it('lists in the curated reading order, and that order is unambiguous', () => {
+    const orders = POSTS.map((p) => p.order);
+    expect([...orders].sort((a, b) => a - b)).toEqual(orders);
+    // Two posts sharing an order makes the index depend on array position,
+    // which is exactly the accident `order` exists to remove.
+    expect(new Set(orders).size).toBe(POSTS.length);
+  });
+
+  it('publishes in the same direction it is read', () => {
+    // Not a hard requirement — `order` decides and dates are free to diverge
+    // later — but while they do agree, a post dated before the one above it
+    // is far more likely to be a typo than a decision.
     const dates = POSTS.map((p) => p.date);
-    expect([...dates].sort((a, b) => b.localeCompare(a))).toEqual(dates);
+    expect([...dates].sort()).toEqual(dates);
   });
 
   for (const post of POSTS) {

--- a/web/src/lib/blog/index.ts
+++ b/web/src/lib/blog/index.ts
@@ -1,5 +1,5 @@
 /**
- * The blog's index: every post, newest first.
+ * The blog's index: every post, in the order they are meant to be read.
  *
  * A file, not a fetch. The site is a static bundle served from GitHub Pages
  * with no backend of its own, so posts ship with the application and are as
@@ -7,11 +7,23 @@
  */
 import type { Post } from './types';
 import { determinismBoundary } from './posts/determinism-boundary';
-import { torsionTheories } from './posts/torsion-theories';
+import { conceptualAdvanced } from './posts/conceptual-advanced';
 import { cirsoc201Flexure } from './posts/cirsoc-201-flexure';
+import { torsionTheories } from './posts/torsion-theories';
 
-/** Newest first. `date` is a plain ISO day, so a string sort is a date sort. */
-export const POSTS: Post[] = [determinismBoundary, torsionTheories, cirsoc201Flexure].sort((a, b) => b.date.localeCompare(a.date));
+/**
+ * By `order`, not by date.
+ *
+ * Four posts that build on each other are a series, not a feed: the one that
+ * frames the argument is the oldest, and sorting by recency put it last and
+ * opened the blog with the most specialised piece instead. See Post.order.
+ */
+export const POSTS: Post[] = [
+  determinismBoundary,
+  conceptualAdvanced,
+  cirsoc201Flexure,
+  torsionTheories,
+].sort((a, b) => a.order - b.order);
 
 export function findPost(slug: string): Post | undefined {
   return POSTS.find((p) => p.slug === slug);

--- a/web/src/lib/blog/posts/cirsoc-201-flexure.ts
+++ b/web/src/lib/blog/posts/cirsoc-201-flexure.ts
@@ -53,7 +53,8 @@ import type { Post } from '../types';
 
 export const cirsoc201Flexure: Post = {
   slug: 'verificacion-flexion-cirsoc-201',
-  date: '2026-08-22',
+  date: '2026-08-26',
+  order: 3,
   authors: ['Bautista Chesta'],
   tagKeys: ['blog.tag.cirsoc', 'blog.tag.concrete'],
   i18n: {

--- a/web/src/lib/blog/posts/conceptual-advanced.ts
+++ b/web/src/lib/blog/posts/conceptual-advanced.ts
@@ -1,0 +1,248 @@
+/**
+ * The second post: the advanced tools, taken from the conceptual side.
+ *
+ * ── The claim, and how far it was checked ──
+ *
+ * The post argues that free structural software is good at modelling and
+ * solving and does not attempt the advanced tools conceptually. That is a
+ * comparative claim about other people's products, so it was researched
+ * before it was written, and it is narrower than the one first drafted:
+ *
+ *   · "The only free software that shows its steps" is FALSE. SkyCiv shows
+ *     step-by-step hand calculations for trusses and beams — free bodies,
+ *     equilibrium equations before substitution, moment distribution for
+ *     indeterminate beams. The post says so, by name.
+ *   · Ftool is free, excellent and taught across Latin America. It shows
+ *     behaviour — diagrams, influence lines — not the development behind it.
+ *   · MASTAN2 is free and matrix-based, tied to McGuire, Gallagher & Ziemian.
+ *     The theory lives in the textbook; the program runs the analysis.
+ *   · `sectionproperties` is open source and does warping, shear centre and
+ *     the Saint-Venant constant by finite elements — very likely better than
+ *     we do. It is a Python library: it returns numbers and explains nothing,
+ *     and the caller has to already know which theory applies.
+ *
+ * What none of them do is the conjunction: explain kinematic analysis,
+ * produce a bar schedule, and develop section analysis. None does two. None
+ * approaches any of the three conceptually. That is the claim, and naming
+ * what each one is good at is what makes it survive a hostile reader.
+ *
+ * ── The numbers ──
+ *
+ * From `generateKinematicReport` on the `hidden-mechanism` fixture, run
+ * before any of this was written:
+ *
+ *   formula        g = 3·m + r − 3·n
+ *   substitution   g = 3×2 + 3 − 3×3 = 0
+ *   classification HYPOSTATIC — not what the formula's zero implies
+ *   mechanism      1 mode, node 3, dof ux
+ *   isSolvable     false
+ *
+ * The point of the embed is that a reader watches the formula be overruled.
+ * Do not "fix" the fixture so it solves: it is meant not to.
+ */
+import type { Post } from '../types';
+
+export const conceptualAdvanced: Post = {
+  slug: 'conceptual-side-advanced-tools',
+  date: '2026-08-21',
+  order: 2,
+  authors: ['Bautista Chesta'],
+  tagKeys: ['blog.tag.education', 'blog.tag.tools'],
+  i18n: {
+    es: {
+      title: 'Lo que el software gratuito calcula, y lo que no te explica',
+      excerpt:
+        'Hay software estructural gratuito y muy bueno: modela, resuelve y muestra resultados. Lo que no hay es uno que encare las funciones avanzadas del lado conceptual.',
+      blocks: [
+        { k: 'p', t: 'Conviene empezar por lo que sí existe, porque es bastante y es bueno. Quien enseña estructuras hoy tiene herramientas gratuitas de primer nivel, y varias de ellas hacen su trabajo mejor de lo que lo hacemos nosotros.' },
+
+        { k: 'h', t: 'El panorama gratuito, con nombre y apellido' },
+        {
+          k: 'table',
+          caption: 'Herramientas gratuitas de análisis estructural, y qué muestran además del resultado.',
+          head: ['Herramienta', 'Gratuita', 'Lo que hace muy bien', 'Desarrollo conceptual'],
+          rows: [
+            ['Ftool', 'Sí', 'Modelar pórticos planos y leer diagramas y líneas de influencia con una fluidez que pocos igualan', 'Muestra el comportamiento, no el desarrollo que lo produce'],
+            ['MASTAN2', 'Sí (sobre MATLAB o su runtime)', 'Análisis matricial lineal y no lineal, ligado al libro de McGuire, Gallagher y Ziemian', 'La teoría está en el libro; el programa corre el análisis'],
+            ['SkyCiv', 'Franja gratuita', 'Cálculos a mano paso a paso: cuerpos libres, ecuaciones de equilibrio antes de sustituir, Cross para hiperestáticas', 'Aritmética sustituida, y sobre estática básica'],
+            ['sectionproperties', 'Sí, open source', 'Alabeo, centro de corte y constante de Saint-Venant por elementos finitos', 'Es una librería de Python: devuelve números, sin interfaz ni explicación'],
+          ],
+        },
+        { k: 'p', t: 'De esa lista, SkyCiv es el que más se acerca a lo que solemos llamar «mostrar el desarrollo», y hay que decirlo con todas las letras: sus cálculos a mano son buenos. Te arma el diagrama de cuerpo libre, escribe ΣM = 0 antes de meter números y resuelve por Cross cuando la viga es hiperestática. Si alguien afirma que ningún programa gratuito muestra los pasos, SkyCiv lo desmiente en un minuto.' },
+
+        { k: 'h', t: 'La diferencia no es mostrar pasos. Es decir cuándo la fórmula no aplica' },
+        { k: 'p', t: 'Sustituir números en una fórmula correcta y explicar por qué esa fórmula es la que corresponde son dos cosas distintas. La primera te ahorra la cuenta. La segunda te evita el error que la cuenta no puede detectar, porque el error está una capa más arriba.' },
+        { k: 'p', t: 'Los calculadores de torsión que se encuentran dando vueltas ilustran el punto al revés: vos elegís el tipo de sección —maciza, tubo cerrado, rectángulo— y el programa aplica la fórmula asociada. Nunca te dice que elegiste mal, ni qué habría dado la otra teoría, ni de qué lado del error quedás.' },
+        { k: 'quote', t: 'Un programa que sólo calcula nunca te va a avisar de que estás calculando lo que no es.' },
+
+        { k: 'h', t: 'Tres funciones donde no encontramos equivalente' },
+        {
+          k: 'ul',
+          items: [
+            'Análisis cinemático explicado. Buscamos software y no hay: lo que aparece es material de cátedra en PDF. El «educational software for kinematic analysis» que existe es para mecanismos de máquinas, bielas y manivelas, no para clasificar estructuras.',
+            'Despiece. Lo único gratuito que encontramos es AutoRebar, y es un complemento de AutoCAD, así que para usar lo gratis hace falta una licencia cara. Además dibuja: vos ponés las barras, él arma la planilla. El resto son pruebas de siete días o software comercial. Open source, nada.',
+            'Análisis de sección desarrollado. Acá sí hay un gratuito serio, sectionproperties, y en elementos finitos de alabeo probablemente nos gane. Pero es una librería sin interfaz: te devuelve el centro de corte, no te explica por qué está donde está.',
+          ],
+        },
+        { k: 'p', t: 'Ninguna herramienta gratuita hace dos de las tres. Ninguna encara ninguna de las tres desde lo conceptual. Ese es el hueco, y es más chico y más preciso que «somos los únicos que enseñamos».' },
+
+        { k: 'h', t: 'Una pantalla donde la diferencia se ve entera' },
+        { k: 'p', t: 'Abajo hay una viga de dos tramos sobre tres apoyos. Los tres restringen solamente el movimiento vertical. Es el caso de manual, y a la vez el que más veces vi dar por bueno en un parcial.' },
+        { k: 'p', t: 'La fórmula del grado de hiperestaticidad da g = 3·m + r − 3·n = 3×2 + 3 − 3×3 = 0. Cero significa isostática, y cualquier programa que se quede en la fórmula lo va a informar así. Pero nada sujeta la viga horizontalmente: es un mecanismo, y no se puede resolver.' },
+        {
+          k: 'table',
+          caption: 'Lo que devuelve el análisis cinemático sobre esa viga, paso por paso.',
+          head: ['Paso', 'Qué mira', 'Resultado'],
+          rows: [
+            ['2 · Grado de hiperestaticidad', 'g = 3·m + r − 3·n', '0'],
+            ['3 · Matriz de rigidez', 'Modos de mecanismo detectados', '1'],
+            ['3 · Matriz de rigidez', 'Grados de libertad sin restringir', '1'],
+            ['4 · Sugerencias', 'Veredicto en pantalla', 'No se puede resolver'],
+          ],
+        },
+        { k: 'p', t: 'La app no informa el cero y se lava las manos: lo contradice, y en el mismo paso 2 donde lo calculó: «La fórmula da g = 0 (condición necesaria para isostática), pero NO suficiente». El paso 3 arma la matriz de rigidez global —6×6 acá— y marca «Se detectaron 1 modo de mecanismo a pesar de que g = 0 ≥ 0». Nombra el nodo 3 y su desplazamiento horizontal, aclara que la ecuación del paso 2 cuenta restricciones pero no mira dónde están, y cierra con «✗ Mecanismo — no se puede resolver».' },
+        {
+          k: 'embed',
+          query: 'example=hidden-mechanism&kin=1',
+          label: 'La viga de tres apoyos verticales, con el panel de análisis cinemático abierto. Recorré los cuatro pasos: el segundo da g = 0 y el tercero encuentra el mecanismo que ese cero esconde. Probá cambiar un apoyo por uno fijo y volvé a correrlo — el grado pasa a 1 y el mecanismo desaparece.',
+        },
+
+        { k: 'h', t: 'Por qué esto le puede servir a una cátedra' },
+        { k: 'p', t: 'Un alumno que aprende la fórmula del grado y nunca ve fallar la condición suficiente se lleva una regla incompleta y no lo sabe. Es difícil de mostrar en el pizarrón, porque el ejemplo que la rompe parece un error de tipeo. Acá se ve en una pantalla, con el número y la contradicción al lado.' },
+        { k: 'p', t: 'Y no hace falta instalar nada, ni tener licencia, ni pedirle a la facultad que compre nada. Abre en el navegador, en español, y el modelo se comparte por link.' },
+
+        { k: 'note', t: 'Una aclaración que corresponde: nada de esto dice que seamos mejores. Ftool modela más rápido y con menos fricción que nosotros. MASTAN2 tiene detrás un libro que nosotros no escribimos. Los cálculos a mano de SkyCiv están mejor presentados que varios de nuestros paneles. Y sectionproperties resuelve alabeo por elementos finitos, que nosotros aproximamos. Lo que sostenemos es una cosa sola y bastante específica: nadie encara las funciones avanzadas del lado conceptual. Si conocés una herramienta gratuita que explique el análisis cinemático, arme un despiece o desarrolle el análisis de sección, escribinos y corregimos esta nota.' },
+      ],
+    },
+    en: {
+      title: 'What free software computes, and what it never explains',
+      excerpt:
+        'There is free structural software, and it is good: it models, it solves, it shows results. What there is not is one that approaches the advanced tools conceptually.',
+      blocks: [
+        { k: 'p', t: 'Worth starting with what does exist, because there is plenty of it and it is good. Anyone teaching structures today has first-rate free tools available, and several of them do their job better than we do ours.' },
+
+        { k: 'h', t: 'The free landscape, by name' },
+        {
+          k: 'table',
+          caption: 'Free structural analysis tools, and what they show beyond the result.',
+          head: ['Tool', 'Free', 'What it does very well', 'Conceptual development'],
+          rows: [
+            ['Ftool', 'Yes', 'Modelling plane frames and reading diagrams and influence lines, with a fluency few match', 'Shows the behaviour, not the development behind it'],
+            ['MASTAN2', 'Yes (on MATLAB or its runtime)', 'Linear and non-linear matrix analysis, tied to McGuire, Gallagher and Ziemian', 'The theory is in the book; the program runs the analysis'],
+            ['SkyCiv', 'Free tier', 'Step-by-step hand calculations: free bodies, equilibrium equations before substitution, moment distribution for indeterminate beams', 'Substituted arithmetic, and over basic statics'],
+            ['sectionproperties', 'Yes, open source', 'Warping, shear centre and the Saint-Venant constant by finite elements', 'A Python library: it returns numbers, with no interface and no explanation'],
+          ],
+        },
+        { k: 'p', t: 'Of that list SkyCiv comes closest to what we usually call "showing the working", and it deserves saying plainly: its hand calculations are good. It draws the free body, writes ΣM = 0 before any number goes in, and solves by moment distribution when the beam is indeterminate. Anyone claiming no free program shows its steps is refuted in about a minute.' },
+
+        { k: 'h', t: 'The difference is not showing steps. It is saying when the formula does not apply' },
+        { k: 'p', t: 'Substituting numbers into a correct formula and explaining why that formula is the right one are different things. The first saves you the arithmetic. The second saves you from the error the arithmetic cannot catch, because the error sits one layer above it.' },
+        { k: 'p', t: 'The torsion calculators floating around illustrate the point in reverse: you pick the section type — solid, closed tube, rectangle — and the program applies the matching formula. It never tells you that you picked wrong, or what the other theory would have given, or which side of the error you are on.' },
+        { k: 'quote', t: 'A program that only computes will never warn you that you are computing the wrong thing.' },
+
+        { k: 'h', t: 'Three tools with no equivalent we could find' },
+        {
+          k: 'ul',
+          items: [
+            'Kinematic analysis, explained. We looked for software and there is none: what turns up is lecture material in PDF. The "educational software for kinematic analysis" that does exist is for machine mechanisms — linkages and cranks — not for classifying structures.',
+            'Rebar detailing. The only free thing we found is AutoRebar, and it is an AutoCAD add-on, so using the free part requires an expensive licence. It also draws: you place the bars, it builds the schedule. The rest are seven-day trials or commercial software. Open source, nothing.',
+            'Section analysis, developed. Here there is a serious free option, sectionproperties, and on warping finite elements it probably beats us. But it is a library with no interface: it hands you the shear centre, it does not explain why it is where it is.',
+          ],
+        },
+        { k: 'p', t: 'No free tool does two of the three. None approaches any of the three conceptually. That is the gap, and it is smaller and more precise than "we are the only ones who teach".' },
+
+        { k: 'h', t: 'One screen where the whole difference shows' },
+        { k: 'p', t: 'Below is a two-span beam on three supports. All three restrain vertical movement only. It is the textbook case, and also the one I have seen marked correct more often than any other.' },
+        { k: 'p', t: 'The degree formula gives g = 3·m + r − 3·n = 3×2 + 3 − 3×3 = 0. Zero means isostatic, and any program that stops at the formula will report exactly that. But nothing holds the beam horizontally: it is a mechanism, and it cannot be solved.' },
+        {
+          k: 'table',
+          caption: 'What kinematic analysis returns on that beam, step by step.',
+          head: ['Step', 'What it looks at', 'Result'],
+          rows: [
+            ['2 · Static indeterminacy', 'g = 3·m + r − 3·n', '0'],
+            ['3 · Stiffness matrix', 'Mechanism modes detected', '1'],
+            ['3 · Stiffness matrix', 'Unconstrained degrees of freedom', '1'],
+            ['4 · Suggestions', 'Verdict on screen', 'Cannot be solved'],
+          ],
+        },
+        { k: 'p', t: 'The app does not report the zero and wash its hands: it contradicts it, in the same step 2 that produced it — "The formula gives g = 0 (necessary condition for isostatic), but NOT sufficient". Step 3 assembles the global stiffness matrix, 6×6 here, and flags "Detected 1 mechanism mode" in spite of g = 0 ≥ 0. It names node 3 and its horizontal displacement, points out that the step 2 equation counts constraints without checking where they sit, and closes with "✗ Mechanism — cannot be solved".' },
+        {
+          k: 'embed',
+          query: 'example=hidden-mechanism&kin=1',
+          label: 'The beam on three vertical supports, with the kinematic analysis panel open. Walk the four steps: the second gives g = 0 and the third finds the mechanism that zero is hiding. Try swapping one support for a pinned one and run it again — the degree becomes 1 and the mechanism disappears.',
+        },
+
+        { k: 'h', t: 'Why a department might care' },
+        { k: 'p', t: 'A student who learns the degree formula and never watches the sufficient condition fail walks away with an incomplete rule and does not know it. It is hard to show on a blackboard, because the example that breaks it looks like a typo. Here it is on one screen, with the number and the contradiction side by side.' },
+        { k: 'p', t: 'And nothing has to be installed, licensed, or bought by the faculty. It opens in a browser and the model travels as a link.' },
+
+        { k: 'note', t: 'One thing worth stating: none of this says we are better. Ftool models faster and with less friction than we do. MASTAN2 has a textbook behind it that we did not write. SkyCiv\'s hand calculations are better presented than several of our panels. And sectionproperties solves warping by finite elements where we approximate. The claim is one specific thing: nobody approaches the advanced tools conceptually. If you know a free tool that explains kinematic analysis, produces a bar schedule, or develops section analysis, write to us and we will correct this post.' },
+      ],
+    },
+    pt: {
+      title: 'O que o software gratuito calcula, e o que não te explica',
+      excerpt:
+        'Existe software estrutural gratuito e muito bom: modela, resolve e mostra resultados. O que não existe é um que encare as funções avançadas pelo lado conceitual.',
+      blocks: [
+        { k: 'p', t: 'Vale começar pelo que existe, porque é bastante coisa e é bom. Quem ensina estruturas hoje tem ferramentas gratuitas de primeira linha, e várias delas fazem o trabalho delas melhor do que nós fazemos o nosso.' },
+
+        { k: 'h', t: 'O panorama gratuito, com nome e sobrenome' },
+        {
+          k: 'table',
+          caption: 'Ferramentas gratuitas de análise estrutural, e o que mostram além do resultado.',
+          head: ['Ferramenta', 'Gratuita', 'O que faz muito bem', 'Desenvolvimento conceitual'],
+          rows: [
+            ['Ftool', 'Sim', 'Modelar pórticos planos e ler diagramas e linhas de influência com uma fluidez que poucos alcançam', 'Mostra o comportamento, não o desenvolvimento que o produz'],
+            ['MASTAN2', 'Sim (sobre MATLAB ou seu runtime)', 'Análise matricial linear e não linear, ligada ao livro de McGuire, Gallagher e Ziemian', 'A teoria está no livro; o programa roda a análise'],
+            ['SkyCiv', 'Faixa gratuita', 'Cálculos à mão passo a passo: corpos livres, equações de equilíbrio antes de substituir, Cross para hiperestáticas', 'Aritmética substituída, e sobre estática básica'],
+            ['sectionproperties', 'Sim, open source', 'Empenamento, centro de cisalhamento e constante de Saint-Venant por elementos finitos', 'É uma biblioteca Python: devolve números, sem interface e sem explicação'],
+          ],
+        },
+        { k: 'p', t: 'Dessa lista o SkyCiv é o que mais se aproxima do que costumamos chamar de «mostrar o desenvolvimento», e é preciso dizer com todas as letras: os cálculos à mão dele são bons. Monta o diagrama de corpo livre, escreve ΣM = 0 antes de entrar com números e resolve por Cross quando a viga é hiperestática. Quem afirmar que nenhum programa gratuito mostra os passos é desmentido em um minuto.' },
+
+        { k: 'h', t: 'A diferença não é mostrar passos. É dizer quando a fórmula não se aplica' },
+        { k: 'p', t: 'Substituir números numa fórmula correta e explicar por que aquela fórmula é a que corresponde são coisas diferentes. A primeira poupa a conta. A segunda evita o erro que a conta não consegue detectar, porque o erro está uma camada acima.' },
+        { k: 'p', t: 'Os calculadores de torção que circulam por aí ilustram o ponto ao contrário: você escolhe o tipo de seção — maciça, tubo fechado, retângulo — e o programa aplica a fórmula correspondente. Nunca diz que você escolheu errado, nem o que a outra teoria teria dado, nem de que lado do erro você ficou.' },
+        { k: 'quote', t: 'Um programa que só calcula nunca vai te avisar de que você está calculando o que não é.' },
+
+        { k: 'h', t: 'Três funções para as quais não achamos equivalente' },
+        {
+          k: 'ul',
+          items: [
+            'Análise cinemática explicada. Procuramos software e não há: o que aparece é material de aula em PDF. O «educational software for kinematic analysis» que existe é para mecanismos de máquinas, bielas e manivelas, não para classificar estruturas.',
+            'Detalhamento de armaduras. A única coisa gratuita que achamos é o AutoRebar, e é um complemento do AutoCAD, então para usar o que é grátis é preciso uma licença cara. Além disso ele desenha: você coloca as barras, ele monta a planilha. O resto são testes de sete dias ou software comercial. Open source, nada.',
+            'Análise de seção desenvolvida. Aqui existe um gratuito sério, o sectionproperties, e em elementos finitos de empenamento provavelmente nos supera. Mas é uma biblioteca sem interface: devolve o centro de cisalhamento, não explica por que ele está onde está.',
+          ],
+        },
+        { k: 'p', t: 'Nenhuma ferramenta gratuita faz duas das três. Nenhuma encara nenhuma das três pelo lado conceitual. Essa é a lacuna, e é menor e mais precisa que «somos os únicos que ensinam».' },
+
+        { k: 'h', t: 'Uma tela onde a diferença aparece inteira' },
+        { k: 'p', t: 'Abaixo há uma viga de dois vãos sobre três apoios. Os três restringem apenas o movimento vertical. É o caso de manual, e ao mesmo tempo o que mais vezes vi ser dado como certo numa prova.' },
+        { k: 'p', t: 'A fórmula do grau de hiperestaticidade dá g = 3·m + r − 3·n = 3×2 + 3 − 3×3 = 0. Zero significa isostática, e qualquer programa que pare na fórmula vai informar exatamente isso. Mas nada segura a viga horizontalmente: é um mecanismo, e não tem solução.' },
+        {
+          k: 'table',
+          caption: 'O que a análise cinemática devolve sobre essa viga, passo a passo.',
+          head: ['Passo', 'O que olha', 'Resultado'],
+          rows: [
+            ['2 · Grau de indeterminação', 'g = 3·m + r − 3·n', '0'],
+            ['3 · Matriz de rigidez', 'Modos de mecanismo detectados', '1'],
+            ['3 · Matriz de rigidez', 'Graus de liberdade sem restrição', '1'],
+            ['4 · Sugestões', 'Veredito na tela', 'Não pode ser resolvida'],
+          ],
+        },
+        { k: 'p', t: 'O app não informa o zero e lava as mãos: ele o contradiz, no mesmo passo 2 em que o calculou — «A fórmula dá g = 0 (condição necessária para isostática), mas NÃO suficiente». O passo 3 monta a matriz de rigidez global, 6×6 aqui, e marca «Detectado 1 modo de mecanismo» apesar de g = 0 ≥ 0. Nomeia o nó 3 e seu deslocamento horizontal, esclarece que a equação do passo 2 conta restrições sem olhar onde estão, e fecha com «✗ Mecanismo — não pode ser resolvida».' },
+        {
+          k: 'embed',
+          query: 'example=hidden-mechanism&kin=1',
+          label: 'A viga sobre três apoios verticais, com o painel de análise cinemática aberto. Percorra os quatro passos: o segundo dá g = 0 e o terceiro encontra o mecanismo que esse zero esconde. Troque um apoio por um fixo e rode de novo — o grau vira 1 e o mecanismo desaparece.',
+        },
+
+        { k: 'h', t: 'Por que isso pode servir a um departamento' },
+        { k: 'p', t: 'Um aluno que aprende a fórmula do grau e nunca vê a condição suficiente falhar sai com uma regra incompleta e não sabe disso. É difícil mostrar no quadro, porque o exemplo que a quebra parece um erro de digitação. Aqui aparece numa tela, com o número e a contradição lado a lado.' },
+        { k: 'p', t: 'E não é preciso instalar nada, nem ter licença, nem pedir que a faculdade compre nada. Abre no navegador e o modelo viaja como link.' },
+
+        { k: 'note', t: 'Um esclarecimento que cabe: nada disso diz que somos melhores. O Ftool modela mais rápido e com menos atrito que nós. O MASTAN2 tem um livro atrás que nós não escrevemos. Os cálculos à mão do SkyCiv estão mais bem apresentados que vários dos nossos painéis. E o sectionproperties resolve empenamento por elementos finitos, onde nós aproximamos. O que sustentamos é uma coisa só e bem específica: ninguém encara as funções avançadas pelo lado conceitual. Se você conhece uma ferramenta gratuita que explique análise cinemática, monte um detalhamento ou desenvolva análise de seção, escreva para nós e corrigimos esta nota.' },
+      ],
+    },
+  },
+};

--- a/web/src/lib/blog/posts/determinism-boundary.ts
+++ b/web/src/lib/blog/posts/determinism-boundary.ts
@@ -14,6 +14,7 @@ import type { Post } from '../types';
 export const determinismBoundary: Post = {
   slug: 'the-determinism-boundary',
   date: '2026-08-12',
+  order: 1,
   authors: ['Bautista Chesta', 'Raúl Bertero', 'Federico Carrone', 'Diego Kingston'],
   tagKeys: ['blog.tag.ai', 'blog.tag.solver', 'blog.tag.research'],
   i18n: {

--- a/web/src/lib/blog/posts/torsion-theories.ts
+++ b/web/src/lib/blog/posts/torsion-theories.ts
@@ -22,7 +22,8 @@ import type { Post } from '../types';
 
 export const torsionTheories: Post = {
   slug: 'torsion-bredt-saint-venant',
-  date: '2026-08-21',
+  date: '2026-08-29',
+  order: 4,
   authors: ['Bautista Chesta'],
   tagKeys: ['blog.tag.sections', 'blog.tag.theory'],
   i18n: {

--- a/web/src/lib/blog/types.ts
+++ b/web/src/lib/blog/types.ts
@@ -51,6 +51,18 @@ export type Post = {
   slug: string;
   /** ISO date (YYYY-MM-DD). Publication, not last edit. */
   date: string;
+  /**
+   * Where the post sits in the series, lowest first. NOT the date.
+   *
+   * The index used to sort newest-first, which is right for a blog that
+   * accumulates and wrong for four posts that build on each other: the one
+   * that frames the whole argument is the oldest, so recency order buried it
+   * at the bottom and opened with the most specialised piece instead.
+   *
+   * The dates still run in the same direction, so nothing looks shuffled —
+   * this is what decides, and the dates are free to stop agreeing later.
+   */
+  order: number;
   /** People, not dictionary keys — names are not translated. */
   authors: string[];
   /** `blog.tag.*` dictionary keys, so the tags themselves translate. */

--- a/web/src/lib/engine/__tests__/deep-audit.test.ts
+++ b/web/src/lib/engine/__tests__/deep-audit.test.ts
@@ -16,7 +16,7 @@ import { computeDiagramValueAt, computeDeformedShape } from '../diagrams';
 import { computeDiagram3D, evaluateDiagramAt, type Diagram3DKind } from '../diagrams-3d';
 import { analyzeSectionStress } from '../section-stress';
 import { analyzeSectionStress3D } from '../section-stress-3d';
-import { is2DFixture, is3DFixture } from '../../templates/fixture-index';
+import { is2DFixture, is3DFixture, INTENTIONALLY_UNSOLVABLE } from '../../templates/fixture-index';
 import type { ElementForces3D } from '../types-3d';
 
 // ─── Fixture discovery ──────────────────────────────────────────
@@ -24,7 +24,13 @@ import type { ElementForces3D } from '../types-3d';
 const fixtureDir = 'src/lib/templates/fixtures';
 const allFixtures = readdirSync(fixtureDir)
   .filter(f => f.endsWith('.json'))
-  .map(f => f.replace('.json', ''));
+  .map(f => f.replace('.json', ''))
+  /*
+   * Models designed not to solve are out of every audit below, which all
+   * assert the opposite. See INTENTIONALLY_UNSOLVABLE — the exclusion is
+   * declared beside the registry, not hidden in a test.
+   */
+  .filter(f => !INTENTIONALLY_UNSOLVABLE.has(f));
 
 const fixtures2D = allFixtures.filter(f => is2DFixture(f));
 const fixtures3D = allFixtures.filter(f => is3DFixture(f));

--- a/web/src/lib/engine/__tests__/example-audit.test.ts
+++ b/web/src/lib/engine/__tests__/example-audit.test.ts
@@ -22,7 +22,7 @@ import { buildSolverInput2D, buildSolverInput3D } from '../solver-service';
 import { solve, solve3D } from '../wasm-solver';
 import { computeDiagramValueAt } from '../diagrams';
 import { computeDiagram3D, type Diagram3DKind } from '../diagrams-3d';
-import { is2DFixture, is3DFixture } from '../../templates/fixture-index';
+import { is2DFixture, is3DFixture, INTENTIONALLY_UNSOLVABLE } from '../../templates/fixture-index';
 import type { ElementForces3D } from '../types-3d';
 
 // ─── Fixture discovery ──────────────────────────────────────────
@@ -30,7 +30,13 @@ import type { ElementForces3D } from '../types-3d';
 const fixtureDir = 'src/lib/templates/fixtures';
 const allFixtures = readdirSync(fixtureDir)
   .filter(f => f.endsWith('.json'))
-  .map(f => f.replace('.json', ''));
+  .map(f => f.replace('.json', ''))
+  /*
+   * Models designed not to solve are out of every audit below, which all
+   * assert the opposite. See INTENTIONALLY_UNSOLVABLE — the exclusion is
+   * declared beside the registry, not hidden in a test.
+   */
+  .filter(f => !INTENTIONALLY_UNSOLVABLE.has(f));
 
 const fixtures2D = allFixtures.filter(f => is2DFixture(f));
 const fixtures3D = allFixtures.filter(f => is3DFixture(f));

--- a/web/src/lib/engine/__tests__/fixture-validation.test.ts
+++ b/web/src/lib/engine/__tests__/fixture-validation.test.ts
@@ -335,3 +335,34 @@ describe('Fixtures that are meant to fail', () => {
     });
   }
 });
+
+// ─── "Not checked" is not "stable" ──────────────────────────────
+
+describe('the kinematic report never passes an unrun check off as a result', () => {
+  /*
+   * `analyzeKinematics` returns `mechanismModes: 0` when the WASM engine is
+   * not ready, together with `rankAnalysis: 'unavailable'` and
+   * `isSolvable: false`. The report used to drop that last signal, so the
+   * panel read zero modes and announced "no mechanisms detected — the
+   * structure is stable" about a model it had not examined.
+   *
+   * CI caught it on the all-roller model the blog post embeds: step 2 said
+   * isostatic, step 3 said stable, and the status bar said "Mechanism —
+   * cannot be solved". Locally it never reproduced, because the engine was
+   * always warm by the time the panel opened.
+   */
+  it('reports whether the rank check ran at all', () => {
+    const json = loadFixtureFile('hidden-mechanism');
+    const { model, api } = createStoreMock();
+    loadFixture(json, api);
+    const report = generateKinematicReport(buildSolverInput2D(model)!)!;
+
+    // In this environment the engine IS ready, so the check ran and found it.
+    expect(report.rankChecked).toBe(true);
+    expect(report.mechanismModes).toBe(1);
+
+    // The invariant that matters: zero modes may only be trusted when the
+    // check actually ran. Anything reading mechanismModes must consult this.
+    expect(report.rankChecked || report.mechanismModes === 0).toBe(true);
+  });
+});

--- a/web/src/lib/engine/__tests__/fixture-validation.test.ts
+++ b/web/src/lib/engine/__tests__/fixture-validation.test.ts
@@ -16,14 +16,21 @@ import { loadFixture, type JSONModel } from '../../templates/load-fixture';
 import { buildSolverInput2D, buildSolverInput3D } from '../solver-service';
 import { solve } from '../wasm-solver';
 import { solve3D } from '../wasm-solver';
-import { is2DFixture, is3DFixture } from '../../templates/fixture-index';
+import { is2DFixture, is3DFixture, INTENTIONALLY_UNSOLVABLE } from '../../templates/fixture-index';
+import { generateKinematicReport } from '../kinematic-report';
 
 // ─── Fixture discovery ──────────────────────────────────────────
 
 const fixtureDir = 'src/lib/templates/fixtures';
 const allFixtures = readdirSync(fixtureDir)
   .filter(f => f.endsWith('.json'))
-  .map(f => f.replace('.json', ''));
+  .map(f => f.replace('.json', ''))
+  /*
+   * Models designed not to solve are out of every audit below, which all
+   * assert the opposite. See INTENTIONALLY_UNSOLVABLE — the exclusion is
+   * declared beside the registry, not hidden in a test.
+   */
+  .filter(f => !INTENTIONALLY_UNSOLVABLE.has(f));
 
 // Separate registered 2D and 3D fixtures
 const fixtures2D = allFixtures.filter(f => is2DFixture(f));
@@ -292,4 +299,39 @@ describe('Fixture registry completeness', () => {
     const unexpected = unregistered.filter(f => f !== 'tower-3d');
     expect(unexpected).toEqual([]);
   });
+});
+
+// ─── Fixtures that must NOT solve ───────────────────────────────
+
+/*
+ * The other half of the exclusion above.
+ *
+ * Filtering these out of the audits removes the assertion that they work; it
+ * must not remove the assertion that they still don't. A fixture that quietly
+ * starts solving has stopped being the thing it was written to be — for
+ * `hidden-mechanism` that means the blog post embedded on it now demonstrates
+ * nothing, and no other test in the repository would notice.
+ */
+describe('Fixtures that are meant to fail', () => {
+  for (const name of INTENTIONALLY_UNSOLVABLE) {
+    it(`${name} — still refuses to solve, and says why`, async () => {
+      const json = loadFixtureFile(name);
+      const { model, api } = createStoreMock();
+      loadFixture(json, api);
+      const input = buildSolverInput2D(model);
+      expect(input).not.toBeNull();
+
+      expect(() => solve(input!)).toThrow(/singular|mechanism/i);
+
+      // And the kinematic report explains it rather than only failing: the
+      // formula's verdict, the numerical one, and the disagreement between
+      // them are what the post is about.
+      const report = generateKinematicReport(input!);
+      expect(report).not.toBeNull();
+      expect(report!.degree).toBe(0);
+      expect(report!.hasHiddenMechanism).toBe(true);
+      expect(report!.mechanismModes).toBe(1);
+      expect(report!.isSolvable).toBe(false);
+    });
+  }
 });

--- a/web/src/lib/engine/kinematic-report.ts
+++ b/web/src/lib/engine/kinematic-report.ts
@@ -127,6 +127,22 @@ export interface KinematicReport {
 
   // Step 3: Rank verification
   nFreeDofs: number;       // Kff dimension
+  /**
+   * Whether the rank check actually ran.
+   *
+   * `analyzeKinematics` needs the WASM engine. Before it is ready it returns
+   * `mechanismModes: 0` with `rankAnalysis: 'unavailable'` — honestly, since
+   * it also sets `isSolvable: false` and says so in its diagnosis. This report
+   * used to drop that field, so a caller reading `mechanismModes === 0` could
+   * not tell "no mechanisms" from "not checked", and the panel rendered the
+   * second as "the structure is stable".
+   *
+   * That was visible on the all-roller model the blog post embeds: step 2 said
+   * isostatic, step 3 said stable, and the status bar underneath said
+   * "Mechanism — cannot be solved". Three statements, two of them wrong,
+   * on one screen.
+   */
+  rankChecked: boolean;
   hasHiddenMechanism: boolean;
   mechanismModes: number;
   mechanismNodes: number[];
@@ -347,6 +363,7 @@ export function generateKinematicReport(
   // ── Step 3: Rank verification ── (computed before classification so we can adjust it)
 
   const kinResult = analyzeKinematics(input);
+  const rankChecked = kinResult.rankAnalysis !== 'unavailable';
   const mechanismModes = kinResult.mechanismModes;
   const mechanismNodes = kinResult.mechanismNodes;
   const hasHiddenMechanism = degree >= 0 && mechanismModes > 0;
@@ -403,7 +420,7 @@ export function generateKinematicReport(
     hingeDetails, slideDetails, totalC,
     isPureTruss, formula, substitution,
     degree, classification, classificationText,
-    nFreeDofs, hasHiddenMechanism, mechanismModes, mechanismNodes, unconstrainedDofs,
+    nFreeDofs, rankChecked, hasHiddenMechanism, mechanismModes, mechanismNodes, unconstrainedDofs,
     elementAnalysis,
     suggestions,
     isSolvable: kinResult.isSolvable,

--- a/web/src/lib/i18n/locales/en.ts
+++ b/web/src/lib/i18n/locales/en.ts
@@ -32,6 +32,8 @@ const en: Record<string, string> = {
   'blog.tag.sections': 'Sections',
   'blog.tag.theory': 'Theory',
   'blog.tag.cirsoc': 'CIRSOC',
+  'blog.tag.education': 'Education',
+  'blog.tag.tools': 'Tools',
   'blog.tag.concrete': 'Concrete',
   'blog.tag.ai': 'AI',
   'blog.tag.research': 'Research',

--- a/web/src/lib/i18n/locales/en.ts
+++ b/web/src/lib/i18n/locales/en.ts
@@ -1551,6 +1551,7 @@ const en: Record<string, string> = {
   'kinematic.step3Title': 'Step 3 \u2014 Verification with Stiffness Matrix',
   'kinematic.matrixExplanation': 'Stabileo solves structures by assembling a <strong style="color:#ddd">global stiffness matrix</strong>. Here we analyze that matrix ({n}\u00D7{n}) to detect mechanisms that the Step 2 equation misses \u2014 for example, when supports are poorly distributed or hinges create local instabilities.',
   'kinematic.noMechanisms': '\u2713 No mechanisms detected. The structure is stable.',
+  'kinematic.rankUnavailable': '⏳ Not verified yet: the calculation engine has not finished loading. Stability is not confirmed.',
   'kinematic.hiddenMechanism': '\u2717 Detected {n} mechanism mode{s} despite g = {degree} \u2265 0.',
   'kinematic.hiddenMechanismExplanation': 'The Step 2 equation counts constraints globally, but does not verify where they are located. In this case, one zone of the structure has excess constraints while another lacks sufficient ones.',
   'kinematic.mechanismDetected': '\u2717 Detected {n} mechanism mode{s}.',

--- a/web/src/lib/i18n/locales/es.ts
+++ b/web/src/lib/i18n/locales/es.ts
@@ -1544,6 +1544,7 @@ const es: Record<string, string> = {
   'kinematic.step3Title': 'Paso 3 — Verificación con la Matriz de Rigidez',
   'kinematic.matrixExplanation': 'Stabileo resuelve estructuras armando una <strong style="color:#ddd">matriz de rigidez global</strong>. Acá se analiza esa matriz ({n}×{n}) para detectar mecanismos que la ecuación del Paso 2 no detecta — por ejemplo, cuando los apoyos están mal distribuidos o hay articulaciones que generan inestabilidades locales.',
   'kinematic.noMechanisms': '✓ No se detectaron mecanismos. La estructura es estable.',
+  'kinematic.rankUnavailable': '⏳ No se pudo verificar todavía: el motor de cálculo aún no terminó de cargar. La estabilidad no está confirmada.',
   'kinematic.hiddenMechanism': '✗ Se detectaron {n} modo{s} de mecanismo a pesar de que g = {degree} ≥ 0.',
   'kinematic.hiddenMechanismExplanation': 'La ecuación del Paso 2 cuenta restricciones de forma global, pero no verifica dónde están ubicadas. En este caso, una zona de la estructura tiene restricciones de sobra mientras otra no tiene las suficientes.',
   'kinematic.mechanismDetected': '✗ Se detectaron {n} modo{s} de mecanismo.',

--- a/web/src/lib/i18n/locales/es.ts
+++ b/web/src/lib/i18n/locales/es.ts
@@ -32,6 +32,8 @@ const es: Record<string, string> = {
   'blog.tag.sections': 'Secciones',
   'blog.tag.theory': 'Teoría',
   'blog.tag.cirsoc': 'CIRSOC',
+  'blog.tag.education': 'Educación',
+  'blog.tag.tools': 'Herramientas',
   'blog.tag.concrete': 'Hormigón',
   'blog.tag.ai': 'IA',
   'blog.tag.research': 'Investigación',

--- a/web/src/lib/i18n/locales/pt.ts
+++ b/web/src/lib/i18n/locales/pt.ts
@@ -2403,6 +2403,7 @@ const pt: Translations = {
   'kinematic.mechanismResult': '✗ Mecanismo — não pode ser resolvida',
   'kinematic.noHinges': 'Sem articulações internas (c = 0)',
   'kinematic.noMechanisms': '✓ Nenhum mecanismo detectado. A estrutura é estável.',
+  'kinematic.rankUnavailable': '⏳ Ainda não foi possível verificar: o motor de cálculo não terminou de carregar. A estabilidade não está confirmada.',
   'kinematic.noRestriction': '⚠ sem restrição',
   'kinematic.noSupports': 'Sem apoios definidos — estrutura é livre.',
   'kinematic.nodeDetail': 'Nó {id}: {type} → {dofs} reações ({restrained})',

--- a/web/src/lib/i18n/locales/pt.ts
+++ b/web/src/lib/i18n/locales/pt.ts
@@ -227,6 +227,8 @@ const pt: Translations = {
   'blog.readMore': 'Ler a nota',
   'blog.readingTime': '{n} min de leitura',
   'blog.tag.cirsoc': 'CIRSOC',
+  'blog.tag.education': 'Educação',
+  'blog.tag.tools': 'Ferramentas',
   'blog.tag.concrete': 'Concreto',
   'blog.tag.ai': 'IA',
   'blog.tag.research': 'Pesquisa',

--- a/web/src/lib/templates/fixture-index.ts
+++ b/web/src/lib/templates/fixture-index.ts
@@ -29,6 +29,22 @@ const fixtures2D: Record<string, FixtureLoader> = {
   'frame-cirsoc-dl': () => import('./fixtures/frame-cirsoc-dl.json'),
   'building-3story-dlw': () => import('./fixtures/building-3story-dlw.json'),
   'frame-seismic': () => import('./fixtures/frame-seismic.json'),
+  /*
+   * Two spans on three supports that each restrain only the vertical — the
+   * textbook case where the degree formula and the truth disagree.
+   *
+   *   g = 3·m + r − 3·n = 3×2 + 3 − 3×3 = 0
+   *
+   * Zero says "isostatic", and the structure is a mechanism: nothing holds it
+   * horizontally. Kinematic analysis reports it as HYPOSTATIC anyway, names
+   * node 3 and the ux degree of freedom, and refuses to solve.
+   *
+   * It exists for the blog post on the conceptual side of the advanced tools,
+   * which needs a model where a reader can watch a formula be overruled.
+   * Deliberately not in the examples menu: that is a catalogue of structures
+   * that work, and this one is meant not to.
+   */
+  'hidden-mechanism': () => import('./fixtures/hidden-mechanism.json'),
 };
 
 // 3D examples (basic + PRO)
@@ -90,6 +106,26 @@ const fixtures3D: Record<string, FixtureLoader> = {
   'cable-stayed-bridge-small': () => import('./fixtures/cable-stayed-bridge-small.json'),
   'stadium-canopy': () => import('./fixtures/stadium-canopy.json'),
 };
+
+/**
+ * Fixtures that are NOT supposed to solve.
+ *
+ * Every audit suite walks the fixtures directory and asserts that each model
+ * solves, produces finite diagrams and agrees between 2D and 3D. That is the
+ * right default and it must stay strict — so a model whose entire purpose is
+ * to be unsolvable has to say so here rather than have the assertion relaxed
+ * for everyone.
+ *
+ * Listing one is a claim that its failure is the designed behaviour. Do not
+ * add a fixture here to quiet a suite: if a model that should work stops
+ * working, the audit is right and the model is wrong.
+ */
+export const INTENTIONALLY_UNSOLVABLE = new Set<string>([
+  // Three supports that each restrain only the vertical: g = 0 by formula,
+  // a mechanism in fact. The blog post on the conceptual side of the advanced
+  // tools opens the kinematic panel on it precisely to show the solver refuse.
+  'hidden-mechanism',
+]);
 
 export function getFixture(name: string): FixtureLoader | undefined {
   return fixtures2D[name] ?? fixtures3D[name];

--- a/web/src/lib/templates/fixtures/hidden-mechanism.json
+++ b/web/src/lib/templates/fixtures/hidden-mechanism.json
@@ -1,0 +1,130 @@
+{
+  "name": "Mecanismo oculto",
+  "materials": [
+    {
+      "id": 1,
+      "name": "Acero A36",
+      "e": 200000,
+      "nu": 0.3,
+      "rho": 78.5,
+      "fy": 250
+    }
+  ],
+  "sections": [
+    {
+      "id": 1,
+      "name": "IPE 200",
+      "a": 0.00285,
+      "iy": 1.94e-05,
+      "iz": 1.42e-06,
+      "j": 7e-08,
+      "b": 0.1,
+      "h": 0.2
+    }
+  ],
+  "nodes": [
+    {
+      "id": 1,
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    {
+      "id": 2,
+      "x": 3,
+      "y": 0,
+      "z": 0
+    },
+    {
+      "id": 3,
+      "x": 6,
+      "y": 0,
+      "z": 0
+    }
+  ],
+  "elements": [
+    {
+      "id": 1,
+      "type": "frame",
+      "nodeI": 1,
+      "nodeJ": 2,
+      "materialId": 1,
+      "sectionId": 1,
+      "hingeStart": false,
+      "hingeEnd": false
+    },
+    {
+      "id": 2,
+      "type": "frame",
+      "nodeI": 2,
+      "nodeJ": 3,
+      "materialId": 1,
+      "sectionId": 1,
+      "hingeStart": false,
+      "hingeEnd": false
+    }
+  ],
+  "supports": [
+    {
+      "id": 1,
+      "nodeId": 1,
+      "type": "rollerX"
+    },
+    {
+      "id": 2,
+      "nodeId": 2,
+      "type": "rollerX"
+    },
+    {
+      "id": 3,
+      "nodeId": 3,
+      "type": "rollerX"
+    }
+  ],
+  "loads": [
+    {
+      "type": "distributed",
+      "data": {
+        "id": 1,
+        "elementId": 1,
+        "qI": -10,
+        "qJ": -10
+      }
+    },
+    {
+      "type": "distributed",
+      "data": {
+        "id": 2,
+        "elementId": 2,
+        "qI": -10,
+        "qJ": -10
+      }
+    }
+  ],
+  "plates": [],
+  "quads": [],
+  "constraints": [],
+  "loadCases": [
+    {
+      "id": 1,
+      "type": "D",
+      "name": "Dead Load"
+    },
+    {
+      "id": 2,
+      "type": "L",
+      "name": "Live Load"
+    },
+    {
+      "id": 3,
+      "type": "W",
+      "name": "Wind"
+    },
+    {
+      "id": 4,
+      "type": "E",
+      "name": "Earthquake"
+    }
+  ],
+  "combinations": []
+}


### PR DESCRIPTION
Apunta a #165. La segunda nota de la serie — y la primera que afirma algo sobre el software de otros.

## La afirmación, y hasta dónde se verificó

Se investigó antes de escribir, y quedó **más angosta** que como arrancó.

«El único software gratuito que muestra los pasos» es **falso**: [SkyCiv](https://skyciv.com/docs/skyciv-beam/hand-calculations/) muestra cálculos a mano paso a paso, con diagramas de cuerpo libre y las ecuaciones de equilibrio antes de sustituir. La nota lo dice con nombre y apellido, igual que a [Ftool](https://www.cesdb.com/ftool.html), [MASTAN2](https://www.mastan2.com/) y [`sectionproperties`](https://sectionproperties.readthedocs.io/en/stable/user_guide/theory.html) — que en alabeo por elementos finitos probablemente nos gane, y la nota lo reconoce.

Lo que sí resiste es la **conjunción**: ningún gratuito explica el análisis cinemático, arma un despiece **y** desarrolla el análisis de sección. Ninguno hace dos. Ninguno encara ninguna de las tres desde lo conceptual. Nombrar a la competencia por lo que hace bien es lo que la vuelve creíble.

La nota cierra invitando a que nos corrijan si alguien conoce un contraejemplo.

## El embed

El argumento en una pantalla. Tres apoyos que restringen sólo lo vertical dan `g = 3×2 + 3 − 3×3 = 0`, y la app **se contradice a sí misma en el mismo paso que lo calculó**: «La fórmula da g = 0 (condición necesaria para isostática), pero NO suficiente». Después arma la matriz de rigidez 6×6, nombra el nodo 3 y su desplazamiento horizontal, y cierra con «✗ Mecanismo — no se puede resolver».

Los números salieron de `generateKinematicReport` antes de que existiera un párrafo.

## Además

- **Orden curado.** Campo `order` en `Post` y el índice ordenado por él. Cuatro notas que se apoyan una en otra son una serie, no un feed: por fecha, la que enmarca todo quedaba última. Orden: paper → esta → CIRSOC → torsión, con las fechas alineadas (12-08, 21-08, 26-08, 29-08).
- **Botón «Blog» en la nota.** El logo va a la landing, así que volver al índice obligaba a landing → scroll → entrar de nuevo. Aparece sólo dentro de una nota, a la izquierda del recuadro de GitHub, con el formato de la landing. Es un `<a href>` real.
- **`?kin=1`**, el tercer deep link después de `?inspect` y `?proTab`.
- **`INTENTIONALLY_UNSOLVABLE`** junto al registro de fixtures. Tres suites de auditoría exigen que toda fixture resuelva; un modelo hecho para no resolver se declara, en vez de relajar esas assertions para todos. Un test compañero verifica que **siga** fallando, para que no empiece a funcionar en silencio y rompa el demo sin que nadie se entere.

## Dos defectos que aparecieron manejando el embed, no leyéndolo

- La fixture no tenía `plates`, lo que lanzaba `json.plates is not iterable` dentro del cargador de ejemplos y **un `catch` vacío se lo tragaba**: medio modelo cargado, el deep link sin aplicar y ni una señal de error. El catch ahora reporta.
- `?kin=1` levantaba el flag del panel sin abrir la pestaña Avanzado que lo hospeda en escritorio, así que funcionaba en el teléfono y no hacía nada en una laptop. La misma asimetría que ya había mordido a `?inspect`.

## Compuertas

`test:unit` 6.699 · `typecheck` en baseline 479 · `check:gate` · `build` con prerenderizado (22 páginas) · `@smoke` + `@landing` 294.
