### PR TITLE
perf(engine): precomputed permutation map — numeric Cholesky without re-sorting

### DIFF
--- a/engine/src/linalg/sparse.rs
+++ b/engine/src/linalg/sparse.rs
@@ -123,6 +123,17 @@ impl CscMatrix {
 
     /// Apply symmetric permutation: B = P*A*P^T.
     /// perm[new_i] = old_i.
+    ///
+    /// KEPT ON PURPOSE, though nothing in the solver calls it any more: the
+    /// symbolic phase now precomputes a permutation map and the numeric phase
+    /// gathers through it, so this is only reached from the reference oracle in
+    /// `sparse_chol`'s tests — which is exactly its value. That oracle is what
+    /// checks the map against the straightforward permute-and-sort it replaced.
+    /// Delete this and the tests lose the independent implementation they
+    /// compare against, which is the opposite of what removing dead code is for.
+    ///
+    /// Note for anyone reusing it: unlike the map, this goes through
+    /// `from_triplets` and therefore SUMS duplicate (row, col) entries.
     pub fn permute_symmetric(&self, perm: &[usize]) -> CscMatrix {
         let n = self.n;
         assert_eq!(perm.len(), n);

--- a/engine/src/linalg/sparse_chol.rs
+++ b/engine/src/linalg/sparse_chol.rs
@@ -29,6 +29,14 @@ pub struct SymbolicCholesky {
     /// snode_upd[t]: prior supernodes whose columns update supernode t
     /// (their row structure contains at least one column of t).
     pub snode_upd: Vec<Vec<usize>>,
+    /// Structure of the permuted matrix P·A·Pᵀ (lower-triangle CSC) and the
+    /// source map pa_src[p] = index into the original `a.values` of the entry
+    /// at permuted position p. Lets numeric_cholesky permute values with a
+    /// single O(nnz) gather instead of re-tripletizing and re-sorting on every
+    /// factorization.
+    pub pa_col_ptr: Vec<usize>,
+    pub pa_row_idx: Vec<usize>,
+    pub pa_src: Vec<usize>,
 }
 
 /// Numeric factorization result.
@@ -70,8 +78,34 @@ pub fn symbolic_cholesky_with_perm(a: &CscMatrix, perm: &[usize]) -> SymbolicCho
     let n = a.n;
     let iperm = inverse_perm(perm);
 
-    // Apply permutation
-    let pa = a.permute_symmetric(perm);
+    // Permuted structure P·A·Pᵀ (lower triangle) plus the source map
+    // pa_src[p] = index of that entry in the original `a`. One sort here in
+    // the symbolic phase; the numeric phase then permutes values with an
+    // O(nnz) gather instead of re-sorting triplets per factorization.
+    // (No duplicate (row, col) can arise: A is lower-triangle without
+    // duplicates and iperm is a bijection.)
+    let nnz = a.col_ptr[n];
+    let mut trip: Vec<(usize, usize, usize)> = Vec::with_capacity(nnz);
+    for j in 0..n {
+        let nj = iperm[j];
+        for k in a.col_ptr[j]..a.col_ptr[j + 1] {
+            let ni = iperm[a.row_idx[k]];
+            let (r, c) = if ni >= nj { (ni, nj) } else { (nj, ni) };
+            trip.push((c, r, k));
+        }
+    }
+    trip.sort_unstable_by_key(|&(c, r, _)| (c, r));
+    let mut pa_col_ptr = vec![0usize; n + 1];
+    let mut pa_row_idx = Vec::with_capacity(nnz);
+    let mut pa_src = Vec::with_capacity(nnz);
+    for &(c, r, k) in &trip {
+        pa_col_ptr[c + 1] += 1;
+        pa_row_idx.push(r);
+        pa_src.push(k);
+    }
+    for c in 0..n {
+        pa_col_ptr[c + 1] += pa_col_ptr[c];
+    }
 
     // Elimination tree of the permuted matrix, computed directly from the
     // graph of A (Liu's algorithm with path compression, O(nnz·α(n))).
@@ -81,8 +115,8 @@ pub fn symbolic_cholesky_with_perm(a: &CscMatrix, perm: &[usize]) -> SymbolicCho
     const NONE: usize = usize::MAX;
     let mut row_cols: Vec<Vec<usize>> = vec![Vec::new(); n];
     for j in 0..n {
-        for k in pa.col_ptr[j]..pa.col_ptr[j + 1] {
-            let i = pa.row_idx[k];
+        for k in pa_col_ptr[j]..pa_col_ptr[j + 1] {
+            let i = pa_row_idx[k];
             if i > j {
                 row_cols[i].push(j);
             }
@@ -133,8 +167,8 @@ pub fn symbolic_cholesky_with_perm(a: &CscMatrix, perm: &[usize]) -> SymbolicCho
         l_row_idx.push(j); // diagonal first
         let tail_start = l_row_idx.len();
 
-        for k in pa.col_ptr[j]..pa.col_ptr[j + 1] {
-            let i = pa.row_idx[k];
+        for k in pa_col_ptr[j]..pa_col_ptr[j + 1] {
+            let i = pa_row_idx[k];
             if i > j && mark[i] != j {
                 mark[i] = j;
                 l_row_idx.push(i);
@@ -228,6 +262,9 @@ pub fn symbolic_cholesky_with_perm(a: &CscMatrix, perm: &[usize]) -> SymbolicCho
         l_nnz,
         snode_start,
         snode_upd,
+        pa_col_ptr,
+        pa_row_idx,
+        pa_src,
     }
 }
 
@@ -249,8 +286,18 @@ pub fn symbolic_cholesky_with_perm(a: &CscMatrix, perm: &[usize]) -> SymbolicCho
 pub fn numeric_cholesky(sym: &Rc<SymbolicCholesky>, a: &CscMatrix) -> Option<NumericCholesky> {
     let n = sym.n;
 
-    // Apply permutation to get numeric values
-    let pa = a.permute_symmetric(&sym.perm);
+    // Permuted values via the map precomputed in the symbolic phase: one
+    // O(nnz) gather, no triplet rebuild, no sort. `a` must have the same
+    // sparsity structure as the matrix the symbolic phase was built from
+    // (that is the standing contract of symbolic reuse).
+    debug_assert_eq!(a.n, n);
+    debug_assert_eq!(a.col_ptr.len(), n + 1);
+    let mut pa_values = vec![0.0f64; sym.pa_src.len()];
+    for (p, &k) in sym.pa_src.iter().enumerate() {
+        pa_values[p] = a.values[k];
+    }
+    let pa_col_ptr = &sym.pa_col_ptr;
+    let pa_row_idx = &sym.pa_row_idx;
 
     let mut l_values = vec![0.0f64; sym.l_nnz];
 
@@ -304,11 +351,11 @@ pub fn numeric_cholesky(sym: &Rc<SymbolicCholesky>, a: &CscMatrix) -> Option<Num
         }
         for d in 0..width {
             let j = s + d;
-            for p in pa.col_ptr[j]..pa.col_ptr[j + 1] {
-                let i = pa.row_idx[p];
+            for p in pa_col_ptr[j]..pa_col_ptr[j + 1] {
+                let i = pa_row_idx[p];
                 // struct(A[:,j]) ⊆ struct(L[:,j]) ⊆ panel rows
                 debug_assert_eq!(map_gen[i], gen);
-                panel[d * rows + map_pos[i]] = pa.values[p];
+                panel[d * rows + map_pos[i]] = pa_values[p];
             }
         }
 

--- a/engine/src/linalg/sparse_chol.rs
+++ b/engine/src/linalg/sparse_chol.rs
@@ -45,6 +45,10 @@ pub struct SymbolicCholesky {
     pub pa_col_ptr: Vec<usize>,
     pub pa_row_idx: Vec<usize>,
     pub pa_src: Vec<usize>,
+    /// Structural fingerprint of the matrix `pa_src` was built from: the
+    /// contract that symbolic reuse must not break, in a form the numeric
+    /// phase can check in O(nnz) against an O(nnz·flops) factorization.
+    pub pa_fingerprint: u64,
 }
 
 /// Numeric factorization result.
@@ -84,36 +88,72 @@ pub fn symbolic_cholesky_with(a: &CscMatrix, ordering: CholOrdering) -> Symbolic
 /// computed fill-reducing permutations.
 pub fn symbolic_cholesky_with_perm(a: &CscMatrix, perm: &[usize]) -> SymbolicCholesky {
     let n = a.n;
+    // Restored: `permute_symmetric`, which this replaces, asserted this at the
+    // top before doing any work. Without it a wrong-length permutation fails
+    // further down as a bare index-out-of-bounds that names nothing — and this
+    // is a pub entry point documented as taking externally computed orderings.
+    assert_eq!(perm.len(), n, "permutation length must equal the matrix order");
     let iperm = inverse_perm(perm);
 
+    // A must have no duplicate (row, col). `from_triplets` guarantees it, but
+    // CscMatrix has public fields, so a hand-built matrix can carry duplicates —
+    // and unlike the `from_triplets` path this replaces, the map cannot SUM
+    // them: two entries landing on one slot would both survive as separate
+    // positions and the panel scatter, which assigns rather than accumulates,
+    // would keep whichever the sort happened to place last. Checked once here,
+    // in the symbolic phase, rather than per factorization.
+    for j in 0..n {
+        let col = &a.row_idx[a.col_ptr[j]..a.col_ptr[j + 1]];
+        assert!(
+            col.windows(2).all(|w| w[0] < w[1]),
+            "column {j} of A must be strictly increasing and duplicate-free",
+        );
+    }
+
     // Permuted structure P·A·Pᵀ (lower triangle) plus the source map
-    // pa_src[p] = index of that entry in the original `a`. One sort here in
-    // the symbolic phase; the numeric phase then permutes values with an
-    // O(nnz) gather instead of re-sorting triplets per factorization.
-    // (No duplicate (row, col) can arise: A is lower-triangle without
-    // duplicates and iperm is a bijection.)
+    // pa_src[p] = index of that entry in the original `a`. The numeric phase
+    // then permutes values with an O(nnz) gather instead of re-sorting
+    // triplets per factorization.
+    //
+    // Bucketed by column with a counting sort, not a comparison sort: nothing
+    // downstream needs the rows ordered WITHIN a pa column. The column build
+    // re-sorts `l_row_idx[tail_start..]` itself, `row_cols[i]` comes out
+    // ascending because the outer loop is over j regardless, and the panel
+    // scatter reaches its slot through `map_pos`. So an O(nnz log nnz) sort
+    // over a 24-byte triplet buffer — ~9.6 MB of transient allocation at
+    // nnz = 400k, on a wasm32 heap — bought ordering no consumer reads.
     let nnz = a.col_ptr[n];
-    let mut trip: Vec<(usize, usize, usize)> = Vec::with_capacity(nnz);
+    let mut pa_col_ptr = vec![0usize; n + 1];
     for j in 0..n {
         let nj = iperm[j];
         for k in a.col_ptr[j]..a.col_ptr[j + 1] {
             let ni = iperm[a.row_idx[k]];
-            let (r, c) = if ni >= nj { (ni, nj) } else { (nj, ni) };
-            trip.push((c, r, k));
+            let c = if ni >= nj { nj } else { ni };
+            pa_col_ptr[c + 1] += 1;
         }
-    }
-    trip.sort_unstable_by_key(|&(c, r, _)| (c, r));
-    let mut pa_col_ptr = vec![0usize; n + 1];
-    let mut pa_row_idx = Vec::with_capacity(nnz);
-    let mut pa_src = Vec::with_capacity(nnz);
-    for &(c, r, k) in &trip {
-        pa_col_ptr[c + 1] += 1;
-        pa_row_idx.push(r);
-        pa_src.push(k);
     }
     for c in 0..n {
         pa_col_ptr[c + 1] += pa_col_ptr[c];
     }
+    let mut pa_row_idx = vec![0usize; nnz];
+    let mut pa_src = vec![0usize; nnz];
+    {
+        let mut cursor = pa_col_ptr.clone();
+        for j in 0..n {
+            let nj = iperm[j];
+            for k in a.col_ptr[j]..a.col_ptr[j + 1] {
+                let ni = iperm[a.row_idx[k]];
+                let (r, c) = if ni >= nj { (ni, nj) } else { (nj, ni) };
+                pa_row_idx[cursor[c]] = r;
+                pa_src[cursor[c]] = k;
+                cursor[c] += 1;
+            }
+        }
+    }
+
+    // Structural fingerprint of the matrix this map was built from. See
+    // `numeric_cholesky` for why nnz alone is not enough to police reuse.
+    let pa_fingerprint = structural_fingerprint(a);
 
     // Elimination tree of the permuted matrix, computed directly from the
     // graph of A (Liu's algorithm with path compression, O(nnz·α(n))).
@@ -273,7 +313,33 @@ pub fn symbolic_cholesky_with_perm(a: &CscMatrix, perm: &[usize]) -> SymbolicCho
         pa_col_ptr,
         pa_row_idx,
         pa_src,
+        pa_fingerprint,
     }
+}
+
+/// A cheap structural digest of a CSC pattern: order, column pointers and row
+/// indices. Values are deliberately NOT included — reuse across changed values
+/// is the whole point of the symbolic phase; reuse across a changed PATTERN is
+/// what has to be caught.
+///
+/// FxHash-style multiply-xor rather than DefaultHasher: this runs once per
+/// numeric factorization, and SipHash over nnz indices is real work next to a
+/// gather. Collisions here mean a missed diagnostic on an already-broken
+/// caller, never a wrong answer on a correct one, so 64 bits of a fast mixer is
+/// the right trade.
+fn structural_fingerprint(a: &CscMatrix) -> u64 {
+    const K: u64 = 0x517c_c1b7_2722_0a95;
+    let mut h: u64 = a.n as u64;
+    let mut mix = |v: usize| {
+        h = (h.rotate_left(5) ^ v as u64).wrapping_mul(K);
+    };
+    for &p in &a.col_ptr {
+        mix(p);
+    }
+    for &i in &a.row_idx {
+        mix(i);
+    }
+    h
 }
 
 /// Compute numeric Cholesky factorization given symbolic structure.
@@ -294,29 +360,44 @@ pub fn symbolic_cholesky_with_perm(a: &CscMatrix, perm: &[usize]) -> SymbolicCho
 pub fn numeric_cholesky(sym: &Rc<SymbolicCholesky>, a: &CscMatrix) -> Option<NumericCholesky> {
     let n = sym.n;
 
-    // Permuted values via the map precomputed in the symbolic phase: one
+    // Permuted values come from the map precomputed in the symbolic phase: an
     // O(nnz) gather, no triplet rebuild, no sort.
     //
-    // `a` must have the SAME SPARSITY STRUCTURE as the matrix the symbolic
-    // phase was built from — the standing contract of symbolic reuse. That is
-    // worth asserting on nnz and not only on the dimensions: `pa_src` holds
-    // positions into the original `a.values`, so a matrix with the same `n` but
-    // a different pattern reads the wrong entries. It is silent whenever the
-    // value array happens to be long enough, and an index panic when it is not.
-    debug_assert_eq!(a.n, n);
-    debug_assert_eq!(a.col_ptr.len(), n + 1);
-    debug_assert_eq!(
-        a.col_ptr[n],
-        sym.pa_src.len(),
-        "numeric_cholesky: matrix has {} nonzeros, symbolic was built for {} — \
-         symbolic reuse requires an unchanged sparsity pattern",
+    // That turns a SOFT contract into a HARD one, and the guard has to match.
+    // The `permute_symmetric(&sym.perm)` this replaces recomputed the permuted
+    // matrix from whatever was passed in, so reuse tolerated a drifting
+    // pattern; `pa_src` holds positions into the values array of the matrix the
+    // symbolic was built from, and reading them against a different pattern
+    // gathers neighbouring entries into every slot past the first divergence.
+    // Cholesky then succeeds and returns displacements for a matrix nobody
+    // assembled.
+    //
+    // This is reachable, not hypothetical. Both P-Delta loops cache one
+    // symbolic (`pdelta.rs:88`, `:331`) and rebuild `k_csc` every iteration
+    // through `CscMatrix::from_dense_symmetric`, whose `|v| > 1e-30` filter
+    // makes the pattern VALUE-dependent — and the geometric stiffness changes
+    // every iteration by design. On the unconstrained path the pattern is
+    // pinned by K's element topology, since K_G occupies the same DOF pairs;
+    // with constraints, `reduce_matrix` can produce entries that cancel, and
+    // where they cancel moves as K_G moves.
+    //
+    // So: `assert!`, not `debug_assert!` — the release wasm32 build is the one
+    // that ships, and `permute_symmetric` ran its own `assert_eq!` there on
+    // every factorization, so debug-only would be a downgrade of a live check.
+    // And the fingerprint, not nnz: one entry dropping below the threshold
+    // while another rises above it leaves nnz identical.
+    assert_eq!(a.n, n, "numeric_cholesky: matrix order does not match the symbolic");
+    assert_eq!(a.col_ptr.len(), n + 1, "numeric_cholesky: malformed column pointers");
+    assert_eq!(
+        structural_fingerprint(a),
+        sym.pa_fingerprint,
+        "numeric_cholesky: sparsity pattern differs from the one the symbolic \
+         factorization was built for ({} nonzeros now, {} then) — symbolic reuse \
+         requires an unchanged pattern, not merely an unchanged shape",
         a.col_ptr[n],
         sym.pa_src.len(),
     );
-    // Collected rather than zero-filled and overwritten: the fill was a memset
-    // of nnz f64 per factorization, inside the function whose whole point is to
-    // stop doing per-factorization work.
-    let pa_values: Vec<f64> = sym.pa_src.iter().map(|&k| a.values[k]).collect();
+
     let pa_col_ptr = &sym.pa_col_ptr;
     let pa_row_idx = &sym.pa_row_idx;
 
@@ -376,7 +457,11 @@ pub fn numeric_cholesky(sym: &Rc<SymbolicCholesky>, a: &CscMatrix) -> Option<Num
                 let i = pa_row_idx[p];
                 // struct(A[:,j]) ⊆ struct(L[:,j]) ⊆ panel rows
                 debug_assert_eq!(map_gen[i], gen);
-                panel[d * rows + map_pos[i]] = pa_values[p];
+                // Gathered straight from the source. Staging these into an
+                // nnz-sized `pa_values` first meant one heap allocation and a
+                // full write-then-read pass over nnz per factorization — the
+                // per-call work this map exists to remove.
+                panel[d * rows + map_pos[i]] = a.values[sym.pa_src[p]];
             }
         }
 
@@ -659,6 +744,89 @@ mod tests {
         let a = make_spd(&[1.0, 2.0, 2.0, 1.0], 2);
         let b = vec![1.0, 1.0];
         assert!(sparse_cholesky_solve_full(&a, &b).is_none());
+    }
+
+
+    /// Reusing a symbolic factorization across a CHANGED PATTERN must fail loudly.
+    ///
+    /// This is the contract the permutation map turned from soft into hard. The
+    /// `permute_symmetric` it replaced rebuilt the permuted matrix from whatever
+    /// was passed in; `pa_src` holds positions into the values array of the
+    /// matrix the symbolic was built from, so reading it against a different
+    /// pattern gathers neighbouring entries and returns a factorization of a
+    /// matrix nobody assembled.
+    ///
+    /// It is reachable: both P-Delta loops cache one symbolic and rebuild the
+    /// CSC every iteration through `from_dense_symmetric`, whose `|v| > 1e-30`
+    /// filter makes the pattern depend on the values.
+    ///
+    /// Two shapes, because the cheap guard only catches one of them.
+    #[test]
+    #[should_panic(expected = "sparsity pattern differs")]
+    fn numeric_cholesky_rejects_a_shorter_pattern() {
+        // 3x3 tridiagonal, then the same matrix with the (2,1) coupling gone.
+        let a = CscMatrix::from_triplets(
+            3,
+            &[0, 1, 1, 2, 2],
+            &[0, 0, 1, 1, 2],
+            &[10.0, 1.0, 8.0, 2.0, 6.0],
+        );
+        let thinner = CscMatrix::from_triplets(
+            3,
+            &[0, 1, 1, 2],
+            &[0, 0, 1, 2],
+            &[10.0, 1.0, 8.0, 6.0],
+        );
+        let sym = Rc::new(symbolic_cholesky(&a));
+        let _ = numeric_cholesky(&sym, &thinner);
+    }
+
+    /// The same nonzero COUNT with a different pattern is the case a length
+    /// check cannot see, and the one P-Delta can actually produce: one entry
+    /// drops below the threshold while another rises above it.
+    #[test]
+    #[should_panic(expected = "sparsity pattern differs")]
+    fn numeric_cholesky_rejects_an_equal_length_but_shifted_pattern() {
+        // Both have five entries; the off-diagonal moved from (2,1) to (2,0).
+        let a = CscMatrix::from_triplets(
+            3,
+            &[0, 1, 1, 2, 2],
+            &[0, 0, 1, 1, 2],
+            &[10.0, 1.0, 8.0, 2.0, 6.0],
+        );
+        let shifted = CscMatrix::from_triplets(
+            3,
+            &[0, 1, 2, 1, 2],
+            &[0, 0, 0, 1, 2],
+            &[10.0, 1.0, 2.0, 8.0, 6.0],
+        );
+        assert_eq!(a.nnz(), shifted.nnz(), "the point of this case is equal nnz");
+        let sym = Rc::new(symbolic_cholesky(&a));
+        let _ = numeric_cholesky(&sym, &shifted);
+    }
+
+    /// And the legitimate use keeps working: same pattern, different values.
+    /// This is what P-Delta and the regularization retry actually do, and it is
+    /// the case the guard must NOT reject.
+    #[test]
+    fn numeric_cholesky_accepts_new_values_on_the_same_pattern() {
+        let pattern_rows = [0usize, 1, 1, 2, 2];
+        let pattern_cols = [0usize, 0, 1, 1, 2];
+        let a1 = CscMatrix::from_triplets(3, &pattern_rows, &pattern_cols,
+            &[10.0, 1.0, 8.0, 2.0, 6.0]);
+        let a2 = CscMatrix::from_triplets(3, &pattern_rows, &pattern_cols,
+            &[20.0, 3.0, 15.0, 4.0, 12.0]);
+
+        let sym = Rc::new(symbolic_cholesky(&a1));
+        let b = vec![1.0, 2.0, 3.0];
+        for a in [&a1, &a2] {
+            let num = numeric_cholesky(&sym, a).expect("SPD matrix should factor");
+            let x = sparse_cholesky_solve(&num, &b);
+            let ax = a.sym_mat_vec(&x);
+            for i in 0..3 {
+                assert!((ax[i] - b[i]).abs() < 1e-10, "A*x != b at row {i}");
+            }
+        }
     }
 
     #[test]

--- a/engine/src/linalg/sparse_chol.rs
+++ b/engine/src/linalg/sparse_chol.rs
@@ -34,6 +34,14 @@ pub struct SymbolicCholesky {
     /// at permuted position p. Lets numeric_cholesky permute values with a
     /// single O(nnz) gather instead of re-tripletizing and re-sorting on every
     /// factorization.
+    ///
+    /// This is a deliberate memory-for-time trade: `pa_row_idx` and `pa_src`
+    /// add 2·nnz(A) usizes to every cached symbolic factorization — about
+    /// 6.4 MB at nnz(A) = 400k — and P-Delta holds one across every load step.
+    /// It buys back a full O(nnz log nnz) sort and a triplet rebuild per
+    /// numeric factorization, which those same iterative paths pay repeatedly.
+    /// On wasm32, where memory growth is user-visible, that is the axis to
+    /// watch if the trade is ever revisited.
     pub pa_col_ptr: Vec<usize>,
     pub pa_row_idx: Vec<usize>,
     pub pa_src: Vec<usize>,
@@ -287,15 +295,28 @@ pub fn numeric_cholesky(sym: &Rc<SymbolicCholesky>, a: &CscMatrix) -> Option<Num
     let n = sym.n;
 
     // Permuted values via the map precomputed in the symbolic phase: one
-    // O(nnz) gather, no triplet rebuild, no sort. `a` must have the same
-    // sparsity structure as the matrix the symbolic phase was built from
-    // (that is the standing contract of symbolic reuse).
+    // O(nnz) gather, no triplet rebuild, no sort.
+    //
+    // `a` must have the SAME SPARSITY STRUCTURE as the matrix the symbolic
+    // phase was built from — the standing contract of symbolic reuse. That is
+    // worth asserting on nnz and not only on the dimensions: `pa_src` holds
+    // positions into the original `a.values`, so a matrix with the same `n` but
+    // a different pattern reads the wrong entries. It is silent whenever the
+    // value array happens to be long enough, and an index panic when it is not.
     debug_assert_eq!(a.n, n);
     debug_assert_eq!(a.col_ptr.len(), n + 1);
-    let mut pa_values = vec![0.0f64; sym.pa_src.len()];
-    for (p, &k) in sym.pa_src.iter().enumerate() {
-        pa_values[p] = a.values[k];
-    }
+    debug_assert_eq!(
+        a.col_ptr[n],
+        sym.pa_src.len(),
+        "numeric_cholesky: matrix has {} nonzeros, symbolic was built for {} — \
+         symbolic reuse requires an unchanged sparsity pattern",
+        a.col_ptr[n],
+        sym.pa_src.len(),
+    );
+    // Collected rather than zero-filled and overwritten: the fill was a memset
+    // of nnz f64 per factorization, inside the function whose whole point is to
+    // stop doing per-factorization work.
+    let pa_values: Vec<f64> = sym.pa_src.iter().map(|&k| a.values[k]).collect();
     let pa_col_ptr = &sym.pa_col_ptr;
     let pa_row_idx = &sym.pa_row_idx;
 


### PR DESCRIPTION
> Stacked on #176 (perf/amd-quotient-graph). Un commit, diff chico.

## Problema

`numeric_cholesky` llamaba a `permute_symmetric` en cada factorización: tripleteo + sort O(nnz·log nnz) + seis vectores temporales de tamaño nnz — trabajo puramente simbólico pagado por iteración numérica. P-Delta y las vías no lineales reusan la simbólica pero pagaban el reordenamiento igual. (La otra mitad de este hallazgo del audit — las listas de columnas no nulas reconstruidas por llamada — ya quedó resuelta en #176 moviéndolas a la simbólica como `snode_upd`.)

## Cambio

La fase simbólica ahora guarda la estructura permutada (`pa_col_ptr`, `pa_row_idx`) y el mapa `pa_src[p]` = índice en el array de valores original. La numérica permuta valores con un gather O(nnz) sin ordenar ni alocar buffers temporales.

El contrato de reuso de patrón no cambia (los callers ya debían pasar una matriz con la misma estructura); el doc comment de `numeric_cholesky` ahora lo declara.

## Medido

Grid 256² (n=65.536, nnz_L=2,02 M), 5 factorizaciones numéricas consecutivas reutilizando la simbólica (el patrón P-Delta): ~116 ms → ~100 ms por factorización (medianas de 3 corridas; máquina ruidosa). El win principal es de presión de alocación: cero buffers temporales por llamada.

## Verificación

- Suite completa: 7100 tests verdes. El test `test_symbolic_reuse` (misma simbólica, dos sets de valores) cubre exactamente el camino del mapa, y los tests diferenciales supernodal-vs-simplicial validan los valores resultantes.
