### PR TITLE
docs(h2): say what the amplification band checks, and what 99 is

### DIFF
--- a/engine/tests/paper_examples.rs
+++ b/engine/tests/paper_examples.rs
@@ -224,6 +224,15 @@ fn a3_building_column_removal() {
     // reconstruction measures 3.97 on the moment itself. The sections were NOT
     // tuned to close that gap — doing so would be fitting the structure to a
     // published number rather than reporting what the model does.
+    //
+    // NOTE — this band cannot fail on its own. The two assertions above pin
+    // 62.90 ± 0.5 and 249.76 ± 1.0, which already bound the quotient to
+    // 3.92‥4.02; anything that reached this line has passed 3.5‥4.5 by
+    // construction. It is kept because it NAMES the result — a reader looking
+    // for what the case study demonstrates finds it here rather than having to
+    // divide two hogging moments — but it is a restatement, not a third check,
+    // and reading it as independent coverage would overstate what this test
+    // holds.
     let amplification = my_damaged / my_intact;
     assert!(
         (3.5..4.5).contains(&amplification),

--- a/web/src/lib/store/verification.svelte.ts
+++ b/web/src/lib/store/verification.svelte.ts
@@ -454,7 +454,10 @@ function createVerificationStore() {
     /**
      * Utilization for display: ALWAYS demand/capacity.
      *
-     * Null when the member has no provided reinforcement AND no code-check baseline.
+     * Null when nothing can answer: no provided verification CARRYING A STRENGTH CHECK, and no
+     * code-check baseline for the member. Not the same as "no reinforcement" — a member whose
+     * provided verification ran and checked no strength falls through to the baseline exactly
+     * as an unreinforced one does, and reads the same from here.
      *
      * NOT null when the utilization is non-finite: that returns `99`, a sentinel, and the
      * docstring used to say "null when unavailable" and stop there — which is how a magic

--- a/web/src/lib/store/verification.svelte.ts
+++ b/web/src/lib/store/verification.svelte.ts
@@ -451,7 +451,20 @@ function createVerificationStore() {
       return pv.overallStatus;
     },
 
-    /** Utilization for display: ALWAYS demand/capacity. Null when unavailable. */
+    /**
+     * Utilization for display: ALWAYS demand/capacity.
+     *
+     * Null when the member has no provided reinforcement AND no code-check baseline.
+     *
+     * NOT null when the utilization is non-finite: that returns `99`, a sentinel, and the
+     * docstring used to say "null when unavailable" and stop there — which is how a magic
+     * number reaches a design table as a ratio and the 3-D viewer as a colour without any
+     * reader of this signature knowing it can. 99 is not a utilization anyone computed; it is
+     * "this could not be computed", wearing the type of an answer.
+     *
+     * Stated rather than fixed. Replacing it means deciding what the table and the viewport
+     * should show for an incomputable ratio, which is a product decision and is on H3's list.
+     */
     getDisplayRatio(elementId: number): number | null {
       void providedRevision;
       const pv = providedFor(elementId);


### PR DESCRIPTION
Follow-up to **#170**, based on `feat/pro-concrete-h2` so the diff is these two fixes and nothing else. **Merge after #170** (which itself merges after #161).

Two documentation fixes. **No behaviour changes** — both are about a reader being told something the code already does.

## 1. The amplification band cannot fail

`paper_examples.rs` asserts `(3.5..4.5).contains(&amplification)` after pinning `62.90 ± 0.5` and `249.76 ± 1.0`. Those two bound the quotient to **3.92‥4.02**, so anything that reaches the third assertion has passed it by construction.

Kept rather than deleted: it **names** the result the case study exists to show, and a reader should not have to divide two hogging moments to find it. But it now says it is a restatement, not a third check — reading it as independent coverage overstates what the test holds.

## 2. `getDisplayRatio` says null and returns 99

The docstring read *"Null when unavailable"*. The body returns **`99`** when `worstUtilization` is not finite. That is how a magic number reaches the design table as a ratio and the 3-D viewer as a colour with nothing in the signature warning a caller it can.

Now stated: null means no provided reinforcement **and** no code-check baseline; `99` means "could not be computed", wearing the type of an answer.

**Stated rather than fixed, deliberately.** Replacing the sentinel means deciding what a table and a viewport should show for an incomputable ratio — a product decision, and already on H3's list in #170's own description. This does not pre-empt it; it stops the next reader from having to discover it.

The same line is on `feat/pro-concrete-h1` and on `main` at `verification.svelte.ts:459`, so #170 is right that it introduces none of this. This fix rides here because H2 is the branch that surfaced it.

## Withdrawn from my review

I had also reported the `designProposed === designApplicable` check in `rcStages` as redundant, since `designVerified === designApplicable` appeared to imply it.

**It does not.** The two come from `providedSummary.withReinforcement` and `.ok` — independent counters over the same loop, not nested sets. Nothing guarantees a member counted `ok` was counted as carrying reinforcement. Asserting both is correct and no change was made.

## Gates

`cargo test --test paper_examples` passes · `typecheck` 479 = baseline, no new · **746 tests pass** across `lib/store` and `lib/flow`.

## One open question for #170, needing no code

Its full e2e run reports **"5 skipped"** without naming them, and the branch carries **20 conditional `test.skip(...)`** across seven spec files — five of them in `f3-product-decisions.spec.ts`, gated on `lockMember()` finding a lockable bar on the fixture.

Which five skipped is not visible from the report, so it cannot be told whether a claim that spec exists to pin was pinned on that run. Worth naming them, by the branch's own standard: *"a conditional that skips silently reads in a report as though it had measured something"*. `test.skip` is the better mechanism — it reports skipped rather than passed — but only if the reader is told which.

https://claude.ai/code/session_01L67REmkuj14xQGpVujp5z9
