### PR TITLE
chore(seo): add the Search Console verification file

### DIFF
--- a/web/public/google845f675e00cfa684.html
+++ b/web/public/google845f675e00cfa684.html
@@ -1,0 +1,1 @@
+google-site-verification: google845f675e00cfa684.html


### PR DESCRIPTION
Google's HTML-file verification for `https://stabileo.com/`.

Google fetches `/google845f675e00cfa684.html` and expects its own token back. The file is served straight from `public/`, so it does not pass through the prerender — deliberate, since that pipeline has already shipped one wrong artifact to production and verification should not depend on it.

Verified locally: the built file is byte-identical and answers 200 as `text/html`.

Nothing secret here. The file must be publicly fetchable for Google to read it; that is the whole mechanism.

**Merging this unblocks Search Console**, which is currently the only reason we cannot answer whether the blog brought any traffic — the site has no instrumentation at all today.