### PR TITLE
ci(deploy): the prerender gate demanded the URLs that answer 301

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -88,14 +88,37 @@ jobs:
           check en/index.html 'A free and open structural-analysis platform'
           check es/index.html 'Una plataforma gratuita y abierta de cálculo estructural'
           check pt/index.html 'Uma plataforma gratuita e aberta de cálculo estrutural'
-          check en/index.html '<link rel="canonical" href="https://stabileo.com/en"'
-          check es/index.html '<link rel="canonical" href="https://stabileo.com/es"'
-          check pt/index.html '<link rel="canonical" href="https://stabileo.com/pt"'
-          # The root is a doorway: English content, consolidating into /en.
-          check index.html '<link rel="canonical" href="https://stabileo.com/en"'
+          #
+          # ── The trailing slash is part of the assertion ──
+          #
+          # These patterns close the quote right after the path, so they pin the
+          # WHOLE href and not a prefix of it. That is deliberate: '/en' would
+          # also match '/enormous'. It also means the slash matters, and this
+          # gate went stale when #172 moved the canonicals to '/en/' — it kept
+          # demanding the form that answers 301 and blocked every deploy from
+          # 2026-09-07 on, including the fix itself.
+          #
+          # GitHub Pages serves '/en/' with 200 and 301s '/en' to it, so the
+          # slash is the URL that resolves. `publicHref` in
+          # src/lib/i18n/public-routes.ts is the single source, and
+          # e2e/prerender.spec.ts asserts the same shape in a browser.
+          check en/index.html '<link rel="canonical" href="https://stabileo.com/en/"'
+          check es/index.html '<link rel="canonical" href="https://stabileo.com/es/"'
+          check pt/index.html '<link rel="canonical" href="https://stabileo.com/pt/"'
+          # The root is a doorway: English content, consolidating into /en/.
+          check index.html '<link rel="canonical" href="https://stabileo.com/en/"'
           check es/blog/the-determinism-boundary/index.html \
-            '<link rel="canonical" href="https://stabileo.com/es/blog/the-determinism-boundary"'
+            '<link rel="canonical" href="https://stabileo.com/es/blog/the-determinism-boundary/"'
           check es/blog/the-determinism-boundary/index.html 'application/ld+json'
+
+          # Every advertised URL must be one that answers 200, not one that
+          # redirects. The sitemap is where a stale slash does the most damage:
+          # the deploy of 2026-08-28 shipped a sitemap whose every <loc> was a
+          # 301. Assert the shape here rather than trusting the generator.
+          if grep -oE '<loc>[^<]*</loc>' dist/sitemap.xml | grep -vE '<loc>https://stabileo\.com/(en|es|pt)(/[^<]*)?/</loc>'; then
+            echo 'sitemap.xml carries a <loc> that is not a trailing-slash locale URL (those answer 301).'
+            exit 1
+          fi
 
           echo "prerendered pages verified"
 


### PR DESCRIPTION
## GitHub Pages has not deployed since 2026-08-28

Two merged PRs never reached stabileo.com — **#172** (`fix/trailing-slash-urls`) and **#156** (PRO
steel M1). Both deploy runs failed on the same step, `Verify the public pages were prerendered`,
with the same line:

```
dist/en/index.html does not carry: <link rel="canonical" href="https://stabileo.com/en"
```

**Production is stale, not broken.** The site is still serving the 2026-08-28 build, so nothing on
it is wrong — it is simply frozen, missing both merges.

## The app is right; this gate was stale

#172 moved every advertised URL to a trailing slash, which is what makes them resolve. Measured
against production right now:

| URL | Response |
|---|---|
| `https://stabileo.com/en` | **301** → `https://stabileo.com/en/` |
| `https://stabileo.com/en/` | **200** |

So `/en` is the form that *redirects*, and the sitemap currently live lists
`<loc>https://stabileo.com/en</loc>` for every entry — a file of URLs that all answer 301. That is
exactly the defect #172 fixed.

#172 updated `prerender.spec.ts`, `blog.spec.ts`, `landing.spec.ts`, the public-routes tests, and
added `published-urls-resolve.test.ts`. **It did not touch this workflow**, whose five `check`
patterns still pinned the no-slash form. Those patterns close the quote right after the path —
deliberately, so `/en` cannot match `/enormous` — which is also why the slash is load-bearing and
why they stopped matching.

That is the worst shape a gate can take: it blocked the deploy of the very change that made the
site's URLs correct, and it did so while **every blocking CI job was green**, because
`prerender.spec.ts` had been updated and this grep had not.

## Verified, not assumed

Reproduced locally at `cbea1316` — the head that contains **both** merges — with the same
`BASE_PATH=/` the workflow uses:

- the build emits `href="https://stabileo.com/en/"`, `/es/`, `/pt/` and
  `/es/blog/the-determinism-boundary/`;
- **the gate as it stood fails on the local dist with the identical message CI printed**;
- the gate as patched passes.

**One fix clears both failed runs**, because the build I verified already contains #156.

## A sitemap gate, because that is where a stale slash costs the most

Added a check that every `<loc>` is a trailing-slash locale URL. **It has teeth**: run against the
sitemap currently live on stabileo.com it reports the three non-slash entries and exits 1. A gate
that cannot fail is not a gate, so it was tested against the bad file and not only against the good
one.

## Scope

**No application code changed.** One file: `.github/workflows/deploy-gh-pages.yml`.

Once this lands on `main`, the deploy should run green and ship #172 and #156 together.
