### PR TITLE
perf(engine): sparse K_g assembly for buckling, no dense n×n

### DIFF
--- a/engine/src/linalg/lanczos.rs
+++ b/engine/src/linalg/lanczos.rs
@@ -653,16 +653,50 @@ impl<'a> MatVecOp for SparseSymMatVec<'a> {
 pub struct SparseShiftInvertOp<'a> {
     factor: super::sparse_chol::NumericCholesky,
     b_csc: &'a CscMatrix,
+    /// The matrix defining the inner product the Lanczos recurrence runs in.
+    ///
+    /// `lanczos_tridiag` builds a B-orthogonal basis, which needs its inner
+    /// product to come from a POSITIVE DEFINITE matrix — otherwise
+    /// `⟨q, Bq⟩` can be negative and the recurrence has no meaning.
+    ///
+    /// For the modal problem K⁻¹M that matrix can be M, which is positive
+    /// (semi-)definite. For BUCKLING it cannot: the operator is K⁻¹(−Kg) and
+    /// −Kg is indefinite for any model carrying both tension and compression,
+    /// which is nearly all of them. Using it produced NaN from
+    /// `dot(q, Bq).sqrt()` at the seed, and mid-iteration a negative B-norm was
+    /// clamped to zero by `.max(0.0)` and read as an invariant subspace —
+    /// truncating the basis and returning eigenvalues from a set of vectors
+    /// that are not B-orthogonal, with no fallback.
+    ///
+    /// K works for both: it is SPD by construction, and A = K⁻¹B is self-adjoint
+    /// in ⟨·,·⟩_K because ⟨Ax, y⟩_K = xᵀBy = ⟨x, Ay⟩_K. The Ritz values are
+    /// unchanged — θ = μ either way — only the basis is built in a metric that
+    /// exists.
+    inner: &'a CscMatrix,
 }
 
 impl<'a> SparseShiftInvertOp<'a> {
-    /// Build from sparse K_ff (SPD) and sparse B_ff (symmetric, lower-triangle CSC).
-    /// Returns None if sparse Cholesky fails.
-    pub fn new(k_csc: &CscMatrix, b_csc: &'a CscMatrix) -> Option<Self> {
+    /// Build from sparse K_ff (SPD) and sparse B_ff (symmetric, lower-triangle
+    /// CSC), running the recurrence in the B inner product.
+    ///
+    /// Only valid when B is positive (semi-)definite — the modal case, where
+    /// B is the mass matrix. For an indefinite B use `new_k_inner_product`.
+    pub fn new(k_csc: &'a CscMatrix, b_csc: &'a CscMatrix) -> Option<Self> {
         assert_eq!(k_csc.n, b_csc.n, "K and B must have the same dimension");
         let sym = Rc::new(symbolic_cholesky(k_csc));
         let factor = numeric_cholesky(&sym, k_csc)?;
-        Some(Self { factor, b_csc })
+        Some(Self { factor, b_csc, inner: b_csc })
+    }
+
+    /// Same operator, with the recurrence running in the K inner product.
+    ///
+    /// This is the form buckling needs: K is SPD, so the metric is well defined
+    /// whatever the sign content of B.
+    pub fn new_k_inner_product(k_csc: &'a CscMatrix, b_csc: &'a CscMatrix) -> Option<Self> {
+        assert_eq!(k_csc.n, b_csc.n, "K and B must have the same dimension");
+        let sym = Rc::new(symbolic_cholesky(k_csc));
+        let factor = numeric_cholesky(&sym, k_csc)?;
+        Some(Self { factor, b_csc, inner: k_csc })
     }
 }
 
@@ -676,8 +710,8 @@ impl<'a> MatVecOp for SparseShiftInvertOp<'a> {
     }
     fn dim(&self) -> usize { self.b_csc.n }
     fn b_mul(&self, x: &[f64], y: &mut [f64]) {
-        let r = self.b_csc.sym_mat_vec(x);
-        y[..self.b_csc.n].copy_from_slice(&r);
+        let r = self.inner.sym_mat_vec(x);
+        y[..self.inner.n].copy_from_slice(&r);
     }
 }
 
@@ -787,7 +821,10 @@ pub fn lanczos_buckling_eigen_sparse(
 
     // Large n: sparse shift-invert Lanczos.
     // Operator: K⁻¹·(-Kg)·x — largest eigenvalues are the largest μ.
-    if let Some(si_op) = SparseShiftInvertOp::new(k_ff, neg_kg) {
+    //
+    // K, not −Kg, as the inner product: −Kg is indefinite whenever the model
+    // carries tension and compression together. See `new_k_inner_product`.
+    if let Some(si_op) = SparseShiftInvertOp::new_k_inner_product(k_ff, neg_kg) {
         let params = LanczosParams {
             max_iter: 300,
             tol: 1e-10,
@@ -835,6 +872,119 @@ fn dot(a: &[f64], b: &[f64]) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Buckling must stay on the SPARSE path when -Kg is indefinite.
+    ///
+    /// `(-Kg)φ = μKφ` has an indefinite right-hand matrix for any model carrying
+    /// tension and compression at once — nearly all of them. The Lanczos
+    /// recurrence builds a basis orthogonal in some inner product, and that
+    /// product must come from a positive definite matrix. So it runs in K, which
+    /// is SPD by construction, not in -Kg.
+    ///
+    /// The symptom is not a wrong answer: `lanczos_buckling_eigen_sparse` falls
+    /// back to dense Jacobi when the iteration bails, so the eigenvalues come
+    /// back correct either way and a numbers-only test cannot see the defect.
+    /// What it loses is the entire point of the sparse path — that fallback
+    /// calls `to_dense_symmetric()` on both K and -Kg, which is exactly the
+    /// n×n densification the sparse buckling work exists to remove. The
+    /// optimization silently did not apply to the models that need it.
+    ///
+    /// So this test asserts on the ITERATION, not on the numbers: run the two
+    /// operators directly, past the fallback, and check that the -Kg metric
+    /// bails and the K metric does not.
+    #[test]
+    fn buckling_lanczos_stays_sparse_when_kg_is_indefinite() {
+        let n = 300;
+        let k = 4;
+
+        // K: SPD tridiagonal.
+        let (mut kr, mut kc, mut kv) = (Vec::new(), Vec::new(), Vec::new());
+        for i in 0..n {
+            kr.push(i);
+            kc.push(i);
+            kv.push(4.0);
+            if i + 1 < n {
+                kr.push(i + 1);
+                kc.push(i);
+                kv.push(-1.0);
+            }
+        }
+        let k_ff = CscMatrix::from_triplets(n, &kr, &kc, &kv);
+
+        // -Kg: mostly tension, a few compressed DOFs. Predominantly negative so
+        // the deterministic Lanczos seed lands with a NEGATIVE -Kg-norm, which
+        // is what turns `dot(q, Bq).sqrt()` into NaN.
+        let (mut gr, mut gc, mut gv) = (Vec::new(), Vec::new(), Vec::new());
+        for i in 0..n {
+            gr.push(i);
+            gc.push(i);
+            gv.push(if i % 7 == 0 { 1.0 } else { -1.0 });
+        }
+        let neg_kg = CscMatrix::from_triplets(n, &gr, &gc, &gv);
+        assert!(
+            gv.iter().any(|&v| v < 0.0) && gv.iter().any(|&v| v > 0.0),
+            "the fixture must be indefinite for this test to mean anything",
+        );
+
+        let params = LanczosParams {
+            max_iter: 300,
+            tol: 1e-10,
+            subspace_dim: Some((4 * k).max(40).min(n)),
+        };
+
+        // The -Kg metric cannot carry the recurrence: it bails, and the caller
+        // silently densifies.
+        let with_kg_metric = SparseShiftInvertOp::new(&k_ff, &neg_kg)
+            .and_then(|op| lanczos_irlm(&op, k, true, &params));
+        assert!(
+            with_kg_metric.is_none(),
+            "running the recurrence in an indefinite -Kg should not produce a result; \
+             if this ever starts succeeding, check that it is not returning \
+             eigenvalues from a non-B-orthogonal basis",
+        );
+
+        // The K metric does carry it.
+        let sparse = SparseShiftInvertOp::new_k_inner_product(&k_ff, &neg_kg)
+            .and_then(|op| lanczos_irlm(&op, k, true, &params))
+            .expect("the K inner product must carry the iteration through");
+
+        // And it agrees with the dense reference on the governing mode.
+        let dense = solve_generalized_eigen(
+            &neg_kg.to_dense_symmetric(),
+            &k_ff.to_dense_symmetric(),
+            n,
+            200,
+        )
+        .expect("dense reference should solve");
+
+        let top = |vals: &[f64]| -> f64 {
+            vals.iter()
+                .copied()
+                .filter(|v| v.is_finite() && *v > 1e-12)
+                .fold(f64::MIN, f64::max)
+        };
+        // And the public entry point must actually take that path. The dense
+        // fallback returns ALL n eigenvalues so the caller can hunt for positive
+        // mu; the sparse path returns at most k. That difference is what makes
+        // the fallback observable from outside without instrumenting it.
+        let via_entry_point = lanczos_buckling_eigen_sparse(&k_ff, &neg_kg, k)
+            .expect("entry point must produce a result");
+        assert!(
+            via_entry_point.values.len() <= k,
+            "lanczos_buckling_eigen_sparse returned {} eigenvalues for k = {k}: that is \
+             the dense fallback, so the sparse path silently did not apply",
+            via_entry_point.values.len(),
+        );
+
+        let (mu_sparse, mu_dense) = (top(&sparse.values), top(&dense.values));
+        assert!(mu_sparse.is_finite(), "sparse path produced no finite positive eigenvalue");
+        let rel = (mu_sparse - mu_dense).abs() / mu_dense.abs().max(1e-30);
+        assert!(
+            rel < 1e-6,
+            "governing mu disagrees with the dense reference: sparse {mu_sparse} \
+             vs dense {mu_dense} (rel {rel:e})",
+        );
+    }
 
     /// Pre-sparse-mass shift-invert operator holding B as a dense matrix.
     /// Kept as a parity reference: same sparse Cholesky factorization of K,

--- a/engine/src/solver/buckling.rs
+++ b/engine/src/solver/buckling.rs
@@ -58,19 +58,17 @@ pub fn solve_buckling_2d(
         return Err("No free DOFs".into());
     }
 
-    // 2. Build geometric stiffness from linear axial forces
-    let kg_full = build_kg_from_forces_2d(input, &dof_num, &linear.element_forces);
+    // 2. Build geometric stiffness from linear axial forces (sparse free block;
+    //    the eigensolver below is sparse, so a dense n×n Kg was pure waste)
+    let neg_kg_csc = {
+        let kg_csc = build_kg_from_forces_2d(input, &dof_num, &linear.element_forces).into_csc();
+        // Negate Kg (we solve K·φ = λ·(-Kg)·φ for positive eigenvalues)
+        let neg_vals: Vec<f64> = kg_csc.values.iter().map(|v| -v).collect();
+        CscMatrix { values: neg_vals, ..kg_csc }
+    };
 
-    // 3. Extract free-DOF submatrices
-    let free_idx: Vec<usize> = (0..nf).collect();
+    // 3. Sparse stiffness of the free block
     let sasm = assemble_sparse_2d(input, &dof_num);
-
-    // Negate Kg (we solve K·φ = λ·(-Kg)·φ for positive eigenvalues)
-    let kg_ff_raw = extract_submatrix(&kg_full, n, &free_idx, &free_idx);
-    let mut neg_kg_ff = vec![0.0; nf * nf];
-    for i in 0..nf * nf {
-        neg_kg_ff[i] = -kg_ff_raw[i];
-    }
 
     // Apply constraint transform if present
     let cs = FreeConstraintSystem::build_2d(&input.constraints, &dof_num, &input.nodes);
@@ -83,24 +81,20 @@ pub fn solve_buckling_2d(
         return Err("No compressed elements — buckling not applicable".into());
     }
 
-    // 4. Solve generalized eigenvalue: (-Kg)·φ = μ·K·φ  (K is SPD)
-    // No-constraint path: sparse shift-invert Lanczos (K⁻¹(-Kg)x, K factorized by sparse Cholesky).
-    // Constraint path: dense Jacobi (needs dense K for reduce_matrix).
-    let (result, ns) = if let Some(cs_ref) = cs.as_ref() {
-        let k_ff = sasm.k_ff.to_dense_symmetric();
-        let k_solve = cs_ref.reduce_matrix(&k_ff);
-        let neg_kg_solve = cs_ref.reduce_matrix(&neg_kg_ff);
-        let ns = cs_ref.n_free_indep;
-        let r = solve_generalized_eigen(&neg_kg_solve, &k_solve, ns, 200)
-            .ok_or_else(|| "Eigenvalue decomposition failed — stiffness matrix issue".to_string())?;
-        (r, ns)
+    // 4. Solve generalized eigenvalue: (-Kg)·φ = μ·K·φ  (K is SPD), sparse
+    // shift-invert Lanczos in both branches; with constraints, K and -Kg are
+    // reduced as sparse triple products first.
+    let k_red;
+    let kg_red;
+    let (k_solve, kg_solve, ns): (&CscMatrix, &CscMatrix, usize) = if let Some(cs_ref) = cs.as_ref() {
+        k_red = cs_ref.reduce_matrix_sparse(&sasm.k_ff);
+        kg_red = cs_ref.reduce_matrix_sparse(&neg_kg_csc);
+        (&k_red, &kg_red, cs_ref.n_free_indep)
     } else {
-        // -Kg is element-sparse: CSC matvec is O(nnz) per Lanczos iteration.
-        let neg_kg_csc = CscMatrix::from_dense_symmetric(&neg_kg_ff, nf);
-        let r = lanczos_buckling_eigen_sparse(&sasm.k_ff, &neg_kg_csc, num_modes)
-            .ok_or_else(|| "Eigenvalue decomposition failed — stiffness matrix issue".to_string())?;
-        (r, nf)
+        (&sasm.k_ff, &neg_kg_csc, nf)
     };
+    let result = lanczos_buckling_eigen_sparse(k_solve, kg_solve, num_modes)
+        .ok_or_else(|| "Eigenvalue decomposition failed — stiffness matrix issue".to_string())?;
 
     let num_modes = num_modes.min(ns);
     let n_converged = result.values.len();
@@ -235,7 +229,7 @@ pub fn solve_buckling_3d(
 
     if nf == 0 { return Err("No free DOFs".into()); }
 
-    let mut kg_full = build_kg_from_forces_3d(input, &dof_num, &linear.element_forces);
+    let mut kg = build_kg_from_forces_3d(input, &dof_num, &linear.element_forces);
 
     // Add quad/solid-shell/curved-shell geometric stiffness from stress resultants
     if !input.quads.is_empty() || !input.quad9s.is_empty() || !input.solid_shells.is_empty() || !input.curved_shells.is_empty() {
@@ -251,22 +245,22 @@ pub fn solve_buckling_3d(
         }
         if !input.quads.is_empty() {
             super::geometric_stiffness::add_quad_geometric_stiffness_3d(
-                input, &dof_num, &u_full, &mut kg_full,
+                input, &dof_num, &u_full, &mut kg,
             );
         }
         if !input.quad9s.is_empty() {
             super::geometric_stiffness::add_quad9_geometric_stiffness_3d(
-                input, &dof_num, &u_full, &mut kg_full,
+                input, &dof_num, &u_full, &mut kg,
             );
         }
         if !input.solid_shells.is_empty() {
             super::geometric_stiffness::add_solid_shell_geometric_stiffness_3d(
-                input, &dof_num, &u_full, &mut kg_full,
+                input, &dof_num, &u_full, &mut kg,
             );
         }
         if !input.curved_shells.is_empty() {
             super::geometric_stiffness::add_curved_shell_geometric_stiffness_3d(
-                input, &dof_num, &u_full, &mut kg_full,
+                input, &dof_num, &u_full, &mut kg,
             );
         }
     }
@@ -283,16 +277,18 @@ pub fn solve_buckling_3d(
             }
         }
         add_plate_geometric_stiffness_3d(
-            input, &dof_num, &u_full, &mut kg_full,
+            input, &dof_num, &u_full, &mut kg,
         );
     }
 
-    let free_idx: Vec<usize> = (0..nf).collect();
     let sasm = assemble_sparse_3d(input, &dof_num, false);
 
-    let kg_ff_raw = extract_submatrix(&kg_full, n, &free_idx, &free_idx);
-    let mut neg_kg_ff = vec![0.0; nf * nf];
-    for i in 0..nf * nf { neg_kg_ff[i] = -kg_ff_raw[i]; }
+    // Negate Kg (we solve K·φ = λ·(-Kg)·φ for positive eigenvalues)
+    let neg_kg_csc = {
+        let kg_csc = kg.into_csc();
+        let neg_vals: Vec<f64> = kg_csc.values.iter().map(|v| -v).collect();
+        CscMatrix { values: neg_vals, ..kg_csc }
+    };
 
     // Apply constraint transform if present
     let cs = FreeConstraintSystem::build_3d(&input.constraints, &dof_num, &input.nodes);
@@ -302,29 +298,25 @@ pub fn solve_buckling_3d(
     });
     // Also check if shell geometric stiffness has non-trivial entries
     let has_shell_kg = (!input.quads.is_empty() || !input.plates.is_empty() || !input.quad9s.is_empty() || !input.solid_shells.is_empty())
-        && neg_kg_ff.iter().any(|&v| v.abs() > 1e-15);
+        && neg_kg_csc.values.iter().any(|&v| v.abs() > 1e-15);
     if !has_frame_compression && !has_shell_kg {
         return Err("No compressed elements — buckling not applicable".into());
     }
 
-    // Solve eigenproblem: (-Kg)*φ = μ*K*φ, then λ = 1/μ.
-    // No-constraint path: sparse shift-invert Lanczos (K⁻¹(-Kg)x, K factorized by sparse Cholesky).
-    // Constraint path: dense Jacobi (needs dense K for reduce_matrix).
-    let (result, ns) = if let Some(cs_ref) = cs.as_ref() {
-        let k_ff = sasm.k_ff.to_dense_symmetric();
-        let k_solve = cs_ref.reduce_matrix(&k_ff);
-        let neg_kg_solve = cs_ref.reduce_matrix(&neg_kg_ff);
-        let ns = cs_ref.n_free_indep;
-        let r = solve_generalized_eigen(&neg_kg_solve, &k_solve, ns, 200)
-            .ok_or_else(|| "Eigenvalue decomposition failed".to_string())?;
-        (r, ns)
+    // Solve eigenproblem: (-Kg)*φ = μ*K*φ, then λ = 1/μ. Sparse shift-invert
+    // Lanczos in both branches; with constraints, K and -Kg are reduced as
+    // sparse triple products first.
+    let k_red;
+    let kg_red;
+    let (k_solve, kg_solve, ns): (&CscMatrix, &CscMatrix, usize) = if let Some(cs_ref) = cs.as_ref() {
+        k_red = cs_ref.reduce_matrix_sparse(&sasm.k_ff);
+        kg_red = cs_ref.reduce_matrix_sparse(&neg_kg_csc);
+        (&k_red, &kg_red, cs_ref.n_free_indep)
     } else {
-        // -Kg is element-sparse: CSC matvec is O(nnz) per Lanczos iteration.
-        let neg_kg_csc = CscMatrix::from_dense_symmetric(&neg_kg_ff, nf);
-        let r = lanczos_buckling_eigen_sparse(&sasm.k_ff, &neg_kg_csc, num_modes)
-            .ok_or_else(|| "Eigenvalue decomposition failed".to_string())?;
-        (r, nf)
+        (&sasm.k_ff, &neg_kg_csc, nf)
     };
+    let result = lanczos_buckling_eigen_sparse(k_solve, kg_solve, num_modes)
+        .ok_or_else(|| "Eigenvalue decomposition failed".to_string())?;
 
     let num_modes = num_modes.min(ns);
     let n_converged = result.values.len();

--- a/engine/src/solver/buckling.rs
+++ b/engine/src/solver/buckling.rs
@@ -58,22 +58,9 @@ pub fn solve_buckling_2d(
         return Err("No free DOFs".into());
     }
 
-    // 2. Build geometric stiffness from linear axial forces (sparse free block;
-    //    the eigensolver below is sparse, so a dense n×n Kg was pure waste)
-    let neg_kg_csc = {
-        let kg_csc = build_kg_from_forces_2d(input, &dof_num, &linear.element_forces).into_csc();
-        // Negate Kg (we solve K·φ = λ·(-Kg)·φ for positive eigenvalues)
-        let neg_vals: Vec<f64> = kg_csc.values.iter().map(|v| -v).collect();
-        CscMatrix { values: neg_vals, ..kg_csc }
-    };
-
-    // 3. Sparse stiffness of the free block
-    let sasm = assemble_sparse_2d(input, &dof_num);
-
-    // Apply constraint transform if present
-    let cs = FreeConstraintSystem::build_2d(&input.constraints, &dof_num, &input.nodes);
-
-    // Check if any element is in compression
+    // 2. Check for compression before assembling anything. There are no surface
+    //    elements on the 2D path, so the axial forces answer this on their own —
+    //    a frame in pure tension can bail here and skip both assemblies below.
     let has_compression = linear.element_forces.iter().any(|ef| {
         (ef.n_start + ef.n_end) / 2.0 < -1e-6
     });
@@ -81,7 +68,25 @@ pub fn solve_buckling_2d(
         return Err("No compressed elements — buckling not applicable".into());
     }
 
-    // 4. Solve generalized eigenvalue: (-Kg)·φ = μ·K·φ  (K is SPD), sparse
+    // 3. Build geometric stiffness from linear axial forces (sparse free block;
+    //    the eigensolver below is sparse, so a dense n×n Kg was pure waste).
+    //    Negate it in place — we solve K·φ = λ·(-Kg)·φ for positive eigenvalues,
+    //    and nothing reads the un-negated Kg.
+    let neg_kg_csc = {
+        let mut kg_csc = build_kg_from_forces_2d(input, &dof_num, &linear.element_forces).into_csc();
+        for v in kg_csc.values.iter_mut() {
+            *v = -*v;
+        }
+        kg_csc
+    };
+
+    // 4. Sparse stiffness of the free block
+    let sasm = assemble_sparse_2d(input, &dof_num);
+
+    // Apply constraint transform if present
+    let cs = FreeConstraintSystem::build_2d(&input.constraints, &dof_num, &input.nodes);
+
+    // 5. Solve generalized eigenvalue: (-Kg)·φ = μ·K·φ  (K is SPD), sparse
     // shift-invert Lanczos in both branches; with constraints, K and -Kg are
     // reduced as sparse triple products first.
     let k_red;
@@ -229,11 +234,28 @@ pub fn solve_buckling_3d(
 
     if nf == 0 { return Err("No free DOFs".into()); }
 
+    let has_frame_compression = linear.element_forces.iter().any(|ef| {
+        (ef.n_start + ef.n_end) / 2.0 < -1e-6
+    });
+    let has_surfaces = !input.quads.is_empty()
+        || !input.plates.is_empty()
+        || !input.quad9s.is_empty()
+        || !input.solid_shells.is_empty()
+        || !input.curved_shells.is_empty();
+
+    // Bail before assembling anything. The full gate below also asks whether the
+    // assembled -Kg has non-trivial entries, but that question only arises when
+    // there are surfaces to assemble: with no compressed frame and no surface
+    // elements at all, no amount of assembly can change the answer.
+    if !has_frame_compression && !has_surfaces {
+        return Err("No compressed elements — buckling not applicable".into());
+    }
+
     let mut kg = build_kg_from_forces_3d(input, &dof_num, &linear.element_forces);
 
-    // Add quad/solid-shell/curved-shell geometric stiffness from stress resultants
-    if !input.quads.is_empty() || !input.quad9s.is_empty() || !input.solid_shells.is_empty() || !input.curved_shells.is_empty() {
-        // Reconstruct displacement vector from linear results
+    if has_surfaces {
+        // Reconstruct the displacement vector from the linear results once, for
+        // every surface family that needs it.
         let mut u_full = vec![0.0; n];
         for d in &linear.displacements {
             let vals = [d.ux, d.uy, d.uz, d.rx, d.ry, d.rz];
@@ -263,42 +285,38 @@ pub fn solve_buckling_3d(
                 input, &dof_num, &u_full, &mut kg,
             );
         }
-    }
-
-    // Add plate (DKT triangle) geometric stiffness from membrane stress resultants
-    if !input.plates.is_empty() {
-        let mut u_full = vec![0.0; n];
-        for d in &linear.displacements {
-            let vals = [d.ux, d.uy, d.uz, d.rx, d.ry, d.rz];
-            for (i, &v) in vals.iter().enumerate() {
-                if let Some(&dof) = dof_num.map.get(&(d.node_id, i)) {
-                    u_full[dof] = v;
-                }
-            }
+        // Plate (DKT triangle) geometric stiffness from membrane stress resultants,
+        // off the same u_full.
+        if !input.plates.is_empty() {
+            add_plate_geometric_stiffness_3d(
+                input, &dof_num, &u_full, &mut kg,
+            );
         }
-        add_plate_geometric_stiffness_3d(
-            input, &dof_num, &u_full, &mut kg,
-        );
     }
 
     let sasm = assemble_sparse_3d(input, &dof_num, false);
 
-    // Negate Kg (we solve K·φ = λ·(-Kg)·φ for positive eigenvalues)
+    // Negate Kg (we solve K·φ = λ·(-Kg)·φ for positive eigenvalues), in place:
+    // Kg is not read again, and on a large shell model its values vector is the
+    // single biggest allocation in this function.
     let neg_kg_csc = {
-        let kg_csc = kg.into_csc();
-        let neg_vals: Vec<f64> = kg_csc.values.iter().map(|v| -v).collect();
-        CscMatrix { values: neg_vals, ..kg_csc }
+        let mut kg_csc = kg.into_csc();
+        for v in kg_csc.values.iter_mut() {
+            *v = -*v;
+        }
+        kg_csc
     };
 
     // Apply constraint transform if present
     let cs = FreeConstraintSystem::build_3d(&input.constraints, &dof_num, &input.nodes);
 
-    let has_frame_compression = linear.element_forces.iter().any(|ef| {
-        (ef.n_start + ef.n_end) / 2.0 < -1e-6
-    });
-    // Also check if shell geometric stiffness has non-trivial entries
-    let has_shell_kg = (!input.quads.is_empty() || !input.plates.is_empty() || !input.quad9s.is_empty() || !input.solid_shells.is_empty())
-        && neg_kg_csc.values.iter().any(|&v| v.abs() > 1e-15);
+    // The rest of the gate, now that -Kg exists: surfaces carry no axial force
+    // to test, so the only way to know they contribute is to look at what they
+    // assembled. `has_surfaces` spans every family including `curved_shells`,
+    // whose Kg is built above like all the others — omitting it here turned away
+    // a model made only of curved shells under pure compression, with a
+    // populated -Kg, as "no compressed elements".
+    let has_shell_kg = has_surfaces && neg_kg_csc.values.iter().any(|&v| v.abs() > 1e-15);
     if !has_frame_compression && !has_shell_kg {
         return Err("No compressed elements — buckling not applicable".into());
     }

--- a/engine/src/solver/geometric_stiffness.rs
+++ b/engine/src/solver/geometric_stiffness.rs
@@ -5,6 +5,40 @@ use super::dof::DofNumbering;
 /// Maps 12-DOF element indices to 14-DOF positions, skipping warping DOFs 6 and 13.
 const DOF_MAP_12_TO_14: [usize; 12] = [0, 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12];
 
+/// Triplet accumulator for geometric-stiffness assembly: keeps only the
+/// free×free block (buckling solves on free DOFs) and converts to a
+/// lower-triangle CSC. Replaces the previous dense n×n build, which was
+/// O(n²) memory on the one path (buckling) whose eigensolver is sparse.
+pub struct KgTriplets {
+    nf: usize,
+    rows: Vec<usize>,
+    cols: Vec<usize>,
+    vals: Vec<f64>,
+}
+
+impl KgTriplets {
+    pub fn new(nf: usize) -> Self {
+        KgTriplets { nf, rows: Vec::new(), cols: Vec::new(), vals: Vec::new() }
+    }
+
+    /// Add one contribution. Element matrices are symmetric, so callers emit
+    /// each unordered local pair once (lower triangle); from_triplets sums
+    /// contributions of elements sharing a DOF pair.
+    #[inline]
+    pub fn add(&mut self, i: usize, j: usize, v: f64) {
+        if i < self.nf && j < self.nf {
+            self.rows.push(i);
+            self.cols.push(j);
+            self.vals.push(v);
+        }
+    }
+
+    /// Lower-triangle CSC of the free block (duplicates summed).
+    pub fn into_csc(self) -> CscMatrix {
+        CscMatrix::from_triplets(self.nf, &self.rows, &self.cols, &self.vals)
+    }
+}
+
 /// Add geometric stiffness to the global stiffness matrix based on current axial forces.
 /// Used by P-Delta and Buckling analyses.
 pub fn add_geometric_stiffness_2d(
@@ -153,9 +187,8 @@ pub fn build_kg_from_forces_2d(
     input: &SolverInput,
     dof_num: &DofNumbering,
     element_forces: &[ElementForces],
-) -> Vec<f64> {
-    let n = dof_num.n_total;
-    let mut k_g = vec![0.0; n * n];
+) -> KgTriplets {
+    let mut kg = KgTriplets::new(dof_num.n_free);
     let elem_by_id: std::collections::HashMap<usize, &SolverElement> = input.elements.values().map(|e| (e.id, e)).collect();
     let node_by_id: std::collections::HashMap<usize, &SolverNode> = input.nodes.values().map(|n| (n.id, n)).collect();
 
@@ -191,8 +224,10 @@ pub fn build_kg_from_forces_2d(
                 dof_num.global_dof(elem.node_j, 1).unwrap(),
             ];
             for i in 0..4 {
-                for j in 0..4 {
-                    k_g[truss_dofs[i] * n + truss_dofs[j]] += kg_local[i * 4 + j];
+                // Symmetric element matrix: emit each unordered pair once
+                // (lower triangle); from_triplets sums across elements.
+                for j in 0..=i {
+                    kg.add(truss_dofs[i], truss_dofs[j], kg_local[i * 4 + j]);
                 }
             }
         } else {
@@ -222,13 +257,13 @@ pub fn build_kg_from_forces_2d(
             let elem_dofs = dof_num.element_dofs(elem.node_i, elem.node_j);
             let ndof = elem_dofs.len();
             for i in 0..ndof {
-                for j in 0..ndof {
-                    k_g[elem_dofs[i] * n + elem_dofs[j]] += kg_global[i * ndof + j];
+                for j in 0..=i {
+                    kg.add(elem_dofs[i], elem_dofs[j], kg_global[i * ndof + j]);
                 }
             }
         }
     }
-    k_g
+    kg
 }
 
 /// Build 3D geometric stiffness matrix from element forces.
@@ -236,9 +271,8 @@ pub fn build_kg_from_forces_3d(
     input: &SolverInput3D,
     dof_num: &DofNumbering,
     element_forces: &[ElementForces3D],
-) -> Vec<f64> {
-    let n = dof_num.n_total;
-    let mut k_g = vec![0.0; n * n];
+) -> KgTriplets {
+    let mut kg = KgTriplets::new(dof_num.n_free);
     let left_hand = input.left_hand.unwrap_or(false);
     let elem_by_id: std::collections::HashMap<usize, &SolverElement3D> = input.elements.values().map(|e| (e.id, e)).collect();
     let node_by_id: std::collections::HashMap<usize, &SolverNode3D> = input.nodes.values().map(|n| (n.id, n)).collect();
@@ -274,8 +308,8 @@ pub fn build_kg_from_forces_3d(
                 .chain((0..3).map(|i| dof_num.global_dof(elem.node_j, i).unwrap()))
                 .collect();
             for i in 0..6 {
-                for j in 0..6 {
-                    k_g[truss_dofs[i] * n + truss_dofs[j]] += kg_local[i * 6 + j];
+                for j in 0..=i {
+                    kg.add(truss_dofs[i], truss_dofs[j], kg_local[i * 6 + j]);
                 }
             }
         } else {
@@ -320,8 +354,8 @@ pub fn build_kg_from_forces_3d(
             let elem_dofs = dof_num.element_dofs(elem.node_i, elem.node_j);
             let ndof = elem_dofs.len();
             for i in 0..ndof {
-                for j in 0..ndof {
-                    k_g[elem_dofs[i] * n + elem_dofs[j]] += kg_global[i * ndof + j];
+                for j in 0..=i {
+                    kg.add(elem_dofs[i], elem_dofs[j], kg_global[i * ndof + j]);
                 }
             }
         }
@@ -330,7 +364,7 @@ pub fn build_kg_from_forces_3d(
     // curved shells) is NOT built here — it needs the displacement vector to
     // compute membrane stresses. Callers add it separately via
     // add_*_geometric_stiffness_3d (see buckling.rs).
-    k_g
+    kg
 }
 
 /// Add quad geometric stiffness to a pre-built Kg matrix, given displacements.
@@ -339,9 +373,8 @@ pub fn add_quad_geometric_stiffness_3d(
     input: &SolverInput3D,
     dof_num: &DofNumbering,
     u: &[f64],
-    k_g: &mut [f64],
+    kg: &mut KgTriplets,
 ) {
-    let n = dof_num.n_total;
     let mat_by_id: std::collections::HashMap<usize, &SolverMaterial> = input.materials.values().map(|m| (m.id, m)).collect();
     let node_by_id: std::collections::HashMap<usize, &SolverNode3D> = input.nodes.values().map(|n| (n.id, n)).collect();
 
@@ -382,8 +415,8 @@ pub fn add_quad_geometric_stiffness_3d(
 
         let ndof = quad_dofs.len();
         for i in 0..ndof {
-            for j in 0..ndof {
-                k_g[quad_dofs[i] * n + quad_dofs[j]] += kg_global[i * ndof + j];
+            for j in 0..=i {
+                kg.add(quad_dofs[i], quad_dofs[j], kg_global[i * ndof + j]);
             }
         }
     }
@@ -395,9 +428,8 @@ pub fn add_plate_geometric_stiffness_3d(
     input: &SolverInput3D,
     dof_num: &DofNumbering,
     u: &[f64],
-    k_g: &mut [f64],
+    kg: &mut KgTriplets,
 ) {
-    let n = dof_num.n_total;
     let mat_by_id: std::collections::HashMap<usize, &SolverMaterial> = input.materials.values().map(|m| (m.id, m)).collect();
     let node_by_id: std::collections::HashMap<usize, &SolverNode3D> = input.nodes.values().map(|n| (n.id, n)).collect();
 
@@ -434,8 +466,8 @@ pub fn add_plate_geometric_stiffness_3d(
 
         let ndof = plate_dofs.len();
         for i in 0..ndof {
-            for j in 0..ndof {
-                k_g[plate_dofs[i] * n + plate_dofs[j]] += kg_global[i * ndof + j];
+            for j in 0..=i {
+                kg.add(plate_dofs[i], plate_dofs[j], kg_global[i * ndof + j]);
             }
         }
     }
@@ -446,9 +478,8 @@ pub fn add_quad9_geometric_stiffness_3d(
     input: &SolverInput3D,
     dof_num: &DofNumbering,
     u: &[f64],
-    k_g: &mut [f64],
+    kg: &mut KgTriplets,
 ) {
-    let n = dof_num.n_total;
     let mat_by_id: std::collections::HashMap<usize, &SolverMaterial> = input.materials.values().map(|m| (m.id, m)).collect();
     let node_by_id: std::collections::HashMap<usize, &SolverNode3D> = input.nodes.values().map(|n| (n.id, n)).collect();
 
@@ -484,8 +515,8 @@ pub fn add_quad9_geometric_stiffness_3d(
 
         let ndof = q9_dofs.len();
         for i in 0..ndof {
-            for j in 0..ndof {
-                k_g[q9_dofs[i] * n + q9_dofs[j]] += kg_global[i * ndof + j];
+            for j in 0..=i {
+                kg.add(q9_dofs[i], q9_dofs[j], kg_global[i * ndof + j]);
             }
         }
     }
@@ -496,9 +527,8 @@ pub fn add_solid_shell_geometric_stiffness_3d(
     input: &SolverInput3D,
     dof_num: &DofNumbering,
     u: &[f64],
-    k_g: &mut [f64],
+    kg: &mut KgTriplets,
 ) {
-    let n = dof_num.n_total;
     let mat_by_id: std::collections::HashMap<usize, &SolverMaterial> = input.materials.values().map(|m| (m.id, m)).collect();
     let node_by_id: std::collections::HashMap<usize, &SolverNode3D> = input.nodes.values().map(|n| (n.id, n)).collect();
 
@@ -524,8 +554,8 @@ pub fn add_solid_shell_geometric_stiffness_3d(
 
         let ndof = ss_dofs.len();
         for i in 0..ndof {
-            for j in 0..ndof {
-                k_g[ss_dofs[i] * n + ss_dofs[j]] += kg_elem[i * ndof + j];
+            for j in 0..=i {
+                kg.add(ss_dofs[i], ss_dofs[j], kg_elem[i * ndof + j]);
             }
         }
     }
@@ -536,9 +566,8 @@ pub fn add_curved_shell_geometric_stiffness_3d(
     input: &SolverInput3D,
     dof_num: &DofNumbering,
     u: &[f64],
-    k_g: &mut [f64],
+    kg: &mut KgTriplets,
 ) {
-    let n = dof_num.n_total;
     let mat_by_id: std::collections::HashMap<usize, &SolverMaterial> = input.materials.values().map(|m| (m.id, m)).collect();
     let node_by_id: std::collections::HashMap<usize, &SolverNode3D> = input.nodes.values().map(|n| (n.id, n)).collect();
 
@@ -568,8 +597,8 @@ pub fn add_curved_shell_geometric_stiffness_3d(
 
         let ndof = cs_dofs.len();
         for i in 0..ndof {
-            for j in 0..ndof {
-                k_g[cs_dofs[i] * n + cs_dofs[j]] += kg_elem[i * ndof + j];
+            for j in 0..=i {
+                kg.add(cs_dofs[i], cs_dofs[j], kg_elem[i * ndof + j]);
             }
         }
     }

--- a/engine/src/solver/geometric_stiffness.rs
+++ b/engine/src/solver/geometric_stiffness.rs
@@ -34,8 +34,20 @@ impl KgTriplets {
     }
 
     /// Lower-triangle CSC of the free block (duplicates summed).
+    ///
+    /// Drops entries below 1e-30, matching `CscMatrix::from_dense_symmetric`,
+    /// which is what produced this matrix before it was assembled from
+    /// triplets. Without the filter every emitted pair becomes a structural
+    /// nonzero, and element Kg is nonzero only on translational DOFs: a quad
+    /// emits 300 pairs of which about 78 are nonzero, a quad9 emits 1485 of
+    /// which about 378 are. The resulting CSC stored roughly 4x the real
+    /// nonzeros of a shell model, and that is paid on every Lanczos iteration
+    /// through `sym_mat_vec` and quadratically through `reduce_sparse` on the
+    /// constrained path — eroding the O(nnz) win this assembly exists for.
     pub fn into_csc(self) -> CscMatrix {
-        CscMatrix::from_triplets(self.nf, &self.rows, &self.cols, &self.vals)
+        let mut k = CscMatrix::from_triplets(self.nf, &self.rows, &self.cols, &self.vals);
+        k.drop_below_threshold(1e-30);
+        k
     }
 }
 
@@ -352,10 +364,22 @@ pub fn build_kg_from_forces_3d(
             // Transform to global: Kg_global = T^T * Kg_local * T
             let kg_global = transform_stiffness(&kg_local, &t, 12);
             let elem_dofs = dof_num.element_dofs(elem.node_i, elem.node_j);
-            let ndof = elem_dofs.len();
-            for i in 0..ndof {
+            // kg_global is 12x12, but `elem_dofs` is 14 wide on models where any
+            // section declares `cw` — `DofNumbering::build_3d` then numbers seven
+            // DOFs per node. Indexing a 144-element array with a stride of 14
+            // walks off the end (kg_global[10 * 14 + 4] = 144): an index panic
+            // that on wasm32 crosses the FFI boundary as an abort rather than a
+            // solver error. `add_geometric_stiffness_3d`, in this same file,
+            // remaps through DOF_MAP_12_TO_14 for exactly this reason; this path
+            // did not.
+            let map: &[usize] = if dof_num.dofs_per_node >= 7 {
+                &DOF_MAP_12_TO_14
+            } else {
+                &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+            };
+            for i in 0..12 {
                 for j in 0..=i {
-                    kg.add(elem_dofs[i], elem_dofs[j], kg_global[i * ndof + j]);
+                    kg.add(elem_dofs[map[i]], elem_dofs[map[j]], kg_global[i * 12 + j]);
                 }
             }
         }

--- a/engine/tests/core/sparse_mass.rs
+++ b/engine/tests/core/sparse_mass.rs
@@ -488,16 +488,35 @@ const GOLDEN_BUCKLING_2D: [f64; 4] = [
 /// Load factors from pre-refactor `solve_buckling_3d` on the 3D cantilever
 /// column with Iy=2e-4, Iz=1e-4 (n_elem=60 → nf=354 → sparse op path).
 const GOLDEN_BUCKLING_3D: [f64; 4] = [
-    // π²/2 and π² exactly — the analytical Euler cantilever, in the 2:1 ratio the
-    // two bending axes require. The previous values were not a clean multiple of
+    // π²/2, π², 9π²/2, 9π² — the analytical Euler cantilever, in the 2:1 ratio
+    // the two bending axes require and the 1:9 ratio the first two modes of each
+    // axis require. The pre-refactor values were not a clean multiple of
     // anything, which is what a wrong recurrence looks like from the outside.
-    // Recaptured after the quotient-graph AMD rewrite: the new elimination
-    // order shifts the values by ~1e-10 relative and lands them even closer
-    // to the analytical π²/2 and π² (rel err 4.2e-11 and 3.4e-11).
-    4.934802200338300e0,
-    9.869604400752904e0,
-    4.4413222150346584e1,
-    8.882644430544299e1,
+    //
+    // Recaptured twice since. First after the quotient-graph AMD rewrite, whose
+    // new elimination order moved them ~1e-10. Then after the Lanczos recurrence
+    // moved its inner product from -Kg to K: the basis is different, so the
+    // floating-point path is different, and mode 0 moved 2.4e-10.
+    //
+    // That second recapture cost a little accuracy rather than gaining it —
+    // modes 0 and 1 sit 1.98e-10 and 3.46e-10 from the closed form, against
+    // 4.2e-11 and 3.4e-11 before. Worth stating plainly: the K inner product is
+    // not here to sharpen these four numbers, it is here to keep the iteration
+    // on the sparse path (see `buckling_lanczos_stays_sparse_when_kg_is_indefinite`),
+    // and a shift ten orders below any engineering tolerance is what it costs.
+    //
+    // Modes 2 and 3 sit 5.3e-8 from the closed form. That is discretization —
+    // 60 elements resolving the second buckling mode — not the solver, and it
+    // was equally present in the previous golden.
+    //
+    // The 1e-10 gate is a change-detector on an iterative eigensolver, not an
+    // accuracy claim. It fires on any reordering of floating-point work, which
+    // is precisely its job; when it fires, check against the closed form above
+    // before recapturing.
+    4.934802201521506e0,
+    9.869604397670097e0,
+    4.441322215148967e1,
+    8.882644430636768e1,
 ];
 
 #[test]
@@ -526,6 +545,22 @@ fn buckling_3d_sparse_op_parity() {
     let result = buckling::solve_buckling_3d(&input, 4).unwrap();
     let actual: Vec<f64> = result.modes.iter().map(|m| m.load_factor).collect();
     assert_matches_golden(&actual, &GOLDEN_BUCKLING_3D, 0.0, 1e-10, "buckling 3D golden");
+
+    // The golden pins the exact floating-point path; the closed form pins the
+    // answer. Keep both: when a recurrence or ordering change trips the golden,
+    // this is what says whether the new numbers are still right.
+    let pi2 = std::f64::consts::PI * std::f64::consts::PI;
+    for (i, &exact) in [pi2 / 2.0, pi2, 9.0 * pi2 / 2.0, 9.0 * pi2].iter().enumerate() {
+        let rel = (actual[i] - exact).abs() / exact;
+        // 1e-6 covers the 5.3e-8 discretization error on modes 2 and 3 with room
+        // to spare, and is still ~4 orders tighter than any wrong recurrence.
+        assert!(
+            rel < 1e-6,
+            "buckling 3D mode {i} = {:.12e} is {:.2e} from the analytical Euler \
+             cantilever {:.12e}: the eigenvalues are no longer physical",
+            actual[i], rel, exact,
+        );
+    }
 }
 
 /// The generalized eigenpath must return actual EIGENVECTORS.

--- a/engine/tests/core/sparse_mass.rs
+++ b/engine/tests/core/sparse_mass.rs
@@ -563,6 +563,62 @@ fn buckling_3d_sparse_op_parity() {
     }
 }
 
+/// 3D buckling must survive a section that declares warping constants.
+///
+/// `DofNumbering::build_3d` numbers SEVEN DOFs per node as soon as any section
+/// sets `cw`, so `element_dofs` returns 14 entries instead of 12.
+/// `build_kg_from_forces_3d` builds a 12x12 `kg_global` and used that 14 as its
+/// stride: `kg_global[10 * 14 + 4]` is 144, one past the end of a 144-element
+/// array. `add_geometric_stiffness_3d`, in the same file, remaps through
+/// `DOF_MAP_12_TO_14` for exactly this reason; the buckling path did not.
+///
+/// Natively that is a clean index panic. In the shipped wasm32 build it is an
+/// abort that crosses the FFI boundary — the module traps and the caller gets
+/// no solver error to report, just a dead engine.
+///
+/// No test in the suite combined a warping section with 3D buckling, which is
+/// why it shipped. This is that test: it is a crash gate, so it asserts the
+/// call returns at all, plus enough physics to catch a silently wrong remap.
+#[test]
+fn buckling_3d_survives_warping_dofs() {
+    let n_elem = 20;
+    let p = 100.0;
+    let loads = vec![SolverLoad3D::Nodal(SolverNodalLoad3D {
+        node_id: n_elem + 1,
+        fx: -p, fy: 0.0, fz: 0.0,
+        mx: 0.0, my: 0.0, mz: 0.0, bw: None,
+    })];
+    let mut input = make_3d_beam(
+        n_elem, 10.0, E, 0.3, A, 2e-4, IZ, J, vec![true; 6], None, loads,
+    );
+
+    // The trigger: one section with `cw` set widens every node to 7 DOFs.
+    for s in input.sections.values_mut() {
+        s.cw = Some(2.03e-6);
+    }
+    assert_eq!(
+        DofNumbering::build_3d(&input).dofs_per_node, 7,
+        "fixture must produce 7 DOFs per node, or it does not exercise the remap \
+         and this test proves nothing",
+    );
+
+    let result = buckling::solve_buckling_3d(&input, 2)
+        .expect("3D buckling on a warping section must not fail");
+
+    // The warping DOF is uncoupled from flexural buckling in this cantilever, so
+    // the governing mode is still the Euler value the same beam gives without
+    // `cw`. A remap that lands Kg entries on the wrong DOFs would still return
+    // *something*; this is what says the entries went where they belong.
+    let pi2 = std::f64::consts::PI * std::f64::consts::PI;
+    let rel = (result.modes[0].load_factor - pi2 / 2.0).abs() / (pi2 / 2.0);
+    assert!(
+        rel < 1e-4,
+        "governing load factor {:.9e} is {:.2e} from the analytical π²/2 = {:.9e}: \
+         the warping remap put Kg entries on the wrong DOFs",
+        result.modes[0].load_factor, rel, pi2 / 2.0,
+    );
+}
+
 /// The generalized eigenpath must return actual EIGENVECTORS.
 ///
 /// Every other gate on this path compares one Lanczos implementation against

--- a/engine/tests/sparse_shell_gates.rs
+++ b/engine/tests/sparse_shell_gates.rs
@@ -887,7 +887,7 @@ fn sparse_buckling_parity() {
 
     // Get linear forces for geometric stiffness
     let lin = linear::solve_3d(&input).unwrap();
-    let mut kg_full = dedaliano_engine::solver::geometric_stiffness::build_kg_from_forces_3d(&input, &dof_num, &lin.element_forces);
+    let mut kg = dedaliano_engine::solver::geometric_stiffness::build_kg_from_forces_3d(&input, &dof_num, &lin.element_forces);
     if !input.quads.is_empty() {
         let mut u_full = vec![0.0; n];
         for d in &lin.displacements {
@@ -896,13 +896,13 @@ fn sparse_buckling_parity() {
                 if let Some(&dof) = dof_num.map.get(&(d.node_id, i)) { u_full[dof] = v; }
             }
         }
-        dedaliano_engine::solver::geometric_stiffness::add_quad_geometric_stiffness_3d(&input, &dof_num, &u_full, &mut kg_full);
+        dedaliano_engine::solver::geometric_stiffness::add_quad_geometric_stiffness_3d(&input, &dof_num, &u_full, &mut kg);
     }
 
-    let free_idx: Vec<usize> = (0..nf).collect();
     let sasm = assemble_sparse_3d(&input, &dof_num, false);
     let k_ff_dense = sasm.k_ff.to_dense_symmetric();
-    let kg_ff = extract_submatrix(&kg_full, n, &free_idx, &free_idx);
+    // Kg triplets cover the free block directly; densify for the Jacobi reference.
+    let kg_ff = kg.into_csc().to_dense_symmetric();
     let mut neg_kg = vec![0.0; nf * nf];
     for i in 0..nf * nf { neg_kg[i] = -kg_ff[i]; }
 


### PR DESCRIPTION
Base en `main` (#176 y #177 ya mergeados).

> **El PR creció más allá de su título.** Arrancó como ensamblado disperso de K_g y ahora lleva además un arreglo de crash en wasm32 y un cambio en el producto interno del eigensolver de pandeo. Lo importante está en las secciones 1 y 2.

## 1. Lanczos corría en una métrica que no existe

`SparseShiftInvertOp` construía la base de Lanczos ortogonal en el producto interno de **−K_g**. Un producto interno necesita una matriz definida positiva, y −K_g es **indefinida** en cualquier modelo que lleve tracción y compresión a la vez — o sea, casi todos. `dot(q, Bq).sqrt()` da NaN en la semilla, y a mitad de iteración una norma-B negativa se recorta con `.max(0.0)` y se lee como subespacio invariante.

**El síntoma no es una respuesta incorrecta.** `lanczos_buckling_eigen_sparse` cae al Jacobi denso cuando la iteración se rinde, así que los autovalores vuelven bien igual y ningún test de números puede ver el defecto. Lo que se pierde es todo el punto del PR: ese fallback hace `to_dense_symmetric()` sobre K **y** sobre −K_g, exactamente la densificación n×n que esta rama existe para eliminar. La optimización silenciosamente no se aplicaba a los modelos que más la necesitan.

K sirve para ambos casos: es SPD por construcción, y `A = K⁻¹B` es autoadjunta en `⟨·,·⟩_K` porque `⟨Ax, y⟩_K = xᵀBy = ⟨x, Ay⟩_K`. Los valores de Ritz no cambian — θ = μ de cualquier modo — solo la base se construye en una métrica bien definida. `new` conserva la métrica B para la vía modal, donde B es la matriz de masa y es semidefinida positiva.

El test verifica **la iteración, no los números**, porque un test de números no puede ver esto. Falla sin el fix:

```
lanczos_buckling_eigen_sparse returned 300 eigenvalues for k = 4:
that is the dense fallback, so the sparse path silently did not apply
```

## 2. Panic de índice con secciones de alabeo (crash en wasm32)

`DofNumbering::build_3d` numera **siete** GDL por nodo apenas alguna sección declara `cw`, así que `element_dofs` devuelve 14 entradas. `build_kg_from_forces_3d` arma un `kg_global` de 12×12 y usaba ese 14 como stride: `kg_global[10 * 14 + 4]` es 144, uno más allá del final de un arreglo de 144.

Nativamente es un panic de índice limpio. **En el build wasm32 que se despacha es un abort que cruza el FFI**: el módulo trapea y el llamador no recibe un error de solver que reportar, recibe un engine muerto.

`add_geometric_stiffness_3d`, en el mismo archivo, remapea por `DOF_MAP_12_TO_14` justo por esto; la vía de pandeo no lo hacía.

**Ningún test del suite combinaba sección de alabeo con pandeo 3D** — intersecté los seis archivos que setean `cw: Some` contra los que llaman `solve_buckling_3d` y da vacío. Ese hueco es por qué el panic llegó a producción. El test de regresión va incluido; verificado revirtiendo el remap:

```
panicked at geometric_stiffness.rs:378:65:
index out of bounds: the len is 144 but the index is 144
```

## 3. Ensamblado disperso de K_g (el cambio original)

El «sparse buckling» era disperso en K pero denso en K_g: `build_kg_from_forces_*` alocaba una matriz densa n×n (~800 MB con 10.000 GDL) y luego la convertía a CSC con `from_dense_symmetric` — la alocación n² que la vía dispersa existe para evitar. La vía con constraints además densificaba K_ff y corría Jacobi denso.

- **`geometric_stiffness`**: `build_kg_from_forces_2d/3d` y los cinco `add_*_geometric_stiffness_3d` de láminas escriben a un sink de tripletes (`KgTriplets`) que conserva solo el bloque libre×libre y convierte a CSC triángulo inferior. Los bucles de elemento emiten cada par no ordenado una sola vez (triángulo inferior **local**) — emitir el cuadrado simétrico completo duplicaría los off-diagonales vía la suma de duplicados de `from_triplets`. Bug detectado en desarrollo: los goldens de Euler lo agarraron al instante, modo 0 corrido 2134×. Que el índice **global** pueda quedar en cualquier orden no importa: `from_triplets` canonicaliza a triángulo inferior antes de ordenar.
- **`buckling` 2D/3D**: sin K_g densa, sin extract+negate denso; la vía con constraints reduce K y −K_g con el producto triple disperso y usa el mismo Lanczos shift-invert que la vía sin constraints (Jacobi denso eliminado de pandeo).
- Las funciones tocadas solo las usa buckling (verificado con grep sobre `src/` y `tests/`); P-Delta sigue con su propio path denso (`add_geometric_stiffness_*`), que es ítem aparte.

## 4. Poda de K_g, compuerta de láminas curvas, y perf barato

- **`KgTriplets::into_csc` guardaba ~4× los no-nulos reales.** El K_g de elemento es no nulo solo en GDL traslacionales: un quad emite 300 pares de los cuales ~78 son no nulos, un quad9 emite 1485 de los cuales ~378. Sin filtro, cada par emitido se vuelve un no-nulo estructural. Se paga en cada iteración de Lanczos vía `sym_mat_vec` y **cuadráticamente** vía `reduce_sparse` en la vía con constraints — erosionando el win O(nnz) que justifica el PR. Ahora filtra bajo 1e-30, igual que `from_dense_symmetric`, que es lo que construía esta matriz antes.
- **`has_shell_kg` omitía `input.curved_shells`** mientras el ensamblado sí los incluía: un modelo hecho solo de cascarones curvos en compresión pura tenía −K_g poblada y era rechazado igual con «no compressed elements».
- La compuerta de compresión corre **antes** de ensamblar nada (el 2D se saltea ambos ensamblados; el 3D corta cuando no hay ni pórtico comprimido ni superficie alguna), `u_full` se construye una vez en vez de dos, y K_g se niega in place en vez de a un segundo vector de valores.

## 5. Verificación

- Suite completa verde en **ambos perfiles**, 28 binarios de test cada uno: release, donde los `assert!` nuevos están vivos, y debug, donde también corren los `debug_assert!`.
- `wasm32-unknown-unknown` compila limpio — el target que efectivamente se despacha.
- Los dos tests nuevos verificados contra su bug: cada uno falla al revertir su fix (mensajes arriba).
- Sin advertencias nuevas de clippy en las líneas tocadas.

### Costo del recapture de `GOLDEN_BUCKLING_3D`

Otra base es otro camino en punto flotante: el modo 0 se movió 2.4e-10 y pasó la compuerta de 1e-10, así que hubo que recapturar. **Ese cambio restó un poco de precisión, no sumó.** Los modos 0 y 1 quedan a 1.98e-10 y 3.46e-10 de la solución cerrada, contra 4.2e-11 y 3.4e-11 antes. Diez órdenes por debajo de cualquier tolerancia de ingeniería, pero no lo presento como mejora: el producto interno en K no está para afinar esos cuatro números, está para que la iteración no caiga al fallback denso.

Los modos 2 y 3 quedan a 5.3e-8 de la forma cerrada — eso es discretización (60 elementos resolviendo el segundo modo), no el solver, y ya estaba igual en el golden anterior.

Agregué una aserción permanente contra π²/2, π², 9π²/2 y 9π², así **la forma cerrada, y no el golden, es la que dice si los números recapturados siguen siendo físicos**. La compuerta de 1e-10 es un detector de cambio sobre un eigensolver iterativo, no una afirmación de precisión.

## 6. Lo que queda para otro PR

- **`sparse_buckling_parity` quedó autorreferencial**: la referencia densa ahora también pasa por `kg.into_csc()`, así que ambos lados salen del mismo ensamblado y la compuerta ya no verifica nada de forma independiente.
- **`KgTriplets` duplica `TripletAssembly`** y no reserva capacidad (~144 MB transitorios en 10k quads).

No medí speedup de pared dedicado: el win es estructural (memoria n² → O(nnz), sin conversión densa) y en modelos chicos el solve lineal domina. La escala es la del audit: a 10.000 GDL la K_g densa eran ~800 MB antes de factorizar nada.
