### PR TITLE
perf(engine): factor the tangent once per displacement-control iteration

### DIFF
--- a/engine/src/solver/arc_length.rs
+++ b/engine/src/solver/arc_length.rs
@@ -419,15 +419,16 @@ pub fn solve_displacement_control(input: &DisplacementControlInput) -> Result<Di
                 break;
             }
 
-            // Solve augmented system:
-            // K_T * δu_r = R
-            // K_T * δu_t = f_ref
+            // Two-system solve with a single factorization per iteration:
+            // K_T * δu_r = R   (residual correction)
+            // K_T * δu_t = f_ref (tangent correction)
             let free_idx: Vec<usize> = (0..nf).collect();
             let k_ff = extract_submatrix(&k_t, n, &free_idx, &free_idx);
             let k_s_dc = if let Some(ref cs) = cs_dc { cs.reduce_matrix(&k_ff) } else { k_ff };
             let residual_s = if let Some(ref cs) = cs_dc { cs.reduce_vector(&residual) } else { residual.clone() };
-            let du_r_s = solve_system(&k_s_dc, &residual_s, ns_dc)?;
-            let du_t_s = solve_system(&k_s_dc, &f_ref_s_dc, ns_dc)?;
+            let tangent = factor_tangent(&k_s_dc, ns_dc)?;
+            let du_r_s = solve_with_tangent(&tangent, &residual_s, ns_dc)?;
+            let du_t_s = solve_with_tangent(&tangent, &f_ref_s_dc, ns_dc)?;
             let du_r = if let Some(ref cs) = cs_dc { cs.expand_solution(&du_r_s) } else { du_r_s };
             let du_t = if let Some(ref cs) = cs_dc { cs.expand_solution(&du_t_s) } else { du_t_s };
 
@@ -507,22 +508,10 @@ fn dot_product(a: &[f64], b: &[f64]) -> f64 {
     a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
 }
 
-fn solve_system(k_ff: &[f64], rhs: &[f64], nf: usize) -> Result<Vec<f64>, String> {
-    let mut k_work = k_ff.to_vec();
-    match cholesky_solve(&mut k_work, rhs, nf) {
-        Some(u) => Ok(u),
-        None => {
-            let mut k_work = k_ff.to_vec();
-            let mut f_work = rhs.to_vec();
-            lu_solve(&mut k_work, &mut f_work, nf)
-                .ok_or_else(|| "Singular tangent stiffness".to_string())
-        }
-    }
-}
-
 /// Tangent stiffness factored once, reusable for multiple right-hand sides.
-/// Same decompositions as `solve_system` (Cholesky with LU fallback), so
-/// solving two RHS with one factor gives identical results to factoring twice.
+/// Both decompositions (Cholesky with LU fallback) match what the previous
+/// per-RHS solve did, so one factor for two RHS gives identical results to
+/// factoring twice.
 enum FactoredTangent {
     /// Cholesky factor L (lower triangle stored in n*n array)
     Cholesky { l: Vec<f64> },
@@ -573,7 +562,8 @@ fn factor_tangent(k_ff: &[f64], nf: usize) -> Result<FactoredTangent, String> {
 }
 
 /// Solve with a pre-factored tangent. The substitution steps are identical to
-/// `cholesky_solve` / `lu_solve`, so results match `solve_system` bit for bit.
+/// `cholesky_solve` / `lu_solve`, so results match a fresh per-RHS solve bit
+/// for bit.
 fn solve_with_tangent(factored: &FactoredTangent, rhs: &[f64], nf: usize) -> Result<Vec<f64>, String> {
     match factored {
         FactoredTangent::Cholesky { l } => {


### PR DESCRIPTION
Follow-up noted in #74: `solve_displacement_control` kept the old double-solve pattern.

## What changed

The Newton iteration in `solve_displacement_control` solved both right-hand sides — `K_T·δu_r = R` and `K_T·δu_t = f_ref` — with two independent `solve_system` calls: two full Cholesky factorizations (or LU, on the fallback) of the same matrix per iteration.

`solve_arc_length` already does this right: `factor_tangent` once per iteration, then both RHS against the stored factor. Displacement control now uses the same pattern. The substitution steps in `solve_with_tangent` are the same ones `cholesky_solve` / `lu_solve` run, so results are bit-identical to the double factorization — no expectation changes.

`solve_system` lost its last caller and is removed; the `FactoredTangent` docstrings that referenced it now describe the equivalence without naming a dead function.

## Verification

- `cargo test -p dedaliano-engine`: full suite green, every target, 0 failures.
- `arc_length` domain (covers both solvers): 10/10.
- `cargo clippy -p dedaliano-engine --lib`: 333 warnings before and after — none new.
- `cargo check --features parallel`: clean.